### PR TITLE
Docs/fix typos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,11 @@
 # Release notes
 
-## Unversioned
+## Version 0.6.8 (2024-04-18)
 
 * Added potential for negative emissions.
   This change requires the user to always constrain the variable `emissions_node`, if it is defined by the user.
-  By default, this is achieved in the developed packages through `EmissionsData` or additional bounds.
+  By default, this is achieved in the developed packages through `EmissionsData` or the addition of additional bounds on
+  the variable `:emissions_node` through the JuMP function [`set_lower_bound`](https://jump.dev/JuMP.jl/stable/api/JuMP/#set_lower_bound).
 * Provided a contribution section in the documentation.
 
 ## Version 0.6.7 (2024-03-21)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,19 +1,20 @@
 # Release notes
 
-## Version 0.6.8 (2024-04-18)
+## Unversioned
 
 * Added potential for negative emissions.
   This change requires the user to always constrain the variable `emissions_node`, if it is defined by the user.
   By default, this is achieved in the developed packages through `EmissionsData` or the addition of additional bounds on
   the variable `:emissions_node` through the JuMP function [`set_lower_bound`](https://jump.dev/JuMP.jl/stable/api/JuMP/#set_lower_bound).
 * Provided a contribution section in the documentation.
+* Minor changes in the naming convention in the documentation.
 
 ## Version 0.6.7 (2024-03-21)
 
 * Allow for deactivation of timeprofile checks while printing a warning in this case.
 * Fixed a bug for a too short `StrategicProfile` in the checks.
 * Added checks for the case dictionary.
-* Extended checks for the modeltype
+* Extended checks for the modeltype.
 * Added functions that can be used to check whether a `TimeProfile` can be indexed over `StrategicPeriod`s, `RepresentativePeriod`s, or `OperationalScenario`s.
 
 ## Version 0.6.6 (2024-03-04)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsBase"
 uuid = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.6.8"
+version = "0.6.7"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsBase"
 uuid = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.6.7"
+version = "0.6.8"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,7 +15,7 @@ cp("NEWS.md", news)
 DocMeta.setdocmeta!(EnergyModelsBase, :DocTestSetup, :(using EnergyModelsBase); recursive=true)
 
 makedocs(
-    sitename = "EnergyModelsBase.jl",
+    sitename = "EnergyModelsBase",
     format = Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
         edit_link="main",
@@ -35,8 +35,8 @@ makedocs(
         ],
         "How-to" => Any[
             "Create a new node" => "how-to/create-new-node.md",
-            "Utilize TimeStruct.jl" => "how-to/utilize-timestruct.md",
-            "Contribute to EnergyModelsBase.jl" => "how-to/contribute.md",
+            "Utilize TimeStruct" => "how-to/utilize-timestruct.md",
+            "Contribute to EnergyModelsBase" => "how-to/contribute.md",
         ],
         "Library" => Any[
             "Public" => "library/public.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -33,7 +33,7 @@ makedocs(
             "Example" => "manual/simple-example.md",
             "Release notes" => "manual/NEWS.md",
         ],
-        "How-to" => Any[
+        "How to" => Any[
             "Create a new node" => "how-to/create-new-node.md",
             "Utilize TimeStruct" => "how-to/utilize-timestruct.md",
             "Contribute to EnergyModelsBase" => "how-to/contribute.md",

--- a/docs/src/how-to/contribute.md
+++ b/docs/src/how-to/contribute.md
@@ -7,6 +7,8 @@ Contributing to `EnergyModelsBase` can be achieved in several different ways.
 The main focus of `EnergyModelsBase` is to provide an easily extendable energy system optimization modelling framework.
 Hence, a first approach to contributing to `EnergyModelsBase` is to create a new package with, _e.g._, the introduction of new node descriptions.
 
+This is explained in _[How to create a new Node](@ref create_new_node)_.
+
 !!! tip
     If you are uncertain how you could incorporate new nodal descriptions, take a look at [`EnergyModelsRenewableProducers`](https://github.com/EnergyModelsX/EnergyModelsRenewableProducers.jl).
     The package is maintained by the developers of `EnergyModelsBase`.
@@ -24,7 +26,7 @@ When filing a bug report, please follow the following guidelines:
       If you are certain that all links are set correctly, it is most likely a bug in `EnergyModelsBase` and should be reported.
     - If the problem occurs in model construction, it is most likely a bug in `EnergyModelsBase` and should be reported.
     - If the problem is only appearing for specific solvers, it is most likely not a bug in `EnergyModelsBase`, but instead a problem of the solver wrapper for `MathOptInterface`. In this case, please contact the developers of the corresponding solver wrapper.
-2. Label the issue as bug,
+2. Label the issue as bug, and
 3. Provide a minimum working example of a case in which the bug occurs.
 
 !!! note
@@ -44,7 +46,7 @@ Feature requests can be achieved through two approaches:
 !!! note
     `EnergyModelsBase` should not include everything.
 
-    The aim of the framework is to be lightweight and extensible by the user.
+    The aim of the framework is to be lightweight and extendable by the user.
     Hence, feature requests should only include basic requirements for the core structure, and not, _e.g._, the description of new technologies.
     These should be developed outside of `EnergyModelsBase`.
 
@@ -89,8 +91,9 @@ It is in general preferable to work on a separate branch when developing new com
 Incorporate your changes in your new branch.
 The changes should be commented to understand the thought process behind them.
 In addition, please provide new tests for the added functionality and be certain that the tests run.
+The tests should be based on a minimum working example.
 
-Some existing tests may potentially require changes when incorporating new features (within the test set `General tests`).
+Some existing tests may potentially require changes when incorporating new features (especially within the test set `General tests`).
 In this case, it is ok that they are failing and we will comment on the required changes in the pull request.
 
 !!! tip

--- a/docs/src/how-to/contribute.md
+++ b/docs/src/how-to/contribute.md
@@ -1,13 +1,13 @@
-# Contributing to EnergyModelsBase
+# Contribute to EnergyModelsBase
 
 Contributing to `EnergyModelsBase` can be achieved in several different ways.
 
-## Creating new extensions
+## Create new extensions
 
 The main focus of `EnergyModelsBase` is to provide an easily extendable energy system optimization modelling framework.
 Hence, a first approach to contributing to `EnergyModelsBase` is to create a new package with, _e.g._, the introduction of new node descriptions.
 
-This is explained in _[How to create a new Node](@ref create_new_node)_.
+This is explained in [_How to create a new node_](@ref create_new_node).
 
 !!! tip
     If you are uncertain how you could incorporate new nodal descriptions, take a look at [`EnergyModelsRenewableProducers`](https://github.com/EnergyModelsX/EnergyModelsRenewableProducers.jl).

--- a/docs/src/how-to/create-new-node.md
+++ b/docs/src/how-to/create-new-node.md
@@ -1,4 +1,4 @@
-# [Creating a new node](@id create_new_node)
+# [Create a new node](@id create_new_node)
 
 The energy system model is based on the *[JuMP](https://jump.dev/JuMP.jl/stable/)* optimization framework, so some basic knowledge on this Julia package is needed to implement a new technology node.
 

--- a/docs/src/how-to/create-new-node.md
+++ b/docs/src/how-to/create-new-node.md
@@ -114,4 +114,4 @@ A more detailed explanation of the different `abstract type`s can be found in *[
 
 ## Example
 
-As an example, you can check out how *[`EnergyModelsRenewableProducers`](https://energymodelsx.github.io/EnergyModelsRenewableProducers.jl/)* introduces two new technology types, a `Source` and a `Storage`.
+As an example, you can check out how [`EnergyModelsRenewableProducers`](https://energymodelsx.github.io/EnergyModelsRenewableProducers.jl/) introduces two new technology types, a `Source` and a `Storage`.

--- a/docs/src/how-to/utilize-timestruct.md
+++ b/docs/src/how-to/utilize-timestruct.md
@@ -28,7 +28,6 @@ The unit in itself is not important, but it can be either if you consider that a
 In this case, the operational periods would correspond to a full day.
 
 !!! note
-
     All operational periods are continuous. This implies that one is not allowed to have jumps in the representative periods. This affects all "dynamic" constraints, that is, constraints where the current operational period is dependent on the previous operational period. In `EnergyModesBase`, this is only the case for the level balance in `RefStorage`. Representative periods allow for jumps between operational periods, as outlined below.
 
 Note that `TimeStruct` does not require that each operational period has the same length.
@@ -71,7 +70,6 @@ It is used in all subsequent structures.
 When iterating over a `TimeStructure`, _e.g._, as `t ∈ operational_periods`, you obtain the single operational periods that are required for solving the optimal dispatch.
 
 !!! warning
-
     Energy conversion, production, or emissions of a node as well as all flows are always defined for a duration of length 1 in operational periods. You have to be careful when considering the output from the model. The same holds for capacities provided in the input file.
 
 ### [Representative periods](@id ts_rp)
@@ -140,7 +138,6 @@ Note, that we used in this example the optional keyword argument `op_per_strat` 
 If we would like to have a duration of 1 in an operational period corresponding to an hour and a duration of 1 in a strategic period to a year, we need to use the value `op_per_strat = 365*24 = 8760`.
 
 !!! warning
-
     It is important to be certain which value one should use for `op_per_strat`. When using the wrong value, one obtains wrong operational results that may affect the analysis.
 
 Similar to the `SimpleTimes` structure, it is possible to also have strategic periods of varying durations.
@@ -167,7 +164,6 @@ However, it may make the code look more complicated, when this is not required.
 It does not have any implication on the model building speed and it is up to the user, which approach to choose.
 
 !!! warning
-
     Fixed operational expenditures and emission limits provided to a model have to be provided for a duration of 1 in the strategic period.
 
 ### Summary
@@ -227,7 +223,6 @@ The example has a progressively increasing value going from 1 in the first hour 
 `OperationalProfile` is normally used for varying demand or profiles for renewable power generation.
 
 !!! warning
-
     It is possible to have an `OperationalProfile` that is shorter or longer than the profile in the time structure.
     If the profile is shorter, then the last value is repeated.
     If the profile is longer, then the last values are ommitted.
@@ -262,7 +257,6 @@ This implies that we can use both `OperationalProfile` and `FixedProfile` combin
 The only requirement is that if one is using Integer input, then the other also has to use Integer input.
 
 !!! warning
-
     It is possible to use `RepresentativeProfile` without `RepresentativePeriods`.
     In this case, the first provided profile is used.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -36,6 +36,17 @@ Pages = [
     "manual/constraint-functions.md",
     "manual/data-functions.md",
     "manual/simple-example.md",
+    "manual/simple-example.md",
+]
+```
+
+## How to guides
+
+```@contents
+Pages = [
+    "how-to/create-new-node.md",
+    "how-to/utilize-timestruct.md",
+    "how-to/contribute.md",
 ]
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,4 +1,4 @@
-# EnergyModelsBase.jl
+# EnergyModelsBase
 
 **EnergyModelsBase** is an operational, multi nodal energy system model, written in Julia.
 The model is based on the [`JuMP`](https://jump.dev/JuMP.jl/) optimization framework.


### PR DESCRIPTION
Fixed errors in the documentation:

- Removed typos in the new contribution section.
- Added How to pages to the outline.
- Changed some wording in headers.
- Removed `.jl` in all references.

The minor version number is increased to obtain the `How to contribute` page in the stable documentation.