### PR TITLE
Added potential for negative emission technologies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Unversioned
+
+* Added potential for negative emissions.
+  This change requires the user to always constrain the variable `emissions_node`, if it is defined by the user.
+  By default, this is achieved in the developed packages through `EmissionsData` or additional bounds.
+
 ## Version 0.6.7 (2024-03-21)
 
 * Allow for deactivation of timeprofile checks while printing a warning in this case.

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -181,6 +181,11 @@ function constraints_level_aux(m, n::RefStorage{S}, 𝒯, 𝒫, modeltype::Energ
     p_stor = storage_resource(n)
     𝒫ᵉᵐ    = setdiff(res_sub(𝒫, ResourceEmit), [p_stor])
 
+    # Set the lower bound for the emissions in the storage node
+    for t ∈ 𝒯
+        set_lower_bound(m[:emissions_node][n, t, p_stor], 0)
+    end
+
     # Constraint for the change in the level in a given operational period
     @constraint(m, [t ∈ 𝒯],
         m[:stor_level_Δ_op][n, t] ==

--- a/src/model.jl
+++ b/src/model.jl
@@ -127,8 +127,8 @@ function variables_emission(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
     𝒫ᵉᵐ  = filter(is_resource_emit, 𝒫)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-    @variable(m, emissions_node[𝒩ᵉᵐ, 𝒯, 𝒫ᵉᵐ] >= 0)
-    @variable(m, emissions_total[𝒯, 𝒫ᵉᵐ] >= 0)
+    @variable(m, emissions_node[𝒩ᵉᵐ, 𝒯, 𝒫ᵉᵐ])
+    @variable(m, emissions_total[𝒯, 𝒫ᵉᵐ])
     @variable(m, emissions_strategic[t_inv ∈ 𝒯ᴵⁿᵛ, p ∈ 𝒫ᵉᵐ] <=
                 emission_limit(modeltype, p, t_inv))
 end


### PR DESCRIPTION
So far, we did not allow for negative emissions as the variables `emissions_node` and `emissions_total` had a lower bound of 0. Removing the change requires the user to **_always_** provide a constraint (or a lower bound) for `ResourceEmit` that are not otherwise constrained with a lower bound to avoid potential negative emissions that are not physical.

In the current case, that corresponds to `RefStorage{ResourceEmit}`.