### PR TITLE
Bugfix for running examples when added from Registry

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
 # Release notes
+=============
+
+Unversioned
+--------------------------
+ * Fixed a bug when running the examples from a non-cloned version of `EnergyModelsBase`.
+ * This was achieved through a separate Project.toml in the examples.
 
 Version 0.6.5 (2024-01-31)
 --------------------------

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
+HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -2,5 +2,6 @@
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,10 +7,15 @@ How to add packages is explained in the *[Quick start](https://energymodelsx.git
 You can run from the Julia REPL the following code:
 
 ```julia
-# Starts the Julia REPL
-julia> using EnergyModelsBase
+# Import EnergyModelsBase
+using EnergyModelsBase
+
 # Get the path of the examples directory
-julia> exdir = joinpath(pkgdir(EnergyModelsBase), "examples")
-# Include the code into the Julia REPL to run the first example
-julia> include(joinpath(exdir, "sink_source.jl"))
+exdir = joinpath(pkgdir(EnergyModelsBase), "examples")
+
+# Include the code into the Julia REPL to run the simple sink-source example
+include(joinpath(exdir, "sink_source.jl"))
+
+# Include the code into the Julia REPL to run the simple network example
+include(joinpath(exdir, "sink_source.jl"))
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,5 +17,5 @@ exdir = joinpath(pkgdir(EnergyModelsBase), "examples")
 include(joinpath(exdir, "sink_source.jl"))
 
 # Include the code into the Julia REPL to run the simple network example
-include(joinpath(exdir, "sink_source.jl"))
+include(joinpath(exdir, "network.jl"))
 ```

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -1,6 +1,6 @@
 using Pkg
 # Activate the local environment including EnergyModelsBase, HiGHS, PrettyTables
-Pkg.activate()
+Pkg.activate(@__DIR__)
 # Install the dependencies.
 Pkg.instantiate()
 

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -1,20 +1,25 @@
 using Pkg
-# Activate the test-environment, where PrettyTables and HiGHS are added as dependencies.
-Pkg.activate(joinpath(@__DIR__, "../test"))
+# Activate the local environment including EnergyModelsBase, HiGHS, PrettyTables
+Pkg.activate()
 # Install the dependencies.
 Pkg.instantiate()
-# Add the package EnergyModelsBase to the environment.
-Pkg.develop(path=joinpath(@__DIR__, ".."))
 
+# Import the required packages
 using EnergyModelsBase
 using JuMP
 using HiGHS
 using PrettyTables
 using TimeStruct
 
+"""
+    generate_example_data()
 
-function generate_data()
-    @info "Generate case data"
+Generate the data for an example consisting of a simple electricity network.
+The more stringent CO₂ emission in latter investment periods force the utilization of the
+more expensive natural gas power plant with CCS to reduce emissions.
+"""
+function generate_example_data()
+    @info "Generate case data - Simple network example"
 
     # Define the different resources and their emission intensity in tCO2/MWh
     NG = ResourceEmit("NG", 0.2)
@@ -32,7 +37,7 @@ function generate_data()
     # can also be extracted using the function `duration` of a `SimpleTimes` structure.
     # This implies, that a strategic period is 8 times longer than an operational period,
     # resulting in the values below as "/8h".
-    op_per_strat = duration(operational_periods)
+    op_per_strat = op_duration * op_number
 
     # Creation of the time structure and global data
     T = TwoLevel(4, 1, operational_periods; op_per_strat)
@@ -55,23 +60,23 @@ function generate_data()
     # Create the individual test nodes, corresponding to a system with an electricity demand/sink,
     # coal and nautral gas sources, coal and natural gas (with CCS) power plants and CO₂ storage.
     nodes = [
-        GenAvailability(1, products),
+        GenAvailability("Availability", products),
         RefSource(
-            2,                          # Node id
+            "NG source",                # Node id
             FixedProfile(1e12),         # Capacity in MW
             FixedProfile(30),           # Variable OPEX in EUR/MW
             FixedProfile(0),            # Fixed OPEX in EUR/8h
             Dict(NG => 1),              # Output from the Node, in this gase, NG
         ),
         RefSource(
-            3,                          # Node id
+            "coal source",              # Node id
             FixedProfile(1e12),         # Capacity in MW
             FixedProfile(9),            # Variable OPEX in EUR/MWh
             FixedProfile(0),            # Fixed OPEX in EUR/8h
             Dict(Coal => 1),            # Output from the Node, in this gase, coal
         ),
         RefNetworkNode(
-            4,                          # Node id
+            "NG+CCS power plant",       # Node id
             FixedProfile(25),           # Capacity in MW
             FixedProfile(5.5),          # Variable OPEX in EUR/MWh
             FixedProfile(0),            # Fixed OPEX in EUR/8h
@@ -82,7 +87,7 @@ function generate_data()
             [capture_data],             # Additonal data for emissions and CO₂ capture
         ),
         RefNetworkNode(
-            5,                          # Node id
+            "coal power plant",         # Node id
             FixedProfile(25),           # Capacity in MW
             FixedProfile(6),            # Variable OPEX in EUR/MWh
             FixedProfile(0),            # Fixed OPEX in EUR/8h
@@ -91,7 +96,7 @@ function generate_data()
             [emission_data],            # Additonal data for emissions
         ),
         RefStorage(
-            6,                          # Node id
+            "CO2 storage",              # Node id
             FixedProfile(60),           # Rate capacity in t/h
             FixedProfile(600),          # Storage capacity in t
             FixedProfile(9.1),          # Storage variable OPEX for the rate in EUR/t
@@ -103,7 +108,7 @@ function generate_data()
             # In practice, for CO₂ storage, this is never used.
         ),
         RefSink(
-            7,                          # Node id
+            "electricity demand",       # Node id
             OperationalProfile([20 30 40 30]), # Demand in MW
             Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
             # Line above: Surplus and deficit penalty for the node in EUR/MWh
@@ -113,15 +118,15 @@ function generate_data()
 
     # Connect all nodes with the availability node for the overall energy/mass balance
     links = [
-        Direct(14, nodes[1], nodes[4], Linear())
-        Direct(15, nodes[1], nodes[5], Linear())
-        Direct(16, nodes[1], nodes[6], Linear())
-        Direct(17, nodes[1], nodes[7], Linear())
-        Direct(21, nodes[2], nodes[1], Linear())
-        Direct(31, nodes[3], nodes[1], Linear())
-        Direct(41, nodes[4], nodes[1], Linear())
-        Direct(51, nodes[5], nodes[1], Linear())
-        Direct(61, nodes[6], nodes[1], Linear())
+        Direct("Av-NG_pp", nodes[1], nodes[4], Linear())
+        Direct("Av-coal_pp", nodes[1], nodes[5], Linear())
+        Direct("Av-CO2_stor", nodes[1], nodes[6], Linear())
+        Direct("Av-demand", nodes[1], nodes[7], Linear())
+        Direct("NG_src-av", nodes[2], nodes[1], Linear())
+        Direct("Coal_src-av", nodes[3], nodes[1], Linear())
+        Direct("NG_pp-av", nodes[4], nodes[1], Linear())
+        Direct("Coal_pp-av", nodes[5], nodes[1], Linear())
+        Direct("CO2_stor-av", nodes[6], nodes[1], Linear())
     ]
 
     # WIP data structure
@@ -134,25 +139,26 @@ function generate_data()
     return case, model
 end
 
-# Create the case and model data and run the model
-case, model = generate_data()
+# Generate the case and model data and run the model
+case, model = generate_example_data()
 optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
 m = run_model(case, model, optimizer)
 
-# Display some results
+# Display some the results
+ng_ccs_pp, coal_pp,  = case[:nodes][[4,5]]
 @info "Capacity usage of the coal power plant"
 pretty_table(
     JuMP.Containers.rowtable(
         value,
-        m[:cap_use][case[:nodes][5], :];
+        m[:cap_use][coal_pp, :];
         header=[:t, :Value]
     ),
 )
-@info "Capacity usage of the nautral gas + CCS power plant"
+@info "Capacity usage of the natural gas + CCS power plant"
 pretty_table(
     JuMP.Containers.rowtable(
         value,
-        m[:cap_use][case[:nodes][4], :];
+        m[:cap_use][ng_ccs_pp, :];
         header=[:t, :Value]
     ),
 )

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -144,7 +144,7 @@ case, model = generate_example_data()
 optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
 m = run_model(case, model, optimizer)
 
-# Display some the results
+# Display some results
 ng_ccs_pp, coal_pp,  = case[:nodes][[4,5]]
 @info "Capacity usage of the coal power plant"
 pretty_table(

--- a/examples/sink_source.jl
+++ b/examples/sink_source.jl
@@ -1,6 +1,6 @@
 using Pkg
 # Activate the local environment including EnergyModelsBase, HiGHS, PrettyTables
-Pkg.activate()
+Pkg.activate(@__DIR__)
 # Install the dependencies.
 Pkg.instantiate()
 

--- a/examples/sink_source.jl
+++ b/examples/sink_source.jl
@@ -83,7 +83,7 @@ case, model = generate_example_data()
 optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
 m = run_model(case, model, optimizer)
 
-# Display some the results
+# Display some results
 source, sink = case[:nodes]
 @info "Capacity usage of the power source"
 pretty_table(

--- a/examples/sink_source.jl
+++ b/examples/sink_source.jl
@@ -1,20 +1,24 @@
 using Pkg
-# Activate the test-environment, where PrettyTables and HiGHS are added as dependencies.
-Pkg.activate(joinpath(@__DIR__, "../test"))
+# Activate the local environment including EnergyModelsBase, HiGHS, PrettyTables
+Pkg.activate()
 # Install the dependencies.
 Pkg.instantiate()
-# Add the package EnergyModelsBase to the environment.
-Pkg.develop(path=joinpath(@__DIR__, ".."))
 
+# Import the required packages
 using EnergyModelsBase
 using JuMP
 using HiGHS
 using PrettyTables
 using TimeStruct
 
+"""
+    generate_example_data()
 
-function generate_data()
-    @info "Generate case data"
+Generate the data for an example consisting of an electricity source and sink. It shows how
+the source adjusts to the demand.
+"""
+function generate_example_data()
+    @info "Generate case data - Simple sink-source example"
 
     # Define the different resources and their emission intensity in tCO2/MWh
     Power = ResourceCarrier("Power", 0.0)
@@ -30,7 +34,7 @@ function generate_data()
     # can also be extracted using the function `duration` of a `SimpleTimes` structure.
     # This implies, that a strategic period is 8 times longer than an operational period,
     # resulting in the values below as "/8h".
-    op_per_strat = duration(operational_periods)
+    op_per_strat = op_duration * op_number
 
     # Creation of the time structure and global data
     T = TwoLevel(2, 1, operational_periods; op_per_strat)
@@ -44,14 +48,14 @@ function generate_data()
     # demand/sink and source
     nodes = [
         RefSource(
-            1,                          # Node id
+            "electricity source",       # Node id
             FixedProfile(1e12),         # Capacity in MW
             FixedProfile(30),           # Variable OPEX in EUR/MW
             FixedProfile(0),            # Fixed OPEX in EUR/8h
             Dict(Power => 1),           # Output from the Node, in this gase, Power
         ),
         RefSink(
-            2,                          # Node id
+            "electricity demand",       # Node id
             OperationalProfile([20 30 40 30]), # Demand in MW
             Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
             # Line above: Surplus and deficit penalty for the node in EUR/MWh
@@ -61,7 +65,7 @@ function generate_data()
 
     # Connect all nodes with the availability node for the overall energy/mass balance
     links = [
-        Direct(12, nodes[1], nodes[2], Linear())
+        Direct("source-demand", nodes[1], nodes[2], Linear())
     ]
 
     # WIP data structure
@@ -74,13 +78,12 @@ function generate_data()
     return case, model
 end
 
-
-# Create the case and model data and run the model
-case, model = generate_data()
+# Generate the case and model data and run the model
+case, model = generate_example_data()
 optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
 m = run_model(case, model, optimizer)
 
-# Inspect some of the results
+# Display some the results
 source, sink = case[:nodes]
 @info "Capacity usage of the power source"
 pretty_table(

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,5 @@
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -12,5 +12,5 @@
             end
         end
     end
-    Pkg.activate()
+    Pkg.activate(@__DIR__)
 end

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -1,7 +1,6 @@
 
 @testset "Run examples" begin
     exdir = joinpath(@__DIR__, "../examples")
-
     files = first(walkdir(exdir))[3]
     for file in files
         if splitext(file)[2] == ".jl"
@@ -13,9 +12,5 @@
             end
         end
     end
-
-    # Cleanup the test environment. Remove EnergyModelsBase from the environment,
-    # since it is added with `Pkg.develop` by the examples. The tests can not be run with
-    # with the package in the environment.
-    Pkg.rm("EnergyModelsBase")
+    Pkg.activate()
 end


### PR DESCRIPTION
The example description was not running on at least a Windows PC, if `EnergyModelsBase` was included through `] add EnergyModelsBase` from the General Registry. The problem is that we were relying on developing `EnergyModelsBase` to the test environment. In the case of an installation of `EnergyModelsBase` from the registry, this `Project.toml` was on Windows a read-only file, not allowing the modification of the file.

This is solved through explicitly creating a `Project.toml` file for the examples.

In addition, the examples were transformed to a uniform design to simplify the understanding.