### PR TITLE
Fix of examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EnergyModelsBase
 
-[![Build Status](https://github.com/EnergyModelsX/EnergyModelsBase.jl/workflows/CI/badge.svg?branch=main)](https://github.com/EnergyModelsX/EnergyModelsBase.jl/actions?query=workflow%3ACI)
+[![Build Status](https://github.com/EnergyModelsX/EnergyModelsBase.jl/workflows/CI/badge.svg)](https://github.com/EnergyModelsX/EnergyModelsBase.jl/actions?query=workflow%3ACI)
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://energymodelsx.github.io/EnergyModelsBase.jl//stable)
 [![In Development](https://img.shields.io/badge/docs-dev-blue.svg)](https://energymodelsx.github.io/EnergyModelsBase.jl/dev/)
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@
 It is designed to model the basic operations of various generation, conversion and storage technologies.
 `EnergyModelsBase` is designed to enable optimization of operations, and to be be easily extendible to investment models, and/or to include new technologies or more detailed models of key technologies.
 
-> **Note:**
->
-> We migrated recently from an internal Git solution to GitHub, including the package [`TimeStruct`](https://github.com/sintefore/TimeStruct.jl). As `TimeStruct` is not yet registered, it is not possible to run the tests without significant changes in the CI. Hence, we plan to wait with creating a release to be certain the tests are running. As a result, the stable docs are not yet available.
-
 ## Usage
 
 The usage of the package is based illustrated through the commented [`examples`](examples).

--- a/docs/src/manual/quick-start.md
+++ b/docs/src/manual/quick-start.md
@@ -8,9 +8,8 @@
 >     ```
 
 !!! note
-    If you receive the error that one of the packages is not yet registered, you have to add the packages using the GitHub repositories through
+    If you receive the error that `EnergyModelsBase` is not yet registered, you have to add the package using the GitHub repositories through
     ```
-    ] add https://github.com/sintefore/TimeStruct.jl
     ] add https://github.com/EnergyModelsX/EnergyModelsBase.jl
     ```
-    Once the packages are registered, this is not required.
+    Once the package is registered, this is not required.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,9 +1,10 @@
 # Running the examples
 
-You have to add the packages `TimeStruct`, `EnergyModelsBase`, `JuMP`, `HiGHS`, and `PrettyTables` to your current project in order to run the examples.
-How to add packages is explained in the *[Quick start](https://energymodelsx.github.io/EnergyModelsBase.jl/dev/manual/quick-start/)* of the documentation
+You have to add the package `EnergyModelsBase` to your current project in order to run the examples.
+It is not necessary to add the other used packages, as the example is instantiating itself.
+How to add packages is explained in the *[Quick start](https://energymodelsx.github.io/EnergyModelsBase.jl/stable/manual/quick-start/)* of the documentation
 
-Once you have the respective pacakges installed in your project, you can run from the Julia REPL the following code:
+You can run from the Julia REPL the following code:
 
 ```julia
 # Starts the Julia REPL

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -1,6 +1,9 @@
 using Pkg
+# Activate the test-environment, where PrettyTables and HiGHS are added as dependencies.
 Pkg.activate(joinpath(@__DIR__, "../test"))
+# Install the dependencies.
 Pkg.instantiate()
+# Add the package EnergyModelsBase to the environment.
 Pkg.develop(path=joinpath(@__DIR__, ".."))
 
 using EnergyModelsBase
@@ -14,7 +17,7 @@ using TimeStruct
 function generate_data()
     @info "Generate case data"
 
-    # Define the different resources
+    # Define the different resources and their emission intensity in tCO2/MWh
     NG = ResourceEmit("NG", 0.2)
     Coal = ResourceCarrier("Coal", 0.35)
     Power = ResourceCarrier("Power", 0.0)
@@ -29,27 +32,62 @@ function generate_data()
     # coal and nautral gas sources, coal and natural gas (with CCS) power plants and CO2 storage.
     nodes = [
         GenAvailability(1, products),
-        RefSource(2, FixedProfile(1e12), FixedProfile(30),
-            FixedProfile(0), Dict(NG => 1),
-            []),
-        RefSource(3, FixedProfile(1e12), FixedProfile(9),
-            FixedProfile(0), Dict(Coal => 1),
-            []),
-        RefNetworkNode(4, FixedProfile(25), FixedProfile(5.5),
-            FixedProfile(0), Dict(NG => 2),
-            Dict(Power => 1, CO2 => 1),
-            [capture_data]),
-        RefNetworkNode(5, FixedProfile(25), FixedProfile(6),
-            FixedProfile(0), Dict(Coal => 2.5),
-            Dict(Power => 1),
-            [emission_data]),
-        RefStorage(6, FixedProfile(60), FixedProfile(600), FixedProfile(9.1),
-            FixedProfile(0), CO2, Dict(CO2 => 1, Power => 0.02), Dict(CO2 => 1),
-            Array{Data}([])),
-        RefSink(7, OperationalProfile([20 30 40 30]),
+        RefSource(
+            2,                          # Node id
+            FixedProfile(1e12),         # Capacity in MW
+            FixedProfile(30),           # Variable OPEX in EUR/MW
+            FixedProfile(0),            # Fixed OPEX in EUR/8h
+            Dict(NG => 1),              # Output from the Node, in this gase, NG
+            [],                         # Potential additional data
+        ),
+        RefSource(
+            3,                          # Node id
+            FixedProfile(1e12),         # Capacity in MW
+            FixedProfile(9),            # Variable OPEX in EUR/MWh
+            FixedProfile(0),            # Fixed OPEX in EUR/8h
+            Dict(Coal => 1),            # Output from the Node, in this gase, coal
+            [],                         # Potential additional data
+        ),
+        RefNetworkNode(
+            4,                          # Node id
+            FixedProfile(25),           # Capacity in MW
+            FixedProfile(5.5),          # Variable OPEX in EUR/MWh
+            FixedProfile(0),            # Fixed OPEX in EUR/8h
+            Dict(NG => 2),              # Input to the node with input ratio
+            Dict(Power => 1, CO2 => 1), # Output from the node with output ratio
+            # Line above: CO2 is required as output for variable definition, but the
+            # value does not matter
+            [capture_data],             # Additonal data for emissions and CO2 capture
+        ),
+        RefNetworkNode(
+            5,                          # Node id
+            FixedProfile(25),           # Capacity in MW
+            FixedProfile(6),            # Variable OPEX in EUR/MWh
+            FixedProfile(0),            # Fixed OPEX in EUR/8h
+            Dict(Coal => 2.5),          # Input to the node with input ratio
+            Dict(Power => 1),           # Output from the node with output ratio
+            [emission_data],            # Additonal data for emissions
+        ),
+        RefStorage(
+            6,                          # Node id
+            FixedProfile(60),           # Rate capacity in MW
+            FixedProfile(600),          # Storage capacity in MWh
+            FixedProfile(9.1),          # Storage variable OPEX for the rate in EUR/MW
+            FixedProfile(0),            # Storage fixed OPEX for the rate in EUR/8h
+            CO2,                        # Stored resource
+            Dict(CO2 => 1, Power => 0.02), # Input resource with input ratio
+            # Line above: This implies that storing CO2 requires Power
+            Dict(CO2 => 1),             # Output from the node with output ratio
+            # In practice, for CO2 storage, this is never used.
+            Array{Data}([]),            # Potential additional data
+        ),
+        RefSink(
+            7,                          # Node id
+            OperationalProfile([20 30 40 30]), # Demand in MW
             Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
-            Dict(Power => 1),
-            []),
+            # Line above: Surplus and deficit penalty for the node in EUR/MWh
+            Dict(Power => 1),           # Energy demand and corresponding ratio
+        ),
     ]
 
     # Connect all nodes with the availability node for the overall energy/mass balance
@@ -78,15 +116,15 @@ function generate_data()
     # Creation of the time structure and global data
     T = TwoLevel(4, 1, operational_periods; op_per_strat)
     model = OperationalModel(
-        Dict(
+        Dict(   # Emission cap for CO2 in t/8h and for NG in MWh/8h
             CO2 => StrategicProfile([160, 140, 120, 100]),
             NG => FixedProfile(1e6)
         ),
-        Dict(
+        Dict(   # Emission price for CO2 in EUR/t and for NG in EUR/MWh
             CO2 => FixedProfile(0),
             NG => FixedProfile(0),
         ),
-        CO2,
+        CO2,    # CO2 instance
     )
 
     # WIP data structure

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,6 @@
 [deps]
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
-LocalRegistry = "89398ba2-070a-4b16-a995-9893c55d93cf"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
1. The documentation of the examples was extended to allow a user to understand which field corresponds to which parameter.
2. The README.md file was updated to account for the registration of TimeStruct and the addition of the CI.
3. The branch statement was removed from the CI badge. This allows it to show the value.