### PR TITLE
Removed `\texttt` in docstrings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Unversioned
+## Version 0.6.8 (2024-04-18)
 
 * Added potential for negative emissions.
   This change requires the user to always constrain the variable `emissions_node`, if it is defined by the user.
@@ -8,6 +8,7 @@
   the variable `:emissions_node` through the JuMP function [`set_lower_bound`](https://jump.dev/JuMP.jl/stable/api/JuMP/#set_lower_bound).
 * Provided a contribution section in the documentation.
 * Minor changes in the naming convention in the documentation.
+* Removed `\texttt{}` from docstrings.
 
 ## Version 0.6.7 (2024-03-21)
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsBase"
 uuid = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.6.7"
+version = "0.6.8"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/src/structures/resource.jl
+++ b/src/structures/resource.jl
@@ -5,10 +5,12 @@ abstract type Resource end
 Base.show(io::IO, r::Resource) = print(io, "$(r.id)")
 
 """
+    ResourceEmit{T<:Real} <: Resource
+
 Resources that can can be emitted (e.g., CO₂, CH₄, NOₓ).
 
 These resources can be included as resources that are emitted, *e.g*, in the variable \
-[``\\texttt{emissions\\_strategic}``](@ref var_emission).
+[`emissions_strategic`](@ref var_emission).
 
 # Fields
 - **`id`** is the name/identifyer of the resource.\n
@@ -20,9 +22,11 @@ struct ResourceEmit{T<:Real} <: Resource
 end
 
 """
+    ResourceCarrier{T<:Real} <: Resource
+
 Resources that can be transported and converted.
 These resources cannot be included as resources that are emitted, *e.g*, in the variable \
-[``\\texttt{emissions\\_strategic}``](@ref var_emission).
+[`emissions_strategic`](@ref var_emission).
 
 # Fields
 - **`id`** is the name/identifyer of the resource.\n


### PR DESCRIPTION
Resolves [Issue 11](https://github.com/EnergyModelsX/EnergyModelsBase.jl/issues/20).
Major version increase to create a new Release for obtaining the latest stable docs version.