### PR TITLE
Fix on checks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Unversioned
+## Version 0.6.6 (2024-03-XX)
 
 ### Examples
 
@@ -26,7 +26,8 @@
 
 ## Version 0.6.4 (2024-01-18)
 
-* Minor modification to the `EmissionsData` allowing now also time dependent process emissions. This is achieved through switching to a parametric type.
+* Minor modification to the `EmissionsData` allowing now also time dependent process emissions.
+* This is achieved through switching to a parametric type.
 
 ## Version 0.6.3 (2024-01-17)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,125 +1,145 @@
 # Release notes
-=============
 
-Unversioned
---------------------------
- * Fixed a bug when running the examples from a non-cloned version of `EnergyModelsBase`.
- * This was achieved through a separate Project.toml in the examples.
- * Added functions `inputs`, `outputs`, and `data_nodes` for `Availability` and `outputs` for `Source` nodes.
- * Allow availability to not require all resources in the the `input` and `output` field.
- * Moved all files declaring structures to a separate folder for improved readability.
- * Reworked the structure of the test folder.
+## Unversioned
 
-Version 0.6.5 (2024-01-31)
---------------------------
- * Updated the restrictions on the fields of individual types to be consistent.
+### Examples
 
-Version 0.6.4 (2024-01-18)
---------------------------
- * Minor modification to the `EmissionsData` allowing now also time dependent process emissions. This is achieved through switching to a parametric type.
+* Fixed a bug when running the examples from a non-cloned version of `EnergyModelsBase`.
+* This is achieved through a separate Project.toml in the examples folder.
 
-Version 0.6.3 (2024-01-17)
---------------------------
- * Changed name of `constraints_level`  to `constraints_level_sp` when the time input is given as a `StrategicPeriod` to improve understandability.
- * Add `modeltype::EnergyModel` as an argument to the methods `constraints_level_sp` (see above) and `constraints_level_aux`.
+### Checks
 
-Version 0.6.2 (2024-01-17)
---------------------------
- * When variables are created with the method `variables_nodes`, it will lead to an `ErrorException` when the method tries to create a variable that has already been created. This is ok, and this error should be ignored. This change specifies exactly what error should be ignored, to avoid that other types of errors are also ignored.
+* Fixed the bug preventing the time profile checks to run.
+* Included checks of the input data and for all nodes.
+* Included tests for checks.
 
-Version 0.6.1 (2024-01-11)
---------------------------
- * Fix: add missing parenthesis in the objective function.
+### Minor updates
 
-Version 0.6.0 (2023-12-14)
---------------------------
- * Switched fields `Input` and `Output` of `Availability` nodes from `Dict{Resource, Real}` to `Array{<:Resource}`. The former is still available as a constructor, while a new constructor is introduced which requires the input only once.
- * All fields in composite types are now lower case.
- * Renamed `Network` to `NetworkNode`. `NetworkNode` can be considered to be replaced in a later iterations as it is not really needed.
- * Added functions for extracting the fields of `Node`s, `Resource`s, and `EnergyModel`s to allow for extensions.
- * Added export of functions that are frequently used in other packages.
- * Moved the emissions to a `Data` type on which we can dispatch, depending on the chosen approach for capture and process emissions.
- * Redesigned storage as parametric type to dispatch on the level balance. This includes as well the introduction of a new variable.
- * Included potential for different durations of operational periods.
- * Included representative periods. These do only affect a `Storage` node as these are the only time dependent nodes.
- * Added emission prices to `OperationalModel`.
+* Added functions `inputs`, `outputs`, and `data_nodes` for `Availability` and `outputs` for `Source` nodes.
+* Allow availability to not require all resources in the the `input` and `output` field.
+* Moved all files declaring structures to a separate folder for improved readability.
+* Reworked the structure of the test folder.
 
-Version 0.5.2 (2023-11-06)
---------------------------
- * Introduced method `create_model` that can take a `JuMP.Model` as input to simplify potential use of other type of models
- * Fixed the documentation to avoid errors
+## Version 0.6.5 (2024-01-31)
 
-Version 0.5.1 (2023-06-16)
---------------------------
- * Updated the documentation based on the new format
+* Updated the restrictions on the fields of individual types to be consistent.
 
-Version 0.5.0 (2023-06-01)
---------------------------
+## Version 0.6.4 (2024-01-18)
+
+* Minor modification to the `EmissionsData` allowing now also time dependent process emissions. This is achieved through switching to a parametric type.
+
+## Version 0.6.3 (2024-01-17)
+
+* Changed name of `constraints_level`  to `constraints_level_sp` when the time input is given as a `StrategicPeriod` to improve understandability.
+* Add `modeltype::EnergyModel` as an argument to the methods `constraints_level_sp` (see above) and `constraints_level_aux`.
+
+## Version 0.6.2 (2024-01-17)
+
+* When variables are created with the method `variables_nodes`, it will lead to an `ErrorException` when the method tries to create a variable that has already been created. This is ok, and this error should be ignored. This change specifies exactly what error should be ignored, to avoid that other types of errors are also ignored.
+
+## Version 0.6.1 (2024-01-11)
+
+* Fix: add missing parenthesis in the objective function.
+
+## Version 0.6.0 (2023-12-14)
+
+* Switched fields `Input` and `Output` of `Availability` nodes from `Dict{Resource, Real}` to `Array{<:Resource}`. The former is still available as a constructor, while a new constructor is introduced which requires the input only once.
+* All fields in composite types are now lower case.
+* Renamed `Network` to `NetworkNode`. `NetworkNode` can be considered to be replaced in a later iterations as it is not really needed.
+* Added functions for extracting the fields of `Node`s, `Resource`s, and `EnergyModel`s to allow for extensions.
+* Added export of functions that are frequently used in other packages.
+* Moved the emissions to a `Data` type on which we can dispatch, depending on the chosen approach for capture and process emissions.
+* Redesigned storage as parametric type to dispatch on the level balance. This includes as well the introduction of a new variable.
+* Included potential for different durations of operational periods.
+* Included representative periods. These do only affect a `Storage` node as these are the only time dependent nodes.
+* Added emission prices to `OperationalModel`.
+
+## Version 0.5.2 (2023-11-06)
+
+* Introduced method `create_model` that can take a `JuMP.Model` as input to simplify potential use of other type of models
+* Fixed the documentation to avoid errors
+
+## Version 0.5.1 (2023-06-16)
+
+* Updated the documentation based on the new format
+
+## Version 0.5.0 (2023-06-01)
+
 ### Switch to TimeStruct.jl
- * Switched the time structure representation to [TimeStruct.jl](https://sintefore.github.io/TimeStruct.jl/)
- * TimeStruct.jl is implemented with only the basis features that were available in TimesStructures.jl. This implies that neither operational nor strategic uncertainty is included in the model
 
-Version 0.4.0 (2023-05-30)
---------------------------
+* Switched the time structure representation to [TimeStruct.jl](https://sintefore.github.io/TimeStruct.jl/)
+* TimeStruct.jl is implemented with only the basis features that were available in TimesStructures.jl. This implies that neither operational nor strategic uncertainty is included in the model
+
+## Version 0.4.0 (2023-05-30)
+
 ### Additional input data changes
- * Changed the structure in which the extra field `Data` is included in the nodes
- * It is changed from `Dict{String, Data}` to `Array{Data}`
 
-Version 0.3.3 (2023-04-26)
---------------------------
- * Changed where storage variables are declared to avoid potential method ambiguity through new storage variables when using `EnergyModelsInvestments`
+* Changed the structure in which the extra field `Data` is included in the nodes
+* It is changed from `Dict{String, Data}` to `Array{Data}`
 
-Version 0.3.2 (2023-02-07)
---------------------------
- * Generalized the function names for identifying and sorting the individual introduced types.
+## Version 0.3.3 (2023-04-26)
 
-Version 0.3.1 (2023-02-03)
---------------------------
- * Take the examples out to the directory `examples`
+* Changed where storage variables are declared to avoid potential method ambiguity through new storage variables when using `EnergyModelsInvestments`
 
-Version 0.3.0 (2023-02-02)
---------------------------
+## Version 0.3.2 (2023-02-07)
+
+* Generalized the function names for identifying and sorting the individual introduced types.
+
+## Version 0.3.1 (2023-02-03)
+
+* Take the examples out to the directory `examples`
+
+## Version 0.3.0 (2023-02-02)
+
 ### Fields of reference types and new types
+
 * Removal of all process emissions and CO₂ capture from reference types to avoid having to include them as well
-in all subtypes defined later to keep the fallback option. This requires in the future to ***remove*** CO₂ as output when using CO₂ capture as it was previously the case. The original types are retained so that they can still be used
+in all subtypes defined later to keep the fallback option. This requires in the future to***remove*** CO₂ as output when using CO₂ capture as it was previously the case. The original types are retained so that they can still be used
 * Introduction of a type `RefStorageEmissions` to account for a storage unit that can be used for storing `ResourceEmit`
 
 ### Introduction of functions for constraints generation
+
 * Substitution of variable and fixed OPEX calculations as well as capacity and flow constraints through functions which utilize dispatching on `node` types
 
 ### Redefinition of introduction of global data
+
 * Removal of the type `AbstractGlobalData` and all subtypes and substitution through `EnergyModel` and the corresponding subtypes
 * Addition of the field `CO2_instance` in the type `OperationalModel`
 * Addition of `ModelType` to the function `create_node` to be able to use different ids for the CO₂ resource
 
 ### Additional changes
+
 * Redefining `CO2Int` in fields of type `Resource` to `CO2_int` to be consistent with the other types
 * Minor changes in constraint description that do not break previous code
 * Changed the input to the function `variables_node` to simplify the generation of variables for a specific `node` type
 
-Version 0.2.7 (2022-12-12)
---------------------------
+## Version 0.2.7 (2022-12-12)
+
 ### Internal release
+
 * Renamed packages to use common prefix
 * Updated README
 
-Version 0.2.4 (2022-09-07)
---------------------------
+## Version 0.2.4 (2022-09-07)
+
 ### Feature update and changes in export
+
 * Inclusion of time dependent profiles for surplus and deficit of sinks
 * Inclusion of parameter checks for surplus and deficit of sinks
 * Export of all reference nodes for easier identification of the nodes
 * Changes in the test structure with improved testing of variables
 * Changes in doc strings for individual functions/types
 
-Version 0.2.3 (2021-09-07)
---------------------------
+## Version 0.2.3 (2021-09-07)
+
 ### Changes in naming
+
 * Major changes in both variable and parameter naming, check the commit message for an overview
 
-Version 0.2.2 (2021-08-20)
---------------------------
+## Version 0.2.2 (2021-08-20)
+
 ### Feature updates
+
 * Change of Availability to abstract type and introduction of GenAvailability
   as composite type to be able to use multiple dispatch on the availability nodes
 * Inclusion of the entry fixed OPEX to the node composite types
@@ -129,24 +149,27 @@ Version 0.2.2 (2021-08-20)
   model data
 
 ### Changes in naming
+
 * Introduce the optimization variables stor_level and stor_max for storages, and
   use these instead of cap_usage and cap_max for the constraints on Storage.
 * Use the new variable cap_storage in Storage nodes for the installed storage capacity.
 
-Version 0.2.1 (2021-04-22)
---------------------------
+## Version 0.2.1 (2021-04-22)
+
 ### Feature updates
+
 * Reduction in variables through introduction of input/output (#2)
 dictionaries for all nodes that only include necessary components
 * Improvement related to emissions to avoid wrong accounting when other emission carriers than CO₂ are present (#2)
 * Link resources generated automatically from input (#2)
 
 ### Changes in naming
+
 * Removal of prefix "create" before "constraints" and "variables"
 * "create_module" switched to "create_node"
 
-Version 0.2.0 (2021-04-19)
---------------------------
+## Version 0.2.0 (2021-04-19)
+
 * Inclusion of abstract type and structures for both resources and (#1)
 differentiation in nodes
 * Development of new functions for the given data structures to obtain (#1)
@@ -161,6 +184,6 @@ next (#1)
 * Providing a test case that can be used for playing around with the simple
 system (#1)
 
-Version 0.1.0 (2021-03-19)
---------------------------
+## Version 0.1.0 (2021-03-19)
+
 * Initial (skeleton) version

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Version 0.6.6 (2024-03-XX)
+## Version 0.6.6 (2024-03-04)
 
 ### Examples
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsBase"
 uuid = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.6.5"
+version = "0.6.6"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/docs/src/how-to/create-new-node.md
+++ b/docs/src/how-to/create-new-node.md
@@ -20,6 +20,12 @@ While step 1 is always required, it is possible to omit step 2 if no new variabl
 It is also possible to create unregistered variables for each instance of the node.
 This is however only advised if you do not need to access the value of the variables after the optimization.
 
+!!! warning
+    When creating a new node type, you are free to change the field names to whatever name you desire. However, if you change the  field names, there are several things to consider:
+
+    1. Certain functions are used within the core structure of the code for accessing the fields. These functions can be found in the *[Public Interface](@ref functions_fields_node)*.
+    2. The function [`EMB.check_node`](@ref) conducts some checks on the individual node data. If the fields and structure from the reference nodes are not present, you also have to create a new function for your node.
+
 ## Additional tips for creating new nodes
 
 1. If the `NewNodeType` should be able to include investments, it is necessary to i) call the function [`constraints_capacity_installed`](@ref).

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -257,108 +257,191 @@ Check that the fields of a `Node` corresponds to required structure.
 """
 function check_node(n::Node, 𝒯, modeltype::EnergyModel)
 end
+"""
+    check_node(n::Availability, 𝒯, modeltype::EnergyModel)
+
+This method checks that an `Availability` node is valid. By default, that does not include
+any checks.
+"""
 function check_node(n::Availability, 𝒯, modeltype::EnergyModel)
 end
+"""
+    check_node(n::Source, 𝒯, modeltype::EnergyModel)
+
+This method checks that a `Source` node is valid.
+
+These checks are always performed, if the user is not creating a new method. Hence, it is
+important that a new `Source` type includes at least the same fields as in the `RefSource`
+node or that a new `Source` type receives a new method for `check_node`.
+
+## Checks
+ - The field `cap` is required to be non-negative.
+ - The values of the dictionary `output` are required to be non-negative.
+ - The value of the field `fixed_opex` is required to be non-negative.
+"""
 function check_node(n::Source, 𝒯, modeltype::EnergyModel)
 
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     @assert_or_log(
-        sum(capacity(n, t) >= 0 for t ∈ 𝒯) == length(𝒯),
+        sum(capacity(n, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
         "The capacity must be non-negative."
     )
     @assert_or_log(
-        sum(opex_fixed(n, t_inv) >= 0 for t_inv ∈ 𝒯ᴵⁿᵛ) == length(𝒯ᴵⁿᵛ),
+        sum(opex_fixed(n, t_inv) ≥ 0 for t_inv ∈ 𝒯ᴵⁿᵛ) == length(𝒯ᴵⁿᵛ),
         "The fixed OPEX must be non-negative."
     )
     @assert_or_log(
-        sum(outputs(n, p) >= 0 for p ∈ outputs(n)) == length(outputs(n)),
+        sum(outputs(n, p) ≥ 0 for p ∈ outputs(n)) == length(outputs(n)),
         "The values for the Dictionary `output` must be non-negative."
     )
 end
+"""
+    check_node(n::NetworkNode, 𝒯, modeltype::EnergyModel)
+
+This method checks that a `NetworkNode` node is valid.
+
+These checks are always performed, if the user is not creating a new method. Hence, it is
+important that a new `NetworkNode` type includes at least the same fields as in the
+`RefNetworkNode` node or that a new `NetworkNode` type receives a new method for `check_node`.
+
+## Checks
+ - The field `cap` is required to be non-negative.
+ - The values of the dictionary `input` are required to be non-negative.
+ - The values of the dictionary `output` are required to be non-negative.
+ - The value of the field `fixed_opex` is required to be non-negative.
+"""
 function check_node(n::NetworkNode, 𝒯, modeltype::EnergyModel)
 
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     @assert_or_log(
-        sum(capacity(n, t) >= 0 for t ∈ 𝒯) == length(𝒯),
+        sum(capacity(n, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
         "The capacity must be non-negative."
     )
     @assert_or_log(
-        sum(inputs(n, p) >= 0 for p ∈ inputs(n)) == length(inputs(n)),
+        sum(inputs(n, p) ≥ 0 for p ∈ inputs(n)) == length(inputs(n)),
         "The values for the Dictionary `input` must be non-negative."
     )
     @assert_or_log(
-        sum(outputs(n, p) >= 0 for p ∈ outputs(n)) == length(outputs(n)),
+        sum(outputs(n, p) ≥ 0 for p ∈ outputs(n)) == length(outputs(n)),
         "The values for the Dictionary `output` must be non-negative."
     )
     @assert_or_log(
-        sum(opex_fixed(n, t_inv) >= 0 for t_inv ∈ 𝒯ᴵⁿᵛ) == length(𝒯ᴵⁿᵛ),
+        sum(opex_fixed(n, t_inv) ≥ 0 for t_inv ∈ 𝒯ᴵⁿᵛ) == length(𝒯ᴵⁿᵛ),
         "The fixed OPEX must be non-negative."
     )
 end
+"""
+    check_node(n::Storage, 𝒯, modeltype::EnergyModel)
+
+This method checks that a `Storage` node is valid.
+
+These checks are always performed, if the user is not creating a new method. Hence, it is
+important that a new `Storage` type includes at least the same fields as in the
+`RefStorage` node or that a new `Storage` type receives a new method for `check_node`.
+
+## Checks
+ - The value of the field `rate_cap` is required to be non-negative.
+ - The value of the field `stor_cap` is required to be non-negative.
+ - The values of the dictionary `input` are required to be non-negative.
+ - The values of the dictionary `output` are required to be non-negative.
+ - The value of the field `fixed_opex` is required to be non-negative.
+"""
 function check_node(n::Storage, 𝒯, modeltype::EnergyModel)
 
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+    cap = capacity(n)
 
     @assert_or_log(
-        sum(capacity(n, t).rate >= 0 for t ∈ 𝒯) == length(𝒯),
+        sum(cap.rate[t] ≥ 0 for t ∈ 𝒯) == length(𝒯),
         "The rate capacity must be non-negative."
     )
     @assert_or_log(
-        sum(capacity(n, t).level >= 0 for t ∈ 𝒯) == length(𝒯),
+        sum(cap.level[t] ≥ 0 for t ∈ 𝒯) == length(𝒯),
         "The level capacity must be non-negative."
     )
     @assert_or_log(
-        sum(inputs(n, p) >= 0 for p ∈ inputs(n)) == length(inputs(n)),
+        sum(inputs(n, p) ≥ 0 for p ∈ inputs(n)) == length(inputs(n)),
         "The values for the Dictionary `input` must be non-negative."
     )
     @assert_or_log(
-        sum(outputs(n, p) >= 0 for p ∈ outputs(n)) == length(outputs(n)),
+        sum(outputs(n, p) ≥ 0 for p ∈ outputs(n)) == length(outputs(n)),
         "The values for the Dictionary `output` must be non-negative."
     )
     @assert_or_log(
-        sum(opex_fixed(n, t_inv) >= 0 for t_inv ∈ 𝒯ᴵⁿᵛ) == length(𝒯ᴵⁿᵛ),
+        sum(opex_fixed(n, t_inv) ≥ 0 for t_inv ∈ 𝒯ᴵⁿᵛ) == length(𝒯ᴵⁿᵛ),
         "The fixed OPEX must be non-negative."
     )
 end
+"""
+    check_node(n::Sink, 𝒯, modeltype::EnergyModel)
+
+This method checks that a `Sink` node is valid.
+
+These checks are always performed, if the user is not creating a new method. Hence, it is
+important that a new `Sink` type includes at least the same fields as in the `RefSink` node
+or that a new `Source` type receives a new method for `check_node`.
+
+## Checks
+ - The field `cap` is required to be non-negative.
+ - The values of the dictionary `input` are required to be non-negative.
+ - The dictionary `penalty` is required to have the keys `:deficit` and `:surplus`.
+ - The sum of the values `:deficit` and `:surplus` in the dictionary `penalty` has to be \
+ non-negative to avoid an infeasible model.
+"""
 function check_node(n::Sink, 𝒯, modeltype::EnergyModel)
     @assert_or_log(
-        sum(capacity(n, t) >= 0 for t ∈ 𝒯) == length(𝒯),
+        sum(capacity(n, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
         "The capacity must be non-negative."
     )
     @assert_or_log(
-        sum(inputs(n, p) >= 0 for p ∈ inputs(n)) == length(inputs(n)),
+        sum(inputs(n, p) ≥ 0 for p ∈ inputs(n)) == length(inputs(n)),
         "The values for the Dictionary `input` must be non-negative."
     )
     @assert_or_log(
         :surplus ∈ keys(n.penalty) && :deficit ∈ keys(n.penalty),
-        "The entries :surplus and :deficit are required in Sink.penalty"
+        "The entries :surplus and :deficit are required in the field `penalty`"
     )
 
     if :surplus ∈ keys(n.penalty) && :deficit ∈ keys(n.penalty)
         # The if-condition was checked above.
         @assert_or_log(
             sum(surplus_penalty(n, t) + deficit_penalty(n, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
-            "An inconsistent combination of :surplus and :deficit lead to a infeasible model."
+            "An inconsistent combination of `:surplus` and `:deficit` leads to an infeasible model."
         )
     end
 end
 
 
 """
-    check_node_data(n, 𝒯, modeltype::EnergyModel)
+    check_node_data(n::Node, data::Data, 𝒯, modeltype::EnergyModel)
 
 Check that the included `Data` types of a `Node` corresponds to required structure.
 This function will always result in a multiple error message, if several instances of the
 same supertype is loaded.
 """
 check_node_data(n::Node, data::Data, 𝒯, modeltype::EnergyModel) = nothing
+
+
+"""
+    check_node_data(n::Node, data::EmissionsData, 𝒯, modeltype::EnergyModel)
+
+Check that the included `Data` types of a `Node` corresponds to required structure.
+This function will always result in a multiple error message, if several instances of the
+same supertype is loaded.
+
+## Checks
+- Each node can only have a single `EmissionsData`.
+- Time profiles for process emissions, if present.
+- The value of the field `co2_capture` is required to be in the range ``[0, 1]``, if \
+[`CaptureData`](@ref) is used.
+"""
 function check_node_data(n::Node, data::EmissionsData, 𝒯, modeltype::EnergyModel)
 
     em_data = filter(data -> typeof(data) <: EmissionsData, node_data(n))
     @assert_or_log(
-        length(em_data) <= 1,
+        length(em_data) ≤ 1,
         "Only one `EmissionsData` can be added to each node."
     )
 
@@ -375,7 +458,7 @@ function check_node_data(n::Node, data::CaptureData, 𝒯, modeltype::EnergyMode
 
     em_data = filter(data -> typeof(data) <: EmissionsData, node_data(n))
     @assert_or_log(
-        length(em_data) <= 1,
+        length(em_data) ≤ 1,
         "Only one `EmissionsData` can be added to each node."
     )
 

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -153,7 +153,7 @@ function check_profile(fieldname, value::StrategicProfile, 𝒯::TwoLevel)
     end
     @assert_or_log len_vals == len_simp "Field '" * string(fieldname) * message
     for t_inv ∈ 𝒯ᴵⁿᵛ
-        check_profile(fieldname, value[t_inv], t_inv.operational, t_inv.sp)
+        check_profile(fieldname, value.vals[t_inv.sp], t_inv.operational, t_inv.sp)
     end
 end
 function check_profile(fieldname, value, 𝒯::TwoLevel)

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -3,7 +3,8 @@
 # if the test fails, without throwing an exception. When set to false, the
 # macro just acts as a normal @assert macro, and interrupts the program at
 # first failed test.
-ASSERTS_AS_LOG = true
+global ASSERTS_AS_LOG = true
+global TEST_ENV = false
 
 # Global vector used to gather the log messages.
 logs = []
@@ -46,11 +47,17 @@ function check_data(case, modeltype::EnergyModel)
     global logs = []
     log_by_element = Dict()
 
+    𝒯 = case[:T]
+
     for n ∈ case[:nodes]
+
         # Empty the logs list before each check.
         global logs = []
-        check_node(n, case[:T], modeltype)
-        check_time_structure(n, case[:T])
+        check_node(n, 𝒯, modeltype)
+        for data ∈ node_data(n)
+            check_node_data(n, data, 𝒯, modeltype)
+        end
+        check_time_structure(n, 𝒯)
         # Put all log messages that emerged during the check, in a dictionary with the node as key.
         log_by_element[n] = logs
     end
@@ -64,7 +71,6 @@ function check_data(case, modeltype::EnergyModel)
     end
 end
 
-
 """
     compile_logs(case, log_by_element)
 
@@ -75,10 +81,10 @@ function compile_logs(case, log_by_element)
 
     for (element, messages) ∈ log_by_element
         if length(messages) > 0
-            log_message *= string("\n### ", element, "\n")
+            log_message *= string("\n### ", element, "\n\n")
         end
         for l ∈ messages
-            log_message *= string(" * ", l, "\n")
+            log_message *= string("* ", l, "\n")
         end
     end
 
@@ -86,13 +92,16 @@ function compile_logs(case, log_by_element)
 
     some_error = sum(length(v) > 0 for (k, v) in log_by_element) > 0
     if some_error
-        # Write the messages to file only if there was an error.
-        io = open("consistency_log.md", "w")
-        println(io, log_message)
-        close(io)
+        # Only print and write the logs if not in a test environment
+        if !TEST_ENV
+            # Write the messages to file only if there was an error.
+            io = open("consistency_log.md", "w")
+            println(io, log_message)
+            close(io)
 
-        # Print the log to the console.
-        @error log_message
+            # Print the log to the console if test is not loaded
+            @error log_message
+        end
 
         # If there was at least one error in the checks, an exception is thrown.
         throw(AssertionError("Inconsistent case data."))
@@ -117,123 +126,270 @@ Check that all fields of a `Node` that are of type `TimeProfile` correspond to t
 """
 function check_time_structure(n::Node, 𝒯)
     for fieldname ∈ fieldnames(typeof(n))
-        if isa(getfield(n, fieldname), TimeProfile)
-            check_profile_field(n.id, fieldname, value, 𝒯)
+        value = getfield(n, fieldname)
+        if isa(value, TimeProfile)
+            check_profile(fieldname, value, 𝒯)
         end
     end
 end
 
 """
-    check_profile_field(fieldname, value::TimeProfile, 𝒯)
+    check_profile(fieldname, value::TimeProfile, 𝒯)
 
 Check that an individual `TimeProfile` corresponds to the time structure `𝒯`.
+It currently does not include support for identifying `OperationalProfile`s.
 """
-function check_profile_field(id, fieldname, value::StrategicProfile, 𝒯::TwoLevel)
+function check_profile(fieldname, value::StrategicProfile, 𝒯::TwoLevel)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-    @assert_or_log length(value.vals) == length(𝒯ᴵⁿᵛ) "Field '" * string(fieldname) * "' does not match the strategic structure."
+
+    len_vals = length(value.vals)
+    len_simp = length(𝒯ᴵⁿᵛ)
+    if len_vals > len_simp
+        message = "' is shorter than the strategic time structure. \
+        Its last values $(len_vals - len_simp) will be omitted."
+    elseif len_vals < len_simp
+        message = "' is shorter than the strategic time structure. It will use the last \
+        value for the last $(len_simp - len_vals) strategic periods."
+    end
+    @assert_or_log len_vals == len_simp "Field '" * string(fieldname) * message
     for t_inv ∈ 𝒯ᴵⁿᵛ
-        check_profile_field(id, fieldname, value.vals[t_inv.sp], t_inv.operational)
+        check_profile(fieldname, value[t_inv], t_inv.operational, t_inv.sp)
     end
 end
-function check_profile_field(id, fieldname, value, 𝒯::TwoLevel)
+function check_profile(fieldname, value, 𝒯::TwoLevel)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
     for t_inv ∈ 𝒯ᴵⁿᵛ
-        check_profile_field(id, fieldname, value, t_inv.operational, string(t_inv.sp))
+        check_profile(fieldname, value, t_inv.operational, t_inv.sp)
     end
 end
 
-function check_profile_field(id, fieldname, value, t_inv, sp)
-end
-function check_profile_field(
-    id,
+"""
+    check_profile(fieldname, value::TimeProfile, ts::TimeStructure, sp)
+
+Check that an individual `TimeProfile` corresponds to the time structure `ts` in strategic
+period sp. The function flow is designed to provide errors in all situations
+It currently does not include support for identifying `OperationalProfile`s.
+"""
+function check_profile(
     fieldname,
     value::OperationalProfile,
-    t_inv::SimpleTimes,
+    ts::SimpleTimes,
     sp
     )
     len_vals = length(value.vals)
-    len_simp = length(t_inv)
-    println(len_vals-len_simp)
-    @assert_or_log len_vals > len_simp "Field '" * string(id, fieldname) * "\
-        ' is longer than the operational time structure in strategic period \
-        " * sp * ". Its last values $(len_vals - len_simp) will be omitted."
-    @assert_or_log len_vals < len_simp "Field '" * string(id, fieldname) * "\
-        ' is shorter than the operational time structure in strategic period \
-        " * sp * ". I will use the last value for the last $(len_simp - len_vals) \
+    len_simp = length(ts)
+    if len_vals > len_simp
+        message = "' in strategic period $(sp)  is longer than the operational time  \
+        structure. Its last values $(len_vals - len_simp) will be omitted."
+    elseif len_vals < len_simp
+        message = "' in strategic period $(sp) is shorter than the operational \
+        time structure. It will use the last value for the last $(len_simp - len_vals) \
         operational periods."
+    end
+    @assert_or_log len_vals == len_simp "Field '" * string(fieldname) * message
 end
-function check_profile_field(
-    id,
+function check_profile(
     fieldname,
     value::OperationalProfile,
-    t_inv::RepresentativePeriods,
+    ts::RepresentativePeriods,
     sp
     )
-    if sp == "1"
-        @warn "Node " * id * ", field name " * fieldname * ":" "Using OperionalProfile with \
-            RepresentativePeriods is dangerous, as it may lead to unexpected behaviour. \
+    if sp == 1
+        @warn "Field " * string(fieldname) * ": Using `OperionalProfile` with \
+            `RepresentativePeriods` is dangerous, as it may lead to unexpected behaviour. \
             It only works reasonable if all representative periods have an operational \
             time structure of the same length. Otherwise, the last value is repeated. \
-            The system is tested for the first representative period."
+            The system is tested for the all representative periods."
     end
-    rp_1 = collect(repr_periods(t_inv))[1]
-    check_profile_field(id, fieldname, value, rp_1.operational, sp)
+    for t_rp ∈ repr_periods(ts)
+        check_profile(fieldname, value, t_rp.operational, sp)
+    end
 end
 
-function check_profile_field(
-    id,
+function check_profile(
     fieldname,
     value::RepresentativeProfile,
-    t_inv::SimpleTimes,
+    ts::SimpleTimes,
     sp
     )
-
-    if sp == "1"
-        @warn "Node " * id * ", field name " * fieldname * ":" "Using RepresentativeProfile \
-            with SimpleTimes is dangerous, as it may lead to unexpected behaviour. \
+    if sp == 1
+        @warn "Field " * string(fieldname) * ": Using `RepresentativeProfile` \
+            with `SimpleTimes` is dangerous, as it may lead to unexpected behaviour. \
             In this case, only the first profile is used and tested."
     end
-    check_profile_field(id, fieldname, value.vals[1], t_inv, sp)
+    check_profile(fieldname, value.vals[1], ts, sp)
 end
-function check_profile_field(
-    id,
+function check_profile(
     fieldname,
     value::RepresentativeProfile,
-    t_inv::RepresentativePeriods,
+    ts::RepresentativePeriods,
     sp
     )
-    for t_rp ∈ t_inv.rep_periods
-        check_profile_field(id, fieldname, value.vals[1], t_rp, sp)
+
+    len_vals = length(value.vals)
+    len_simp = length(repr_periods(ts))
+    if len_vals > len_simp
+        message = "' is longer than the representative time structure in strategic period \
+        $(sp). Its last values $(len_vals - len_simp) will be omitted."
+    elseif len_vals < len_simp
+        message = "' is shorter than the representative time structure in strategic period \
+        $(sp). It will use the last value for the last $(len_simp - len_vals) \
+        operational periods."
+    end
+    @assert_or_log len_vals == len_simp "Field '\
+    " * string(fieldname) * "' in strategic period $(sp) does not match \
+    the corresponding representative structure."
+    for t_rp ∈ repr_periods(ts)
+        check_profile(
+            fieldname,
+            value.vals[minimum([t_rp.rper, length(value.vals)])],
+            t_rp.operational,
+            sp,
+        )
     end
 end
+check_profile(fieldname, value, ts, sp) = nothing
 
 """
-    check_node(n, 𝒯, modeltype::EnergyModel)
+    check_node(n::Node, 𝒯, modeltype::EnergyModel)
 
 Check that the fields of a `Node` corresponds to required structure.
 """
 function check_node(n::Node, 𝒯, modeltype::EnergyModel)
 end
-
-function check_node(n::Source, 𝒯, modeltype::EnergyModel)
-    @assert_or_log sum(n.cap[t] >= 0 for t ∈ 𝒯) == length(𝒯) "The capacity must be non-negative."
+function check_node(n::Availability, 𝒯, modeltype::EnergyModel)
 end
+function check_node(n::Source, 𝒯, modeltype::EnergyModel)
 
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+
+    @assert_or_log(
+        sum(capacity(n, t) >= 0 for t ∈ 𝒯) == length(𝒯),
+        "The capacity must be non-negative."
+    )
+    @assert_or_log(
+        sum(opex_fixed(n, t_inv) >= 0 for t_inv ∈ 𝒯ᴵⁿᵛ) == length(𝒯ᴵⁿᵛ),
+        "The fixed OPEX must be non-negative."
+    )
+    @assert_or_log(
+        sum(outputs(n, p) >= 0 for p ∈ outputs(n)) == length(outputs(n)),
+        "The values for the Dictionary `output` must be non-negative."
+    )
+end
+function check_node(n::NetworkNode, 𝒯, modeltype::EnergyModel)
+
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+
+    @assert_or_log(
+        sum(capacity(n, t) >= 0 for t ∈ 𝒯) == length(𝒯),
+        "The capacity must be non-negative."
+    )
+    @assert_or_log(
+        sum(inputs(n, p) >= 0 for p ∈ inputs(n)) == length(inputs(n)),
+        "The values for the Dictionary `input` must be non-negative."
+    )
+    @assert_or_log(
+        sum(outputs(n, p) >= 0 for p ∈ outputs(n)) == length(outputs(n)),
+        "The values for the Dictionary `output` must be non-negative."
+    )
+    @assert_or_log(
+        sum(opex_fixed(n, t_inv) >= 0 for t_inv ∈ 𝒯ᴵⁿᵛ) == length(𝒯ᴵⁿᵛ),
+        "The fixed OPEX must be non-negative."
+    )
+end
+function check_node(n::Storage, 𝒯, modeltype::EnergyModel)
+
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+
+    @assert_or_log(
+        sum(capacity(n, t).rate >= 0 for t ∈ 𝒯) == length(𝒯),
+        "The rate capacity must be non-negative."
+    )
+    @assert_or_log(
+        sum(capacity(n, t).level >= 0 for t ∈ 𝒯) == length(𝒯),
+        "The level capacity must be non-negative."
+    )
+    @assert_or_log(
+        sum(inputs(n, p) >= 0 for p ∈ inputs(n)) == length(inputs(n)),
+        "The values for the Dictionary `input` must be non-negative."
+    )
+    @assert_or_log(
+        sum(outputs(n, p) >= 0 for p ∈ outputs(n)) == length(outputs(n)),
+        "The values for the Dictionary `output` must be non-negative."
+    )
+    @assert_or_log(
+        sum(opex_fixed(n, t_inv) >= 0 for t_inv ∈ 𝒯ᴵⁿᵛ) == length(𝒯ᴵⁿᵛ),
+        "The fixed OPEX must be non-negative."
+    )
+end
 function check_node(n::Sink, 𝒯, modeltype::EnergyModel)
-    @assert_or_log sum(n.cap[t] >= 0 for t ∈ 𝒯) == length(𝒯) "The capacity must be non-negative."
-
-    @assert_or_log :surplus ∈ keys(n.penalty) &&
-                   :deficit ∈ keys(n.penalty) "The entries :surplus and :deficit are required in Sink.penalty"
+    @assert_or_log(
+        sum(capacity(n, t) >= 0 for t ∈ 𝒯) == length(𝒯),
+        "The capacity must be non-negative."
+    )
+    @assert_or_log(
+        sum(inputs(n, p) >= 0 for p ∈ inputs(n)) == length(inputs(n)),
+        "The values for the Dictionary `input` must be non-negative."
+    )
+    @assert_or_log(
+        :surplus ∈ keys(n.penalty) && :deficit ∈ keys(n.penalty),
+        "The entries :surplus and :deficit are required in Sink.penalty"
+    )
 
     if :surplus ∈ keys(n.penalty) && :deficit ∈ keys(n.penalty)
         # The if-condition was checked above.
-        @assert_or_log sum(n.penalty[:surplus][t] + n.penalty[:deficit][t] ≥ 0 for t ∈ 𝒯) ==
-                    length(𝒯) "An inconsistent combination of :surplus and :deficit lead to infeasible model."
+        @assert_or_log(
+            sum(surplus_penalty(n, t) + deficit_penalty(n, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+            "An inconsistent combination of :surplus and :deficit lead to a infeasible model."
+        )
     end
-
 end
 
-# function check_node(n::RefNetworkNodeEmissions, 𝒯, modeltype::EnergyModel)
-#     @assert_or_log n.co2_capture ≤ 1 "The field CO2_capture must be less or equal to 1."
-#     @assert_or_log n.co2_capture ≥ 0 "The field CO2_capture must be non-negative."
-# end
+
+"""
+    check_node_data(n, 𝒯, modeltype::EnergyModel)
+
+Check that the included `Data` types of a `Node` corresponds to required structure.
+This function will always result in a multiple error message, if several instances of the
+same supertype is loaded.
+"""
+check_node_data(n::Node, data::Data, 𝒯, modeltype::EnergyModel) = nothing
+function check_node_data(n::Node, data::EmissionsData, 𝒯, modeltype::EnergyModel)
+
+    em_data = filter(data -> typeof(data) <: EmissionsData, node_data(n))
+    @assert_or_log(
+        length(em_data) <= 1,
+        "Only one `EmissionsData` can be added to each node."
+    )
+
+    # No checks necessary for a standard `EmissionsEnergy`
+    isa(data, EmissionsEnergy) && return
+
+    for p ∈ process_emissions(data)
+        value = process_emissions(data, p)
+        !isa(value, TimeProfile) && continue
+        check_profile(string(p)*" process emissions", value, 𝒯)
+    end
+end
+function check_node_data(n::Node, data::CaptureData, 𝒯, modeltype::EnergyModel)
+
+    em_data = filter(data -> typeof(data) <: EmissionsData, node_data(n))
+    @assert_or_log(
+        length(em_data) <= 1,
+        "Only one `EmissionsData` can be added to each node."
+    )
+
+    for p ∈ process_emissions(data)
+        value = process_emissions(data, p)
+        !isa(value, TimeProfile) && continue
+        check_profile(string(p)*" process emissions", value, 𝒯)
+    end
+    @assert_or_log(
+        co2_capture(data) ≤ 1,
+        "The field `co2_capture` in `CaptureData` must be less or equal to 1."
+    )
+    @assert_or_log(
+        co2_capture(data) ≥ 0,
+        "The field `co2_capture` in `CaptureData` must be non-negative."
+    )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,4 +15,5 @@ const TEST_ATOL = 1e-6
     include("test_modeltype.jl")
     include("test_examples.jl")
     include("test_utils.jl")
+    include("test_checks.jl")
 end

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -111,6 +111,13 @@ end
 
     day = SimpleTimes(24, 1)
 
+    # Test that there is an error with wrong strategic profiles
+    # - EMB.check_profile(fieldname, value::StrategicProfile, 𝒯::TwoLevel)
+    ts = TwoLevel(2, 1, day)
+    ops = OperationalProfile(ones(24))
+    tp = StrategicProfile([ops, ops, ops])
+    @test_throws AssertionError simple_graph(ts, tp)
+
     # Test that there is an error with wrong operational profiles
     # - EMB.check_profile(fieldname, value::OperationalProfile, ts::SimpleTimes, sp)
     ts = TwoLevel(2, 1, day)

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -1,0 +1,534 @@
+# Set the global to true to suppress the error message
+EMB.TEST_ENV = true
+
+@testset "Test checks - emission data" begin
+    # Resources used in the analysis
+    Power = ResourceCarrier("Power", 0.0)
+    CO2 = ResourceEmit("CO2", 1.0)
+
+    # Function for setting up the system
+    function simple_graph(em_data::Vector{<:EmissionsData})
+
+        resources = [Power, CO2]
+        ops = SimpleTimes(5, 2)
+        T = TwoLevel(2, 2, ops; op_per_strat=10)
+
+        source = RefSource(
+            "source_emit",
+            FixedProfile(4),
+            FixedProfile(0),
+            FixedProfile(10),
+            Dict(Power => 1),
+            em_data,
+        )
+        sink = RefSink(
+            "sink",
+            FixedProfile(3),
+            Dict(:surplus => FixedProfile(-4), :deficit => FixedProfile(4)),
+            Dict(Power => 1),
+        )
+
+        ops = SimpleTimes(5, 2)
+        T = TwoLevel(2, 2, ops; op_per_strat=10)
+
+        nodes = [source, sink]
+        links = [Direct(12, source, sink)]
+        model = OperationalModel(
+            Dict(CO2 => FixedProfile(100)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2
+        )
+        case = Dict(
+                    :T => T,
+                    :nodes => nodes,
+                    :links => links,
+                    :products => resources,
+        )
+        return run_model(case, model, HiGHS.Optimizer), case, model
+    end
+
+    # Test that only a single EmissionData is allowed
+    # - EMB.check_node_data(n::Node, data::EmissionsData, 𝒯, modeltype::EnergyModel)
+    em_data = [EmissionsProcess(Dict(CO2 => 10.0)), EmissionsEnergy()]
+    @test_throws AssertionError simple_graph(em_data)
+
+    # Test that the capture rate is bound by 0 and 1
+    # - EMB.check_node_data(n::Node, data::CaptureData, 𝒯, modeltype::EnergyModel)
+    em_data = [CaptureEnergyEmissions(1.2)]
+    @test_throws AssertionError simple_graph(em_data)
+
+    em_data = [CaptureEnergyEmissions(-1.2)]
+    @test_throws AssertionError simple_graph(em_data)
+
+end
+
+@testset "Test checks - timeprofiles" begin
+
+    # Resources used in the analysis
+    Power = ResourceCarrier("Power", 0.0)
+    CO2 = ResourceEmit("CO2", 1.0)
+
+    # Function for setting up the system
+    function simple_graph(T::TimeStructure, tp::TimeProfile)
+
+        resources = [Power, CO2]
+
+        source = RefSource(
+            "source_emit",
+            tp,
+            FixedProfile(0),
+            FixedProfile(10),
+            Dict(Power => 1),
+        )
+        sink = RefSink(
+            "sink",
+            FixedProfile(3),
+            Dict(:surplus => FixedProfile(-4), :deficit => FixedProfile(4)),
+            Dict(Power => 1),
+        )
+
+        modeltype = OperationalModel(
+            Dict(CO2 => FixedProfile(100)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2
+        )
+
+        nodes = [source, sink]
+        links = [Direct(12, source, sink)]
+        model = OperationalModel(
+            Dict(CO2 => FixedProfile(100)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2
+        )
+        case = Dict(
+                    :T => T,
+                    :nodes => nodes,
+                    :links => links,
+                    :products => resources,
+        )
+        return run_model(case, model, HiGHS.Optimizer), case, model
+    end
+
+    day = SimpleTimes(24, 1)
+
+    # Test that there is an error with wrong operational profiles
+    # - EMB.check_profile(fieldname, value::OperationalProfile, ts::SimpleTimes, sp)
+    ts = TwoLevel(2, 1, day)
+    tp = OperationalProfile(ones(20))
+    @test_throws AssertionError simple_graph(ts, tp)
+    tp = OperationalProfile(ones(30))
+    @test_throws AssertionError simple_graph(ts, tp)
+
+    # Test that there is warning when using OperationalProfile with RepresentativePeriods
+    # - EMB.check_profile(fieldname, value::RepresentativeProfile, ts::SimpleTimes, sp)
+    ts = TwoLevel(2, 1, RepresentativePeriods(3, 8760, ones(3)/3, [day, day, day]))
+    tp = OperationalProfile(ones(24))
+    msg = "Field cap: Using `OperionalProfile` with \
+    `RepresentativePeriods` is dangerous, as it may lead to unexpected behaviour. \
+    It only works reasonable if all representative periods have an operational \
+    time structure of the same length. Otherwise, the last value is repeated. \
+    The system is tested for the all representative periods."
+    @test_logs (:warn, msg) simple_graph(ts, tp)
+
+    # Test that there is warning when using RepresentativeProfile without RepresentativePeriods
+    # - EMB.check_profile(fieldname, value::RepresentativeProfile, ts::SimpleTimes, sp)
+    ts = TwoLevel(2, 1, day)
+    tp = RepresentativeProfile([FixedProfile(5), FixedProfile(10)])
+    msg = "Field cap: Using `RepresentativeProfile` with `SimpleTimes` is dangerous, as it \
+    may lead to unexpected behaviour. In this case, only the first profile is used and tested."
+    @test_logs (:warn, msg) simple_graph(ts, tp)
+
+    # Test that there is an error when `RepresentativeProfile` have a different length than
+    # the corresponding `RepresentativePeriods`
+    # - EMB.check_profile(fieldname, value::RepresentativeProfile, ts::SimpleTimes, sp)
+    ts = TwoLevel(2, 1, RepresentativePeriods(3, 8760, ones(3)/3, [day, day, day]))
+    @test_throws AssertionError simple_graph(ts, tp)
+end
+
+@testset "Test checks - Nodes" begin
+
+    # Resources used in the checks
+    NG = ResourceEmit("NG", 0.2)
+    Power = ResourceCarrier("Power", 0.0)
+    CO2 = ResourceEmit("CO2", 1.0)
+    aux = ResourceCarrier("aux", 0.0)
+
+    # Function for setting up the system for testing `Sink` and `Source`
+    function simple_graph(source::Source, sink::Sink)
+        resources = [Power, CO2]
+        ops = SimpleTimes(5, 2)
+        T = TwoLevel(2, 2, ops; op_per_strat=10)
+
+        nodes = [source, sink]
+        links = [Direct(12, source, sink)]
+        model = OperationalModel(
+            Dict(CO2 => FixedProfile(100)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2
+        )
+        case = Dict(
+                    :T => T,
+                    :nodes => nodes,
+                    :links => links,
+                    :products => resources,
+        )
+        return run_model(case, model, HiGHS.Optimizer), case, model
+    end
+
+    # Test that the fields of a Source are correctly checked
+    # - check_node(n::Source, 𝒯, modeltype::EnergyModel)
+    @testset "Checks Source" begin
+        # Sink used in the analysis
+        sink = RefSink(
+            "sink",
+            OperationalProfile([6, 8, 10, 6, 8]),
+            Dict(:surplus => FixedProfile(4), :deficit => FixedProfile(10)),
+            Dict(Power => 1),
+        )
+
+        # Test that a wrong capacity is caught by the checks.
+        source = RefSource(
+            "source",
+            FixedProfile(-4),
+            FixedProfile(10),
+            FixedProfile(0),
+            Dict(Power => 1),
+        )
+        @test_throws AssertionError simple_graph(source, sink)
+
+        # Test that a wrong output dictionary is caught by the checks.
+        source = RefSource(
+            "source",
+            FixedProfile(4),
+            FixedProfile(10),
+            FixedProfile(0),
+            Dict(Power => -1),
+        )
+        @test_throws AssertionError simple_graph(source, sink)
+
+        # Test that a wrong fixed OPEX is caught by the checks.
+        source = RefSource(
+            "source",
+            FixedProfile(4),
+            FixedProfile(10),
+            FixedProfile(-5),
+            Dict(Power => 1),
+        )
+        @test_throws AssertionError simple_graph(source, sink)
+
+        # Test that correct input solves the model to optimality.
+        source = RefSource(
+            "source",
+            FixedProfile(4),
+            FixedProfile(10),
+            FixedProfile(5),
+            Dict(Power => 1),
+        )
+        m , _, _ = simple_graph(source, sink)
+        @test termination_status(m) == MOI.OPTIMAL
+    end
+
+    # Test that the fields of a Sink are correctly checked
+    # - check_node(n::Sink, 𝒯, modeltype::EnergyModel)
+    @testset "Checks Sink" begin
+        # Source used in the analysis
+        source = RefSource(
+            "source",
+            FixedProfile(4),
+            FixedProfile(10),
+            FixedProfile(0),
+            Dict(Power => 1),
+        )
+
+        # Test that an inconsistent Sink.penalty dictionaries is caught by the checks.
+        sink = RefSink(
+            "sink",
+            FixedProfile(3),
+            Dict(:surplus => FixedProfile(4), :def => FixedProfile(2)),
+            Dict(Power => 1),
+        )
+        @test_throws AssertionError simple_graph(source, sink)
+
+        # The penalties in this Sink node lead to an infeasible optimum. Test that the
+        # checks forbids it.
+        sink = RefSink(
+            "sink",
+            FixedProfile(3),
+            Dict(:surplus => FixedProfile(-4), :deficit => FixedProfile(2)),
+            Dict(Power => 1),
+        )
+        @test_throws AssertionError simple_graph(source, sink)
+
+        # Check that a wrong capacity in a sink is caught by the checks.
+        sink = RefSink(
+            "sink",
+            OperationalProfile(-[6, 8, 10, 6, 8]),
+            Dict(:surplus => FixedProfile(4), :deficit => FixedProfile(10)),
+            Dict(Power => 1),
+        )
+        @test_throws AssertionError simple_graph(source, sink)
+
+        # Test that correct input solves the model to optimality.
+        sink = RefSink(
+            "sink",
+            OperationalProfile([6, 8, 10, 6, 8]),
+            Dict(:surplus => FixedProfile(4), :deficit => FixedProfile(10)),
+            Dict(Power => 1),
+        )
+        m , _, _ = simple_graph(source, sink)
+        @test termination_status(m) == MOI.OPTIMAL
+    end
+
+    # Function for setting up the system for testing a `NetworkNode`
+    function simple_graph(network::NetworkNode)
+
+        # Used source, network, and sink
+        source = RefSource(
+            "source",
+            FixedProfile(4),
+            FixedProfile(10),
+            FixedProfile(0),
+            Dict(NG => 1),
+        )
+
+        sink = RefSink(
+            "sink",
+            FixedProfile(3),
+            Dict(:surplus => FixedProfile(4), :deficit => FixedProfile(100)),
+            Dict(Power => 1),
+        )
+
+        resources = [NG, Power, CO2]
+        ops = SimpleTimes(5, 2)
+        T = TwoLevel(2, 2, ops; op_per_strat=10)
+
+        nodes = [source, network, sink]
+        links = [
+            Direct(12, source, network)
+            Direct(23, network, sink)
+            ]
+
+        model = OperationalModel(
+            Dict(CO2 => FixedProfile(100), NG => FixedProfile(100)),
+            Dict(CO2 => FixedProfile(0), NG => FixedProfile(0)),
+            CO2
+        )
+        case = Dict(
+                    :T => T,
+                    :nodes => nodes,
+                    :links => links,
+                    :products => resources,
+        )
+        return run_model(case, model, HiGHS.Optimizer), case, model
+    end
+
+    # Test that the fields of a NetworkNode are correctly checked
+    # - check_node(n::NetworkNode, 𝒯, modeltype::EnergyModel)
+    @testset "Test checks - NetworkNode" begin
+
+        # Test that a wrong capacity is caught by the checks.
+        network = RefNetworkNode(
+            "network",
+            FixedProfile(-25),
+            FixedProfile(5.5),
+            FixedProfile(0),
+            Dict(NG => 2),
+            Dict(Power => 1),
+        )
+        @test_throws AssertionError simple_graph(network)
+
+        # Test that a wrong fixed OPEX is caught by the checks.
+        network = RefNetworkNode(
+            "network",
+            FixedProfile(25),
+            FixedProfile(5.5),
+            FixedProfile(-100),
+            Dict(NG => 2),
+            Dict(Power => 1),
+        )
+        @test_throws AssertionError simple_graph(network)
+
+        # Test that a wrong input dictionary is caught by the checks.
+        network = RefNetworkNode(
+            "network",
+            FixedProfile(25),
+            FixedProfile(5.5),
+            FixedProfile(0),
+            Dict(NG => -2),
+            Dict(Power => 1),
+        )
+        @test_throws AssertionError simple_graph(network)
+
+        # Test that a wrong output dictionary is caught by the checks.
+        network = RefNetworkNode(
+            "network",
+            FixedProfile(25),
+            FixedProfile(5.5),
+            FixedProfile(0),
+            Dict(NG => 2),
+            Dict(Power => -1),
+        )
+        @test_throws AssertionError simple_graph(network)
+
+        # Test that correct input solves the model to optimality.
+        network = RefNetworkNode(
+            "network",
+            FixedProfile(25),
+            FixedProfile(5.5),
+            FixedProfile(0),
+            Dict(NG => 2),
+            Dict(Power => 1),
+        )
+        m , _, _ = simple_graph(network)
+        @test termination_status(m) == MOI.OPTIMAL
+    end
+
+
+    # Function for setting up the system for testing a `Storage` node
+    function simple_graph(storage::Storage)
+
+        # Used source, network, and sink
+        source = RefSource(
+            "source",
+            FixedProfile(10),
+            FixedProfile(10),
+            FixedProfile(0),
+            Dict(Power => 1),
+        )
+        aux_source = RefSource(
+            "aux",
+            FixedProfile(10),
+            FixedProfile(10),
+            FixedProfile(0),
+            Dict(aux => 1),
+        )
+
+        sink = RefSink(
+            "sink",
+            FixedProfile(10),
+            Dict(:surplus => FixedProfile(4), :deficit => FixedProfile(1000)),
+            Dict(Power => 1),
+        )
+
+        T = TwoLevel(2, 2, SimpleTimes(5, 2); op_per_strat=10)
+
+        nodes = [source, aux_source, storage, sink]
+        links = [
+            Direct(13, source, storage)
+            Direct(23, aux_source, storage)
+            Direct(34, storage, sink)
+            ]
+        resources = [Power, aux, CO2]
+
+        model = OperationalModel(
+            Dict(CO2 => FixedProfile(100)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2
+        )
+        case = Dict(
+                    :T => T,
+                    :nodes => nodes,
+                    :links => links,
+                    :products => resources,
+        )
+        return run_model(case, model, HiGHS.Optimizer), case, model
+    end
+
+    # Test that the fields of a Storage are correctly checked
+    # - check_node(n::Storage, 𝒯, modeltype::EnergyModel)
+    @testset "Test checks - Storage" begin
+
+        # Test that a wrong capacities are caught by the checks.
+        storage = RefStorage(
+            "storage",
+            FixedProfile(-10),
+            FixedProfile(1e8),
+            FixedProfile(10),
+            FixedProfile(2),
+            Power,
+            Dict(Power => 1, aux => 0.05),
+            Dict(Power => 1),
+        )
+        @test_throws AssertionError simple_graph(storage)
+        storage = RefStorage(
+            "storage",
+            FixedProfile(10),
+            FixedProfile(-1e8),
+            FixedProfile(10),
+            FixedProfile(2),
+            Power,
+            Dict(Power => 1, aux => 0.05),
+            Dict(Power => 1),
+        )
+        @test_throws AssertionError simple_graph(storage)
+
+
+        # Test that a wrong fixed OPEX is caught by the checks.
+        storage = RefStorage(
+            "storage",
+            FixedProfile(10),
+            FixedProfile(1e8),
+            FixedProfile(10),
+            FixedProfile(-2),
+            Power,
+            Dict(Power => 1, aux => 0.05),
+            Dict(Power => 1),
+        )
+        @test_throws AssertionError simple_graph(storage)
+
+
+        # Test that a wrong input dictionary is caught by the checks.
+        storage = RefStorage(
+            "storage",
+            FixedProfile(10),
+            FixedProfile(1e8),
+            FixedProfile(10),
+            FixedProfile(2),
+            Power,
+            Dict(Power => -1, aux => 0.05),
+            Dict(Power => 1),
+        )
+        @test_throws AssertionError simple_graph(storage)
+        storage = RefStorage(
+            "storage",
+            FixedProfile(10),
+            FixedProfile(1e8),
+            FixedProfile(10),
+            FixedProfile(2),
+            Power,
+            Dict(Power => 1, aux => -0.05),
+            Dict(Power => 1),
+        )
+        @test_throws AssertionError simple_graph(storage)
+
+        # Test that a wrong output dictionary is caught by the checks.
+        storage = RefStorage(
+            "storage",
+            FixedProfile(10),
+            FixedProfile(1e8),
+            FixedProfile(10),
+            FixedProfile(2),
+            Power,
+            Dict(Power => 1, aux => 0.05),
+            Dict(Power => -1),
+        )
+        @test_throws AssertionError simple_graph(storage)
+
+        # Test that correct input solves the model to optimality.
+        storage = RefStorage(
+            "storage",
+            FixedProfile(10),
+            FixedProfile(1e8),
+            FixedProfile(10),
+            FixedProfile(2),
+            Power,
+            Dict(Power => 1, aux => 0.05),
+            Dict(Power => 1),
+        )
+        m , _, _ = simple_graph(storage)
+        @test termination_status(m) == MOI.OPTIMAL
+    end
+end
+
+# Set the global again to false
+EMB.TEST_ENV = false

--- a/test/test_nodes.jl
+++ b/test/test_nodes.jl
@@ -10,7 +10,8 @@
 
         resources = [Power, CO2]
         ops = SimpleTimes(5, 2)
-        T = TwoLevel(2, 2, ops; op_per_strat=duration(ops))
+        op_per_strat = duration(ops)
+        T = TwoLevel(2, 2, ops; op_per_strat)
 
         nodes = [source, sink]
         links = [Direct(12, source, sink)]
@@ -28,48 +29,7 @@
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
-    @testset "Checks :surplus/:deficit" begin
-        # Source used in the analysis
-        source = RefSource(
-            "source",
-            FixedProfile(4),
-            FixedProfile(10),
-            FixedProfile(0),
-            Dict(Power => 1),
-        )
-
-        # Test that an inconsistent Sink.Penalty dict is caught by the checks.
-        sink = RefSink(
-            "sink",
-            FixedProfile(3),
-            Dict(:surplus => FixedProfile(4), :def => FixedProfile(2)),
-            Dict(Power => 1),
-        )
-        @test_throws AssertionError simple_graph(source, sink)
-
-        # The penalties in this Sink node lead to an infeasible optimum. Test that the
-        # checks forbids it.
-        sink = RefSink(
-            "sink",
-            FixedProfile(3),
-            Dict(:surplus => FixedProfile(-4), :deficit => FixedProfile(2)),
-            Dict(Power => 1),
-        )
-        @test_throws AssertionError simple_graph(source, sink)
-
-        # The penalties in this Sink node are valid, and should lead to an optimal solution.
-        sink = RefSink(
-            "sink",
-            FixedProfile(3),
-            Dict(:surplus => FixedProfile(-4), :deficit => FixedProfile(4)),
-            Dict(Power => 1),
-        )
-        m, case, model = simple_graph(source, sink)
-        @test termination_status(m) == MOI.OPTIMAL
-    end
-
-    @testset "General tests - RefSink" begin
-
+    @testset "General tests - RefSource" begin
 
         source = RefSource(
             "source",
@@ -315,7 +275,8 @@ end
 
         resources = [NG, Power, CO2]
         ops = SimpleTimes(5, 2)
-        T = TwoLevel(2, 2, ops; op_per_strat=duration(ops))
+        op_per_strat = duration(ops)
+        T = TwoLevel(2, 2, ops; op_per_strat)
 
         nodes = [source, network, sink]
         links = [
@@ -671,7 +632,8 @@ end
             Dict(Power => 1),
         )
 
-        T = TwoLevel(2, 2, ops; op_per_strat=duration(ops))
+        op_per_strat = duration(ops)
+        T = TwoLevel(2, 2, ops; op_per_strat)
 
         nodes = [source, aux_source, storage, sink]
         links = [
@@ -836,7 +798,7 @@ end
 
         # Run the model and extract the data
         op_profile_1 = FixedProfile(0)
-        op_profile_2 = OperationalProfile([20, 20, 20, 20, 20])
+        op_profile_2 = FixedProfile(20)
         demand = RepresentativeProfile([op_profile_1, op_profile_2])
 
         op_1 = SimpleTimes(100, 2)
@@ -969,7 +931,8 @@ end
             Dict(Power => 1),
         )
 
-        T = TwoLevel(2, 2, ops; op_per_strat=duration(ops))
+        op_per_strat = duration(ops)
+        T = TwoLevel(2, 2, ops; op_per_strat)
 
         nodes = [source, network, storage, sink]
         links = [

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,11 +1,11 @@
-@testset "" begin
+@testset "Variable creation" begin
     m = JuMP.Model()
 
     function create_variable(range)
         @variable(m, same_name[range] ≥ 0)
     end
 
-    # Create a varaible named `same_name`, creating it once should be ok, but twice is not
+    # Create a variable named `same_name`, creating it once should be ok, but twice is not
     # allowed in jump, regardless of the indices.
     create_variable(1:4)
     try


### PR DESCRIPTION
The checks were not properly working so far. Specifically, the following problems occurred:

1. we did not have checks on the `data` field, specifically for the type `EmissionData`,
2. we did not check the majority of the nodes,
3. the time profile checks were not working and resorted to the blank default,
4. we did not have tests which could be used for identifying the errors.

This PR should solve all of the above problems. The change in the tests for the field `data` allows in addition for changes in the tests from `EnergyModelsInvestments`.

Minor additional change:

- I updated the NEWS.md to follow the style from [markdownlint](https://github.com/DavidAnson/markdownlint/tree/v0.33.0), I was to annoyed by the constant warnings.