### PR TITLE
Including GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+      - release-*
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Since TimeStruct doesn't have binary dependencies, only test on a subset of
+        # possible platforms.
+        include:
+          - version: '1'  # The latest point-release (Linux)
+            os: ubuntu-latest
+            arch: x64
+          - version: '1'  # The latest point-release (Windows)
+            os: windows-latest
+            arch: x64
+          - version: '1.9'  # 1.9 
+            os: ubuntu-latest
+            arch: x64
+          - version: '1.9'  # 1.9
+            os: ubuntu-latest
+            arch: x86
+          - version: 'nightly'
+            os: ubuntu-latest
+            arch: x64
+    steps:
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v3
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          depwarn: error
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v3
+        with:
+          file: lcov.info

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # EnergyModelsBase
 
+[![Build Status](https://github.com/EnergyModelsX/EnergyModelsBase.jl/workflows/CI/badge.svg?branch=main)](https://github.com/EnergyModelsX/EnergyModelsBase.jl/actions?query=workflow%3ACI)
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://energymodelsx.github.io/EnergyModelsBase.jl//stable)
 [![In Development](https://img.shields.io/badge/docs-dev-blue.svg)](https://energymodelsx.github.io/EnergyModelsBase.jl/dev/)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -35,7 +35,6 @@ Pages = [
     "manual/optimization-variables.md",
     "manual/constraint-functions.md",
     "manual/data-functions.md",
-    "manual/nodes.md",
     "manual/simple-example.md",
 ]
 ```


### PR DESCRIPTION
The included GitHub CI is based on the one used for [TimeStruct](https://github.com/sintefore/TimeStruct.jl/blob/main/.github/workflows/ci.yml).