### PR TITLE
Added conditional argument to remove TimeProfile checks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Version 0.6.7 (2024-03-14)
+## Version 0.6.7 (2024-03-21)
 
 * Allow for deactivation of timeprofile checks while printing a warning in this case.
 * Fixed a bug for a too short `StrategicProfile` in the checks.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Version 0.6.7 (2024-03-07)
+## Version 0.6.7 (2024-03-11)
 
 * Allow for deactivation of timeprofile checks while printing a warning in this case.
 * Fixed a bug for a too short `StrategicProfile` in the checks.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## Version 0.6.7 (2024-03-07)
+
+* Allow for deactivation of timeprofile checks while printing a warning in this case.
+* Fixed a bug for a too short `StrategicProfile` in the checks.
+
 ## Version 0.6.6 (2024-03-04)
 
 ### Examples

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,12 @@
 # Release notes
 
-## Version 0.6.7 (2024-03-11)
+## Version 0.6.7 (2024-03-14)
 
 * Allow for deactivation of timeprofile checks while printing a warning in this case.
 * Fixed a bug for a too short `StrategicProfile` in the checks.
+* Added checks for the case dictionary.
+* Extended checks for the modeltype
+* Added functions that can be used to check whether a `TimeProfile` can be indexed over `StrategicPeriod`s, `RepresentativePeriod`s, or `OperationalScenario`s.
 
 ## Version 0.6.6 (2024-03-04)
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsBase"
 uuid = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.6.6"
+version = "0.6.7"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -372,17 +372,17 @@ end
 check_profile(fieldname, value, ts, sp) = nothing
 
 """
-    check_strategic_profile(time_profile, message)
+    check_strategic_profile(time_profile::TimeProfile, message::String)
 
-Function for checking that and individual `TimeProfile` does not include the wrong type for
+Function for checking that an individual `TimeProfile` does not include the wrong type for
 strategic indexing
 
 ## Checks
 - `TimeProfile`s access in `StrategicPeriod`s cannot include `OperationalProfile`, \
-`RepresentativeProfile`, or `ScenarioProfile` as this is not allowed through indexing \
+`ScenarioProfile`, or `RepresentativeProfile` as this is not allowed through indexing \
 on the `TimeProfile`.
 """
-function check_strategic_profile(time_profile, message)
+function check_strategic_profile(time_profile::TimeProfile, message::String)
 
     @assert_or_log(
         !isa(time_profile, OperationalProfile),
@@ -408,6 +408,66 @@ function check_strategic_profile(time_profile, message)
         @assert_or_log(
             !isa(time_profile.vals, Vector{<:RepresentativeProfile}),
             "Representative profiles in strategic profiles " * message
+        )
+    end
+end
+
+"""
+    check_representative_profile(time_profile::TimeProfile, message::String)
+
+Function for checking that an individual `TimeProfile` does not include the wrong type for
+representative periods indexing
+
+## Input
+- `time_profile` - The time profile that should be checked.
+- `message` - A message that should be printed after the type of profile.
+
+## Checks
+- `TimeProfile`s access in `RepresentativePeriod`s cannot include `OperationalProfile` \
+or `ScenarioProfile` as this is not allowed through indexing on the `TimeProfile`.
+"""
+function check_representative_profile(time_profile::TimeProfile, message::String)
+
+    @assert_or_log(
+        !isa(time_profile, OperationalProfile),
+        "Operational profiles " * message
+    )
+    @assert_or_log(
+        !isa(time_profile, ScenarioProfile),
+        "Scenario profiles " * message
+    )
+    if isa(time_profile, StrategicProfile)
+        @assert_or_log(
+            !isa(time_profile.vals, Vector{<:OperationalProfile}),
+            "Operational profiles in strategic profiles " * message
+        )
+        @assert_or_log(
+            !isa(time_profile.vals, Vector{<:ScenarioProfile}),
+            "Scenario profiles in strategic profiles " * message
+        )
+    end
+end
+
+"""
+    check_scenario_profile(time_profile::TimeProfile, message::String)
+
+Function for checking that an individual `TimeProfile` does not include the wrong type for
+scenario indexing
+
+## Checks
+- `TimeProfile`s access in `RepresentativePeriod`s cannot include `OperationalProfile` \
+or `ScenarioProfile` as this is not allowed through indexing on the `TimeProfile`.
+"""
+function check_scenario_profile(time_profile::TimeProfile, message::String)
+
+    @assert_or_log(
+        !isa(time_profile, OperationalProfile),
+        "Operational profiles " * message
+    )
+    if isa(time_profile, StrategicProfile)
+        @assert_or_log(
+            !isa(time_profile.vals, Vector{<:OperationalProfile}),
+            "Operational profiles in strategic profiles " * message
         )
     end
 end

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -50,11 +50,11 @@ function check_data(case, modeltype::EnergyModel, check_timeprofiles::Bool)
 
     if !check_timeprofiles
         @warn "Checking of the time profiles is deactivated:\n" *
-        "Deactivating the checks for the time profiles is strongly discouraged.\n" *
-        "While the model will still run, unexpected results can occur, as well as\n" *
+        "Deactivating the checks for the time profiles is strongly discouraged. " *
+        "While the model will still run, unexpected results can occur, as well as " *
         "inconsistent case data.\n\n" *
-        "Deactivating the checks for the timeprofiles should only be considered,\n" *
-        "when testing new components. In all other instances, it is recommended to\n" *
+        "Deactivating the checks for the timeprofiles should only be considered, " *
+        "when testing new components. In all other instances, it is recommended to " *
         "provide the correct timeprofiles using a preprocessing routine.\n\n" *
         "If timeprofiles are not checked, inconsistencies can occur."  maxlog=1
     end

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -55,8 +55,8 @@ function check_data(case, modeltype::EnergyModel, check_timeprofiles::Bool)
         "inconsistent case data.\n\n" *
         "Deactivating the checks for the timeprofiles should only be considered,\n" *
         "when testing new components. In all other instances, it is recommended to\n" *
-        "provide the correct timeprofiles using a preprocessing routine. \n\n" *
-        "If timeprofiles are not checked, inconsistencies can occur."
+        "provide the correct timeprofiles using a preprocessing routine.\n\n" *
+        "If timeprofiles are not checked, inconsistencies can occur."  maxlog=1
     end
 
     # Check the case data. If the case data is not in the correct format, the overall check

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -527,8 +527,9 @@ node or that a new `Source` type receives a new method for `check_node`.
 ## Checks
  - The field `cap` is required to be non-negative.
  - The values of the dictionary `output` are required to be non-negative.
- - The value of the field `fixed_opex` is required to be follow a given structure as
-   outlined in the function `check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)`.
+ - The value of the field `fixed_opex` is required to be non-negative and
+   accessible through a `StrategicPeriod` as outlined in the function
+   `check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)`.
 """
 function check_node(n::Source, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
@@ -557,8 +558,9 @@ important that a new `NetworkNode` type includes at least the same fields as in 
  - The field `cap` is required to be non-negative.
  - The values of the dictionary `input` are required to be non-negative.
  - The values of the dictionary `output` are required to be non-negative.
- - The value of the field `fixed_opex` is required to be follow a given structure as
-   outlined in the function `check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)`.
+ - The value of the field `fixed_opex` is required to be non-negative and
+   accessible through a `StrategicPeriod` as outlined in the function
+   `check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)`.
 """
 function check_node(n::NetworkNode, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
@@ -592,8 +594,9 @@ important that a new `Storage` type includes at least the same fields as in the
  - The value of the field `stor_cap` is required to be non-negative.
  - The values of the dictionary `input` are required to be non-negative.
  - The values of the dictionary `output` are required to be non-negative.
- - The value of the field `fixed_opex` is required to be follow a given structure as
-   outlined in the function `check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)`.
+ - The value of the field `fixed_opex` is required to be non-negative and
+   accessible through a `StrategicPeriod` as outlined in the function
+   `check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)`.
 """
 function check_node(n::Storage, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -48,7 +48,7 @@ function create_model(case, modeltype::EnergyModel, m::JuMP.Model; check_timepro
 end
 function create_model(case, modeltype::EnergyModel; check_timeprofiles::Bool=true)
     m = JuMP.Model()
-    create_model(case, modeltype::EnergyModel, m; check_timeprofiles)
+    create_model(case, modeltype, m; check_timeprofiles)
 end
 
 """

--- a/src/model.jl
+++ b/src/model.jl
@@ -4,7 +4,7 @@
 Create the model and call all required functions based on provided `modeltype`
 and case data.
 """
-function create_model(case, modeltype::EnergyModel, m::JuMP.Model)
+function create_model(case, modeltype::EnergyModel, m::JuMP.Model; check_timeprofiles=true)
     @debug "Construct model"
 
     # WIP Data structure
@@ -14,7 +14,7 @@ function create_model(case, modeltype::EnergyModel, m::JuMP.Model)
     𝒫 = case[:products]
 
     # Check if the case data is consistent before the model is created.
-    check_data(case, modeltype)
+    check_data(case, modeltype, check_timeprofiles)
 
     # Declaration of variables for the problem
     variables_flow(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype)
@@ -34,9 +34,9 @@ function create_model(case, modeltype::EnergyModel, m::JuMP.Model)
 
     return m
 end
-function create_model(case, modeltype::EnergyModel)
+function create_model(case, modeltype::EnergyModel; check_timeprofiles=true)
     m = JuMP.Model()
-    create_model(case, modeltype::EnergyModel, m)
+    create_model(case, modeltype::EnergyModel, m; check_timeprofiles)
 end
 
 """

--- a/src/model.jl
+++ b/src/model.jl
@@ -7,7 +7,7 @@ Create the model and call all required functions.
 - `case` - The case dictionary requiring the keys `:T`, `:nodes`, `:links`, and `products`.
   If the input is not provided in the correct form, the checks will identify the problem.
 - `modeltype` - Used modeltype, that is a subtype of the type `EnergyModel`.
-- `m` - the empthy `JuMP.Model` instance. If it is not provided, then it is assumed that the
+- `m` - the empty `JuMP.Model` instance. If it is not provided, then it is assumed that the
   input is a standard `JuMP.Model`.
 
 ## Conditional input

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,20 +1,32 @@
 """
-    create_model(case, modeltype::EnergyModel)
+    create_model(case, modeltype::EnergyModel, m::JuMP.Model; check_timeprofiles::Bool=true)
 
-Create the model and call all required functions based on provided `modeltype`
-and case data.
+Create the model and call all required functions.
+
+## Input
+- `case` - The case dictionary requiring the keys `:T`, `:nodes`, `:links`, and `products`.
+  If the input is not provided in the correct form, the checks will identify the problem.
+- `modeltype` - Used modeltype, that is a subtype of the type `EnergyModel`.
+- `m` - the empthy `JuMP.Model` instance. If it is not provided, then it is assumed that the
+  input is a standard `JuMP.Model`.
+
+## Conditional input
+- `check_timeprofiles=true` - A boolean indicator whether the time profiles of the individual
+  nodes should be checked or not. It is advised to not deactivate the check, except if you
+  are testing new components. It may lead to unexpected behaviour and potential
+  inconsistencies in the input data, if the time profiles are not checked.
 """
-function create_model(case, modeltype::EnergyModel, m::JuMP.Model; check_timeprofiles=true)
+function create_model(case, modeltype::EnergyModel, m::JuMP.Model; check_timeprofiles::Bool=true)
     @debug "Construct model"
+
+    # Check if the case data is consistent before the model is created.
+    check_data(case, modeltype, check_timeprofiles)
 
     # WIP Data structure
     𝒯 = case[:T]
     𝒩 = case[:nodes]
     ℒ = case[:links]
     𝒫 = case[:products]
-
-    # Check if the case data is consistent before the model is created.
-    check_data(case, modeltype, check_timeprofiles)
 
     # Declaration of variables for the problem
     variables_flow(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype)
@@ -34,7 +46,7 @@ function create_model(case, modeltype::EnergyModel, m::JuMP.Model; check_timepro
 
     return m
 end
-function create_model(case, modeltype::EnergyModel; check_timeprofiles=true)
+function create_model(case, modeltype::EnergyModel; check_timeprofiles::Bool=true)
     m = JuMP.Model()
     create_model(case, modeltype::EnergyModel, m; check_timeprofiles)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,10 +10,10 @@ The dictionary requires the keys:
  - `:products::Vector{Resource}`
  - `:T::TimeStructure`
 """
-function run_model(case::Dict, model::EnergyModel, optimizer)
+function run_model(case::Dict, model::EnergyModel, optimizer; check_timeprofiles=true)
    @debug "Run model" optimizer
 
-    m = create_model(case, model)
+    m = create_model(case, model; check_timeprofiles)
 
     if !isnothing(optimizer)
         set_optimizer(m, optimizer)

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -52,7 +52,6 @@ EMB.TEST_ENV = true
     for key ∈ keys(case)
         case_test = deepcopy(case)
         pop!(case_test, key)
-        println(case_test)
         @test_throws AssertionError run_model(case_test, model, HiGHS.Optimizer)
     end
 

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -239,7 +239,7 @@ end
     em_data = [CaptureEnergyEmissions(-1.2)]
     @test_throws AssertionError run_simple_graph(em_data)
 
-    # Test that the timeprofile check is working
+    # Test that the timeprofile check is working and only showing the warning once
     # - EMB.check_node_data(n::Node, data::EmissionsData, 𝒯, modeltype::EnergyModel
     em_data = [EmissionsProcess(Dict(CO2 => StrategicProfile([1])))]
     @test_throws AssertionError run_simple_graph(em_data)
@@ -253,6 +253,8 @@ end
     "provide the correct timeprofiles using a preprocessing routine. \n\n" *
     "If timeprofiles are not checked, inconsistencies can occur."
     @test_logs (:warn, msg) create_model(case, model; check_timeprofiles=false)
+    @test_logs (:warn, msg) for k ∈ [1,2] create_model(case, model; check_timeprofiles=false) end
+
 end
 
 @testset "Test checks - timeprofiles" begin

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -245,12 +245,12 @@ end
     @test_throws AssertionError run_simple_graph(em_data)
     case, model = simple_graph(em_data)
     msg = "Checking of the time profiles is deactivated:\n" *
-    "Deactivating the checks for the time profiles is strongly discouraged.\n" *
-    "While the model will still run, unexpected results can occur, as well as\n" *
+    "Deactivating the checks for the time profiles is strongly discouraged. " *
+    "While the model will still run, unexpected results can occur, as well as " *
     "inconsistent case data.\n\n" *
-    "Deactivating the checks for the timeprofiles should only be considered,\n" *
-    "when testing new components. In all other instances, it is recommended to\n" *
-    "provide the correct timeprofiles using a preprocessing routine. \n\n" *
+    "Deactivating the checks for the timeprofiles should only be considered, " *
+    "when testing new components. In all other instances, it is recommended to " *
+    "provide the correct timeprofiles using a preprocessing routine.\n\n" *
     "If timeprofiles are not checked, inconsistencies can occur."
     @test_logs (:warn, msg) create_model(case, model; check_timeprofiles=false)
     @test_logs (:warn, msg) for k ∈ [1,2] create_model(case, model; check_timeprofiles=false) end
@@ -355,12 +355,12 @@ end
     # Check that turning of the timeprofile checks leads to a warning
     case, model = simple_graph(ts, tp)
     msg = "Checking of the time profiles is deactivated:\n" *
-    "Deactivating the checks for the time profiles is strongly discouraged.\n" *
-    "While the model will still run, unexpected results can occur, as well as\n" *
+    "Deactivating the checks for the time profiles is strongly discouraged. " *
+    "While the model will still run, unexpected results can occur, as well as " *
     "inconsistent case data.\n\n" *
-    "Deactivating the checks for the timeprofiles should only be considered,\n" *
-    "when testing new components. In all other instances, it is recommended to\n" *
-    "provide the correct timeprofiles using a preprocessing routine. \n\n" *
+    "Deactivating the checks for the timeprofiles should only be considered, " *
+    "when testing new components. In all other instances, it is recommended to " *
+    "provide the correct timeprofiles using a preprocessing routine.\n\n" *
     "If timeprofiles are not checked, inconsistencies can occur."
     @test_logs (:warn, msg) create_model(case, model; check_timeprofiles=false)
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -63,7 +63,6 @@ end
     end
 
     function test_type_order(sorted_node_types)
-        @info sorted_node_types
         indexes = Dict(sorted_node_types .=> keys(sorted_node_types))
 
         @test indexes[EMB.Node] == 1


### PR DESCRIPTION
The check on the `TimeProfile` can be annoying in certain cases, specifically when testing a new Node. It is now possible *via* a conditional argument `check_timeprofiles=true` in the `create_model` and `run_model` functions.

Setting the value to `false` will result in a warning, but allow to utilize wrong time structures.

In addition, a bug was fixed when the `StrategicProfile` was shorter than the used `TimeStructure`. In this case the checks errored at a point where they should not.