### PR TITLE
Adjustment/docs GitHub

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,6 @@ jobs:
         shell: julia --color=yes --project=docs/ {0}
         run: |
           using Pkg
-          Pkg.add(url="https://github.com/sintefore/TimeStruct.jl")
           Pkg.develop(PackageSpec(path=pwd()))
           Pkg.instantiate()
       - name: Build and deploy

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,7 +42,7 @@ Version 0.5.1 (2023-06-16)
 Version 0.5.0 (2023-06-01)
 --------------------------
 ### Switch to TimeStruct.jl
- * Switched the time structure representation to [TimeStruct.jl](https://gitlab.sintef.no/julia-one-sintef/timestruct.jl)
+ * Switched the time structure representation to [TimeStruct.jl](https://sintefore.github.io/TimeStruct.jl/)
  * TimeStruct.jl is implemented with only the basis features that were available in TimesStructures.jl. This implies that neither operational nor strategic uncertainty is included in the model
 
 Version 0.4.0 (2023-05-30)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # EnergyModelsBase
 
-`EnergyModelsBase` is the core package to building flexible multi-energy-carrier energy systems models.
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://energymodelsx.github.io/EnergyModelsBase.jl//stable)
+[![In Development](https://img.shields.io/badge/docs-dev-blue.svg)](https://energymodelsx.github.io/EnergyModelsBase.jl/dev/)
+
+`EnergyModelsBase` is the core package for building flexible multi-energy-carrier energy systems models.
 It is designed to model the basic operations of various generation, conversion and storage technologies.
 `EnergyModelsBase` is designed to enable optimization of operations, and to be be easily extendible to investment models, and/or to include new technologies or more detailed models of key technologies.
 
-> **Note**
-> We migrated recently from an internal Git solution to GitHub, including the package [`TimeStruct`](https://github.com/sintefore/TimeStruct.jl). As `TimeStruct` is not yet registered, it is not possible to build automatically the documentation or run the tests without significant changes in the CI. Every user is however free to build the documentation from the [`docs`](docs) folder.
+> **Note:**
+>
+> We migrated recently from an internal Git solution to GitHub, including the package [`TimeStruct`](https://github.com/sintefore/TimeStruct.jl). As `TimeStruct` is not yet registered, it is not possible to run the tests without significant changes in the CI. Hence, we plan to wait with creating a release to be certain the tests are running. As a result, the stable docs are not yet available.
 
 ## Usage
 
-The documentation for `EnergyModelsBase` is currently not available as we migrated recently to GitHub.
-Once `TimeStruct` is registered in the Julia Registry, we will update the README.md  and add the links to the documentation.
-
-See examples of usage of the package and a simple guide for running them in the folder [`examples`](examples).
+The usage of the package is based illustrated through the commented [`examples`](examples).
 
 ## Cite
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,4 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"

--- a/docs/src/how-to/create-new-node.md
+++ b/docs/src/how-to/create-new-node.md
@@ -108,4 +108,4 @@ A more detailed explanation of the different `abstract type`s can be found in *[
 
 ## Example
 
-As an example, you can check out how *[Renewable Producers](https://gitlab.sintef.no/clean_export/energymodelsrenewableproducers.jl)* introduces two new technology types, a `Source` and a `Storage`.
+As an example, you can check out how *[Renewable Producers](https://energymodelsx.github.io/EnergyModelsRenewableProducers.jl/dev/)* introduces two new technology types, a `Source` and a `Storage`.

--- a/docs/src/how-to/utilize-timestruct.md
+++ b/docs/src/how-to/utilize-timestruct.md
@@ -1,14 +1,14 @@
-# [Utilize `TimeStruct.jl`](@id utilize_timestruct)
+# [Utilize `TimeStruct`](@id utilize_timestruct)
 
-`EnergyModelsBase` uses for the description of time the package [`TimeStruct.jl`](https://sintefore.github.io/TimeStruct.jl/stable/).
-[`TimeStruct.jl`](https://sintefore.github.io/TimeStruct.jl/stable/) offers a large variety of different options that can appear to be overwhelming, when first exposed to them.
+`EnergyModelsBase` uses for the description of time the package [`TimeStruct`](https://sintefore.github.io/TimeStruct.jl/stable/).
+[`TimeStruct`](https://sintefore.github.io/TimeStruct.jl/stable/) offers a large variety of different options that can appear to be overwhelming, when first exposed to them.
 Hence, it is important to highlight how it works and which parameters you would want to analyse.
 
 ## Structures for time description
 
-`TimeStruct.jl` introduces individual structures that are used for describing time.
+`TimeStruct` introduces individual structures that are used for describing time.
 In the following introduction, the most important structures are explained.
-There are other structures, but these will be added once `EnergyModelsbase.jl` supports their formulation.
+There are other structures, but these will be added once `EnergyModelsbase` supports their formulation.
 
 ### Operational periods
 
@@ -29,9 +29,9 @@ In this case, the operational periods would correspond to a full day.
 
 !!! note
 
-    All operational periods are continuous. This implies that one is not allowed to have jumps in the representative periods. This affects all "dynamic" constraints, that is, constraints where the current operational period is dependent on the previous operational period. In `EnergyModesBase.jl`, this is only the case for the level balance in `RefStorage`. Representative periods allow for jumps between operational periods, as outlined below.
+    All operational periods are continuous. This implies that one is not allowed to have jumps in the representative periods. This affects all "dynamic" constraints, that is, constraints where the current operational period is dependent on the previous operational period. In `EnergyModesBase`, this is only the case for the level balance in `RefStorage`. Representative periods allow for jumps between operational periods, as outlined below.
 
-Note that `TimeStruct.jl` does not require that each operational period has the same length.
+Note that `TimeStruct` does not require that each operational period has the same length.
 Consider the following example:
 
 ```jldoctest test_label; setup = :(using TimeStruct)
@@ -66,7 +66,7 @@ SimpleTimes{Int64}(11, [4, 2, 1, 1, 2, 4, 2, 1, 1, 2, 4])
 
 and a constructor will automatically deduce that there have to be 11 operational periods.
 
-`SimpleTimes` is also the lowest `TimeStructure` that is present in `TimeStruct.jl`.
+`SimpleTimes` is also the lowest `TimeStructure` that is present in `TimeStruct`.
 It is used in all subsequent structures.
 When iterating over a `TimeStructure`, _e.g._, as `t ∈ operational_periods`, you obtain the single operational periods that are required for solving the optimal dispatch.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,41 +1,30 @@
 # EnergyModelsBase.jl
 
-```@docs
-EnergyModelsBase
-```
-
 **EnergyModelsBase** is an operational, multi nodal energy system model, written in Julia.
-The model is based on the [`JuMP`](https://jump.dev/JuMP.jl/stable/) optimization framework.
+The model is based on the [`JuMP`](https://jump.dev/JuMP.jl/) optimization framework.
 It is a multi carrier energy model, where the definition of the carriers are fully up to the user of the model.
 One of the primary design goals was to develop a model that can easily be extended with new functionalities without the need to understand and remember every variable and constraint in the model.
 
-For running a basic energy system model, only the base technology package
-[`EnergyModelsBase.jl`](https://clean_export.pages.sintef.no/energymodelsbase.jl/)
-and the time structure package
-[`TimeStruct.jl`](https://sintefore.github.io/TimeStruct.jl/stable/)
-is needed.
+For running a basic energy system model, only the base technology package `EnergyModelsBase` and the time structure package
+[`TimeStruct`](https://sintefore.github.io/TimeStruct.jl/) are needed.
 
 The main package provides simple descriptions for energy sources, sinks, conversion, and storage units.
 It corresponds to an operational model without geographic features.
 
 Other packages can the optionally be added if specific functionality or technology nodes are needed. The most important packages are
 
-- [`EnergyModelsGeography.jl`](https://clean_export.pages.sintef.no/energymodelsgeography.jl/):
+- [`EnergyModelsGeography`](https://energymodelsx.github.io/EnergyModelsGeography.jl/):
    this package makes it possible to easily extend your energy model with different
    geographic areas, where transmission can be set to allow for the transport of
    resources between the different areas.
-- [`EnergyModelsInvestments.jl`](https://clean_export.pages.sintef.no/energymodelsinvestments.jl/):
+- [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/):
    this package implements functionality for investments, where the length of the
    investment periods are fully flexible and is decided by setting the time
    structure.
 
 Open Packages implementing technology specific nodes:
 
-- [`EnergyModelsRenewableProducers.jl`](https://clean_export.pages.sintef.no/energymodelsrenewableproducers.jl/): implements `NonDisRES` for intermittent (**Non**-**Dis**patchable) **R**enewable **E**nergy **S**ources and `HydroStor` modeling a regulated hydro storage plant as well as `PumpedHydroStor` modelling a pumped hydro storage plant.
-
-!!! note
-    Some of the links are currently not available, as they point towards internal SINTEF webpages.
-    These links will be updated as soon as possible.
+- [`EnergyModelsRenewableProducers`](https://energymodelsx.github.io/EnergyModelsRenewableProducers.jl/): implements `NonDisRES` for intermittent (**Non**-**Dis**patchable) **R**enewable **E**nergy **S**ources and `HydroStor` modeling a regulated hydro storage plant as well as `PumpedHydroStor` modelling a pumped hydro storage plant.
 
 ## Manual outline
 

--- a/docs/src/library/public.md
+++ b/docs/src/library/public.md
@@ -1,5 +1,11 @@
 # [Public interface](@id sec_lib_public)
 
+## Module
+
+```@docs
+EnergyModelsBase
+```
+
 ## Resources
 
 `Resource`s correspond to the mass/energy that is converted or transported within an energy system.
@@ -8,8 +14,8 @@ Instead, they are implemented through flows and levels, as explained in *[Optimi
 
 ### `Resource` types
 
-The following resources are implemented in `EnergyModelsBase.jl`.
-`EnergyModelsBase.jl` differentiates between `ResourceCarrier` and `ResourceEmit` resources.
+The following resources are implemented in `EnergyModelsBase`.
+`EnergyModelsBase` differentiates between `ResourceCarrier` and `ResourceEmit` resources.
 The key difference between both is that `ResourceEmit` resources can have emissions, *e.g.*, CO₂ or methane.
 Emissions are accounted for and can have either a cap and/or a price associated with them.
 
@@ -33,14 +39,14 @@ co2_int
 
 ## Nodes
 
-`Node`s are used in `EnergyModelsBase.jl` to convert `Resource`s.
+`Node`s are used in `EnergyModelsBase` to convert `Resource`s.
 They are coupled to the rest of the system through the *[Flow variables](@ref var_flow)*.
-Nodes are the key types for extending `EnergyModelsBase.jl` through dispatch.
+Nodes are the key types for extending `EnergyModelsBase` through dispatch.
 You can find an introduction of the different node types on the page *[Creating a new node](@ref create_new_node)*
 
 ### Abstract `Node` types
 
-The following abstract node types are implemented in the `EnergyModelsBase.jl`.
+The following abstract node types are implemented in the `EnergyModelsBase`.
 These abstract types are relevant for dispatching in individual functions.
 
 ```@docs
@@ -53,7 +59,7 @@ Availability
 
 ### [Reference node types](@id sec_lib_public_refnodes)
 
-The following composite types are inmplemented in the `EnergyModelsBase.jl`.
+The following composite types are inmplemented in the `EnergyModelsBase`.
 They can be used for describing a simple energy system without any non-linear or binary based expressions.
 Hence, there are, *e.g.*, no operation point specific efficiencies implemented.
 
@@ -128,7 +134,7 @@ RefStorageEmissions
 
 ### `Link` types
 
-The following types for links are implemented in `EnergyModelsBase.jl`.
+The following types for links are implemented in `EnergyModelsBase`.
 The thought process is to dispatch on the [`EMB.Formulation`](@ref) of a link as additional option.
 This is in the current stage not implemented.
 
@@ -155,8 +161,8 @@ formulation
 ### `EnergyModel` and `Data` types
 
 The type `EnergyModel` is used for creating the global parameters of a model.
-It can be as well used for extending `EnergyModelsBase.jl` as described in the section *[Extensions to the model](@ref sec_phil_ext)*.
-`EnergyModelsBase.jl` only provides an `OperationalModel` while `InvestmentModel` is added through the extension `EnergyModelsInvestments.jl`
+It can be as well used for extending `EnergyModelsBase` as described in the section *[Extensions to the model](@ref sec_phil_ext)*.
+`EnergyModelsBase` only provides an `OperationalModel` while `InvestmentModel` is added through the extension [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/)
 
 ```@docs
 EnergyModel
@@ -188,12 +194,12 @@ co2_instance
 
 ## Functions for running the model
 
-The following functions are provided for both creating a model using `EnergyModelsBase.jl` and solving said model.
+The following functions are provided for both creating a model using `EnergyModelsBase` and solving said model.
 Both functions have the input `case` and `model`.
 `run_model` calls `create_model` in the function, hence, it is not necessary to call the function beforehand.
 
 The `case` dictionary has to follow a certain outline.
-In this case, it is simplest to look at the provided *[examples](https://gitlab.sintef.no/clean_export/energymodelsbase.jl/-/tree/main/examples)*.
+In this case, it is simplest to look at the provided *[examples](https://github.com/EnergyModelsX/EnergyModelsBase.jl/tree/main/examples)*.
 
 !!! note
     We are currently debating to replace the dictionary used for `case` as well with a composite type.
@@ -221,7 +227,7 @@ See the pages *[Constraint functions](@ref constraint_functions)* and *[Data fun
 
 !!! warning
     The function `constraints_capacity_installed` should not be changed.
-    It is used for the inclusion of investments through `EnergyModelsInvestments.jl`.
+    It is used for the inclusion of investments through `EnergyModelsInvestments`.
     It also has to be called, if you create a new function `constraints_capacity`.
 
 ```@docs

--- a/docs/src/manual/optimization-variables.md
+++ b/docs/src/manual/optimization-variables.md
@@ -1,9 +1,9 @@
 # [Optimization variables](@id optimization_variables)
 
-[`EnergyModelsBase`](@ref) creates a variety of default variables for the individual nodes and edges.
+`EnergyModelsBase` creates a variety of default variables for the individual nodes and edges.
 These default variables are in general also created when new `Node`s or `Link`s are developed.
 It is not necessary to utilize all of the default variables in the individual nodes.
-It is however recommended to include in this situation constraints or fixes using either the `@constraint` macro or alternatively the `JuMP.jl` function `fix(x, value)`.
+It is however recommended to include in this situation constraints or fixes using either the `@constraint` macro or alternatively the `JuMP` function `fix(x, value)`.
 The latter is the recommended approach.
 
 !!! note

--- a/docs/src/manual/philosophy.md
+++ b/docs/src/manual/philosophy.md
@@ -66,19 +66,19 @@ This approach allows for a different mathematical description compared to the in
 As an example, it is possible to introduce a new demand node that provides a profit for satisfying a demand combined with having no penalty if the demand is not satisfied.
 
 Calling `create_model` within a new function allows the introduction of entirely new functions.
-This approach is chosen in [`EnergyModelsGeography.jl`](https://clean_export.pages.sintef.no/energymodelsgeography.jl/) although it still uses dispatch on individual technology nodes.
+This approach is chosen in [`EnergyModelsGeography`](https://energymodelsx.github.io/EnergyModelsGeography.jl/) although it still uses dispatch on individual technology nodes.
 
 Dispatching on the type `EnergyModel` allows for adding methods to all functions that have `modeltype` included in the call.
-This is done in the package [`EnergyModelsInvestments.jl`](https://clean_export.pages.sintef.no/energymodelsinvestments.jl/) where investments are added to the model through introducting the `abstract type` `AbstractInvestmentModel`.
+This is done in the package [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) where investments are added to the model through introducting the `abstract type` `AbstractInvestmentModel`.
 It can be problematic when one also wants to use investments.
 In addition, care has to be taken with respect to method amibiguity when dispatching on the type `EnergyModel`.
 
 The `Array{Data}` field provides us with flexibility with respect to providing additional data to the existing nodes.
-It is implemented in `EnergyModelsBase.jl` for including emissions (both process and energy usage related).
+It is implemented in `EnergyModelsBase` for including emissions (both process and energy usage related).
 In that case, it allows for flexibility through either saying whether process (or energy related emissions) are present, or not.
 In addition, it allows for capturing the CO₂ from either the individual CO₂ sources (process and energy usage related), alternatively from both sources, or not at all.
 The individual data types are explained in the Section *[Emissions data](@ref sec_lib_public_emdata)* in the public library as well as on *[Data functions](@ref data_functions)*.
-In addition, it is already used in the package [`EnergyModelsInvestments.jl`](https://clean_export.pages.sintef.no/energymodelsinvestments.jl/) through the introduction of the `abstract type` `InvestmentData` as subtype of `Data`.
+In addition, it is already used in the package [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) through the introduction of the `abstract type` `InvestmentData` as subtype of `Data`.
 The introduction of `InvestmentData` allows providing additional parameters to individual technologies.
-However, the implementation in `EnergyModelsInvestments.jl` does not utilize the extension through the *[Data functions](@ref data_functions)*.
+However, the implementation in `EnergyModelsInvestments` does not utilize the extension through the *[Data functions](@ref data_functions)*.
 Instead, as outlined above, it dispatches on the type `EnergyModel`.

--- a/docs/src/manual/quick-start.md
+++ b/docs/src/manual/quick-start.md
@@ -13,4 +13,4 @@
     ] add https://github.com/sintefore/TimeStruct.jl
     ] add https://github.com/EnergyModelsX/EnergyModelsBase.jl
     ```
-    Once the packages are registered, this is not required any longer.
+    Once the packages are registered, this is not required.

--- a/docs/src/manual/quick-start.md
+++ b/docs/src/manual/quick-start.md
@@ -1,17 +1,16 @@
 # Quick Start
 
 >  1. Install the most recent version of [Julia](https://julialang.org/downloads/)
->  2. Add the [CleanExport internal Julia registry](https://gitlab.sintef.no/clean_export/registrycleanexport):
+>  2. Install the package [`EnergyModelsBase`](https://energymodelsx.github.io/EnergyModelsBase.jl/) and the time package [`TimeStruct`](https://sintefore.github.io/TimeStruct.jl/), by running:
 >     ```
->     ] registry add git@gitlab.sintef.no:clean_export/registrycleanexport.git
->     ```
->  3. Add the [SINTEF internal Julia registry](https://gitlab.sintef.no/julia-one-sintef/onesintef):
->     ```
->     ] registry add git@gitlab.sintef.no:julia-one-sintef/onesintef.git
->     ```
->  4. Install the base package [`EnergyModelsBase.jl`](https://clean_export.pages.sintef.no/energymodelsbase.jl/) and the time package [`TimeStruct.jl`](https://gitlab.sintef.no/julia-one-sintef/timestruct.jl), by running:
->     ```
->     ] add EnergyModelsBase
 >     ] add TimeStruct
+>     ] add EnergyModelsBase
 >     ```
->     This will fetch the packages from the CleanExport package and OneSINTEF registries.
+
+!!! note
+    If you receive the error that one of the packages is not yet registered, you have to add the packages using the GitHub repositories through
+    ```
+    ] add https://github.com/sintefore/TimeStruct.jl
+    ] add https://github.com/EnergyModelsX/EnergyModelsBase.jl
+    ```
+    Once the packages are registered, this is not required any longer.

--- a/docs/src/manual/simple-example.md
+++ b/docs/src/manual/simple-example.md
@@ -1,17 +1,8 @@
 # Examples
 
-For the content of the individual examples, see the *[examples](https://gitlab.sintef.no/clean_export/energymodelsbase.jl/-/tree/main/examples)* directory in the project repository.
+For the content of the individual examples, see the *[examples](https://github.com/EnergyModelsX/EnergyModelsBase.jl/tree/main/examples)* directory in the project repository.
 
 ## The package is installed with `] add`
-
-First, add the *[Clean Export Julia packages repository](https://gitlab.sintef.no/clean_export/registrycleanexport)*.
-Then run
-
-```
-~/some/directory/ $ julia           # Starts the Julia REPL
-julia> ]                            # Enter Pkg mode
-pkg> add EnergyModelsBase           # Install the package EnergyModelsBase to the current environment.
-```
 
 From the Julia REPL, run
 
@@ -37,8 +28,7 @@ julia> include(joinpath(exdir, "network.jl"))
 
 ## The code was downloaded with `git clone`
 
-First, add the internal *[Clean Export Julia package registry](https://gitlab.sintef.no/clean_export/registrycleanexport)*.
-The examples can then be run from the terminal with
+The examples can be run from the terminal with
 
 ```shell script
 ~/../energymodelsrenewableproducers.jl/examples $ julia sink_source.jl

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,26 +1,15 @@
 # Running the examples
 
-## The package is installed with `] add`
+You have to add the packages `TimeStruct`, `EnergyModelsBase`, `JuMP`, `HiGHS`, and `PrettyTables` to your current project in order to run the examples.
+How to add packages is explained in the *[Quick start](https://energymodelsx.github.io/EnergyModelsBase.jl/dev/manual/quick-start/)* of the documentation
 
-First, add the [*Clean Export* Julia packages repository](https://gitlab.sintef.no/clean_export/registrycleanexport). Then run 
-```
-~/some/directory/ $ julia           # Starts the Julia REPL
-julia> ]                            # Enter Pkg mode 
-pkg> add EnergyModelsBase           # Install the package EnergyModelsBase to the current environment.
-```
-From the Julia REPL, run
+Once you have the respective pacakges installed in your project, you can run from the Julia REPL the following code:
+
 ```julia
 # Starts the Julia REPL
 julia> using EnergyModelsBase
 # Get the path of the examples directory
 julia> exdir = joinpath(pkgdir(EnergyModelsBase), "examples")
-# Include the code into the Julia REPL to run the examples
+# Include the code into the Julia REPL to run the first example
 julia> include(joinpath(exdir, "sink_source.jl"))
-```
-
-## The code was downloaded with `git clone`
-
-First, add the internal [*Clean Export* Julia package registry](https://gitlab.sintef.no/clean_export/registrycleanexport). The examples can then be run from the terminal with
-```shell script
-~/.../energymodelsbase.jl/examples $ julia sink_source.jl
 ```

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -21,11 +21,9 @@ function generate_data()
     CO2 = ResourceEmit("CO2", 1.0)
     products = [NG, Coal, Power, CO2]
 
-    # Creation of a dictionary with entries of 0 for all emission resources
-    # This dictionary is normally used as usage based non-energy emissions.
-    𝒫ᵉᵐ₀ = Dict(k => 0.0 for k ∈ products if typeof(k) == ResourceEmit{Float64})
-    𝒫ᵉᵐ₀[CO2] = 0.0
-    capture_data = CaptureEnergyEmissions(𝒫ᵉᵐ₀, 0.9)
+    # Creation of the emission data for the individual nodes.
+    capture_data = CaptureEnergyEmissions(0.9)
+    emission_data = EmissionsEnergy()
 
     # Create the individual test nodes, corresponding to a system with an electricity demand/sink,
     # coal and nautral gas sources, coal and natural gas (with CCS) power plants and CO2 storage.
@@ -44,7 +42,7 @@ function generate_data()
         RefNetworkNode(5, FixedProfile(25), FixedProfile(6),
             FixedProfile(0), Dict(Coal => 2.5),
             Dict(Power => 1),
-            []),
+            [emission_data]),
         RefStorage(6, FixedProfile(60), FixedProfile(600), FixedProfile(9.1),
             FixedProfile(0), CO2, Dict(CO2 => 1, Power => 0.02), Dict(CO2 => 1),
             Array{Data}([])),

--- a/examples/sink_source.jl
+++ b/examples/sink_source.jl
@@ -22,11 +22,6 @@ function generate_data()
     CO2 = ResourceEmit("CO2", 1.0)
     products = [Power, CO2]
 
-    # Creation of a dictionary with entries of 0 for all emission resources
-    # This dictionary is normally used as usage based non-energy emissions.
-    𝒫ᵉᵐ₀ = Dict(k => 0.0 for k ∈ products if typeof(k) == ResourceEmit{Float64})
-    𝒫ᵉᵐ₀[CO2] = 0.0
-
     # Create the individual test nodes, corresponding to a system with an electricity
     # demand/sink and source
     nodes = [

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -1,7 +1,12 @@
 """
-Main module for `EnergyModelsBase.jl`.
+Main module for `EnergyModelsBase` a framework for building flexible energy system models.
 
-This module provides the framework for building energy system models.
+It exports several types and associated functions for accessing fields.
+In addition, all required functions for creaeting and running the model are exported.
+
+You can find the exported types and functions below or on the pages \
+*[Constraint functions](@ref constraint_functions)* and \
+*[Data functions](@ref data_functions)*.
 """
 module EnergyModelsBase
 

--- a/src/structures_resource.jl
+++ b/src/structures_resource.jl
@@ -1,10 +1,5 @@
 """
-Resources that can be transported and converted.
-
-# Fields
-- **`id`** is the name/identifyer of the resource.\n
-- **`co2_int::T`** is the the CO2 intensity.\n
-
+General resource supertype to be used for the declaration of subtypes.
 """
 abstract type Resource end
 Base.show(io::IO, r::Resource) = print(io, "$(r.id)")
@@ -12,10 +7,12 @@ Base.show(io::IO, r::Resource) = print(io, "$(r.id)")
 """
 Resources that can can be emitted (e.g., CO2, CH4, NOx).
 
+These resources can be included as resources that are emitted, *e.g*, in the variable \
+[``\\texttt{emissions\\_strategic}``](@ref var_emission).
+
 # Fields
 - **`id`** is the name/identifyer of the resource.\n
-- **`co2_int::T`** is the the CO2 intensity.\n
-
+- **`co2_int::T`** is the the CO2 intensity, *e.g.*, t/MWh.
 """
 struct ResourceEmit{T<:Real} <: Resource
     id
@@ -23,7 +20,13 @@ struct ResourceEmit{T<:Real} <: Resource
 end
 
 """
-General resources.
+Resources that can be transported and converted.
+These resources cannot be included as resources that are emitted, *e.g*, in the variable \
+[``\\texttt{emissions\\_strategic}``](@ref var_emission).
+
+# Fields
+- **`id`** is the name/identifyer of the resource.\n
+- **`co2_int::T`** is the the CO2 intensity, *e.g.*, t/MWh.
 """
 struct ResourceCarrier{T<:Real} <: Resource
     id

--- a/test/example_model.jl
+++ b/test/example_model.jl
@@ -7,11 +7,8 @@ function generate_data()
     CO2      = ResourceEmit("CO2",1.)
     products = [NG, Coal, Power, CO2]
 
-    # Creation of a dictionary with entries of 0 for all emission resources
-    # This dictionary is normally used as usage based non-energy emissions.
-    𝒫ᵉᵐ₀ = Dict(k  => 0. for k ∈ products if typeof(k) == ResourceEmit{Float64})
-    𝒫ᵉᵐ₀[CO2] = 0.0
-    capture_data = CaptureEnergyEmissions(𝒫ᵉᵐ₀, 0.9)
+    # Creation of the emission data for the individual nodes.
+    capture_data = CaptureEnergyEmissions(0.9)
     emission_data = EmissionsEnergy()
 
     # Create the individual test nodes, corresponding to a system with an electricity demand/sink,


### PR DESCRIPTION
The docs still included a significant number of internal links to SINTEF pages.
These links were updated to the corresponding GitHub repositories and their documentation.
In addition, the examples section was updated for simpler runs by the user.