### PR TITLE
Removed const EMB from examples

### DIFF
--- a/examples/network.jl
+++ b/examples/network.jl
@@ -137,7 +137,7 @@ end
 # Create the case and model data and run the model
 case, model = generate_data()
 optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
-m = EMB.run_model(case, model, optimizer)
+m = run_model(case, model, optimizer)
 
 # Display some results
 @info "Capacity usage of the coal power plant"

--- a/examples/sink_source.jl
+++ b/examples/sink_source.jl
@@ -78,7 +78,7 @@ end
 # Create the case and model data and run the model
 case, model = generate_data()
 optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
-m = EMB.run_model(case, model, optimizer)
+m = run_model(case, model, optimizer)
 
 # Inspect some of the results
 source, sink = case[:nodes]


### PR DESCRIPTION
As we were made aware, we use the constant `EMB` in the examples without defining it directly. This was not identified in the CI, as we test the examples after `test\runtests.jl` where the constant is defined.

The definition of the constant is however not longer necessary, as the function is exported. Hence, we removed the constant.