### PR TITLE
Improvement of `Storage` level balances

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,4 +10,4 @@ TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"
 [compat]
 JuMP = "^0.23, 1"
 julia = "^1.6"
-TimeStruct = "^0.7.0"
+TimeStruct = "^0.8"

--- a/docs/src/how-to/contribute.md
+++ b/docs/src/how-to/contribute.md
@@ -4,7 +4,7 @@ Contributing to `EnergyModelsBase` can be achieved in several different ways.
 
 ## Create new extensions
 
-The main focus of `EnergyModelsBase` is to provide an easily extendable energy system optimization modelling framework.
+The main focus of `EnergyModelsBase` is to provide an easily extensible energy system optimization modelling framework.
 Hence, a first approach to contributing to `EnergyModelsBase` is to create a new package with, _e.g._, the introduction of new node descriptions.
 
 This is explained in [_How to create a new node_](@ref create_new_node).

--- a/docs/src/how-to/utilize-timestruct.md
+++ b/docs/src/how-to/utilize-timestruct.md
@@ -47,7 +47,7 @@ The night has a reduced time resolution of 4 hours.
 However, we still model a full 24 hours as can be seen by the command
 
 ```jldoctest test_label; setup = :(using TimeStruct)
-duration(operational_periods)
+TimeStruct._total_duration(operational_periods)
 
 # output
 24

--- a/docs/src/library/public.md
+++ b/docs/src/library/public.md
@@ -59,7 +59,7 @@ Availability
 
 ### [Reference node types](@id sec_lib_public_refnodes)
 
-The following composite types are inmplemented in the `EnergyModelsBase`.
+The following composite types are implemented in the `EnergyModelsBase`.
 They can be used for describing a simple energy system without any non-linear or binary based expressions.
 Hence, there are, *e.g.*, no operation point specific efficiencies implemented.
 
@@ -70,6 +70,26 @@ RefSink
 RefStorage
 GenAvailability
 ```
+
+### Storage behaviours
+
+`EnergyModelsBase` provides several different storage behaviours for calculating the level balance of a `Storage` node.
+In general, the concrete storage behaviours are ready to use and should account for all eventualities.
+
+
+```@docs
+Accumulating
+AccumulatingEmissions
+Cyclic
+CyclicRepresentative
+CyclicStrategic
+```
+
+!!! note
+    We have not yet supported upper and lower bound constraints in the case of using `OperationalScenarios`.
+    While the calculation of the overall level balance and the operational costs is consistent, it can happen that violation of the upper and lower bound of the storage level is violated.
+
+    This impacts specifically `CyclicRepresentative`.
 
 ### [Functions for accessing fields of `Node` types](@id functions_fields_node)
 
@@ -235,10 +255,18 @@ constraints_flow_in
 constraints_flow_out
 constraints_capacity
 constraints_capacity_installed
-constraints_level
+constraints_level_aux
 constraints_opex_var
 constraints_opex_fixed
 constraints_data
+```
+
+In addition, auxiliary functions are introduced for the calculation of the previous level of storage nodes.
+These auxiliary functions provide the user with simple approaches for calculating the level balances.
+
+```@docs
+previous_level
+previous_level_sp
 ```
 
 ## [Emission data](@id sec_lib_public_emdata)

--- a/docs/src/library/public.md
+++ b/docs/src/library/public.md
@@ -76,7 +76,6 @@ GenAvailability
 `EnergyModelsBase` provides several different storage behaviours for calculating the level balance of a `Storage` node.
 In general, the concrete storage behaviours are ready to use and should account for all eventualities.
 
-
 ```@docs
 Accumulating
 AccumulatingEmissions
@@ -255,6 +254,7 @@ constraints_flow_in
 constraints_flow_out
 constraints_capacity
 constraints_capacity_installed
+constraints_level
 constraints_level_aux
 constraints_opex_var
 constraints_opex_fixed
@@ -302,7 +302,34 @@ co2_capture
 process_emissions
 ```
 
-## Miscellaneous functions/macros
+## Miscellaneous types/functions/macros
+
+### `PreviousPeriods` and `CyclicPeriods`
+
+`PreviousPeriods` is a type used to store information from the previous periods in an iteration loop through the application of the iterator [`withprev`](https://sintefore.github.io/TimeStruct.jl/stable/reference/api/#TimeStruct.withprev) of `TimeStruct`.
+
+`CyclicPeriods` is used for storing the current and the last period.
+The periods can either be either and `AbstractStrategicPeriod` or `AbstractRepresentativePeriod`.
+In the former case, it is however not fully used as the last strategic period is not relevant for the level balances.
+
+```@docs
+PreviousPeriods
+CyclicPeriods
+```
+
+The individual fields can be accessed through the following functions:
+
+```@docs
+strat_per
+rep_per
+op_per
+last_per
+current_per
+```
+
+### Macros for checking the input data
+
+The macro `@assert_or_log` is an extension to the `@assert` macro to allow either for asserting the input data directly, or logging the errors in the input data.
 
 ```@docs
 @assert_or_log

--- a/docs/src/manual/constraint-functions.md
+++ b/docs/src/manual/constraint-functions.md
@@ -74,7 +74,7 @@ corresponds to the main constraint for calculating the level balance of a `Stora
 Within this constraint, two different functions are called:
 
 ```julia
-constraints_level_aux(m, n, 𝒯, 𝒫, modeltype::EnergyModel)
+constraints_level_aux(m, n::Storage, 𝒯, 𝒫, modeltype::EnergyModel)
 ```
 
 and
@@ -89,7 +89,7 @@ General properties are the calculation of the change in storage level in an oper
 It is implemented for a generic `Storage` node as well for a `RefStorage{AccumulatingEmissions}` node.
 Using the `AccumulatingEmissions` requires that the stored resource is a `ResourceEmit` and limits the variable ``\texttt{stor\_level\_}\Delta\texttt{\_op}[n, t, p] \geq 0`` as well as introduces emission variables.
 
-The second function, `constraints_level_iterate`, iterates through the time strucutre and eventually declares the level balance of the `Storage` node within a strategic period.
+The second function, `constraints_level_iterate`, iterates through the time structure and eventually declares the level balance of the `Storage` node within a strategic period.
 It automatically deduces the type of the time structure, _i.e._, whether representative periods and/or operational scenarios are included, and subsequently calculates the corresponding previous period used in the level balance through calling the function [`previous_level`](@ref).
 
 `RepresentativePeriods` are handled through scaling of the change in the level in a representative period.

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -109,7 +109,7 @@ function generate_example_data()
         ),
         RefSink(
             "electricity demand",       # Node id
-            OperationalProfile([20 30 40 30]), # Demand in MW
+            OperationalProfile([20, 30, 40, 30]), # Demand in MW
             Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
             # Line above: Surplus and deficit penalty for the node in EUR/MWh
             Dict(Power => 1),           # Energy demand and corresponding ratio

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -95,7 +95,7 @@ function generate_example_data()
             Dict(Power => 1),           # Output from the node with output ratio
             [emission_data],            # Additonal data for emissions
         ),
-        RefStorage{EMB.AccumulatingEmissions}(
+        RefStorage{AccumulatingEmissions}(
             "CO2 storage",              # Node id
             FixedProfile(60),           # Rate capacity in t/h
             FixedProfile(600),          # Storage capacity in t

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -95,7 +95,7 @@ function generate_example_data()
             Dict(Power => 1),           # Output from the node with output ratio
             [emission_data],            # Additonal data for emissions
         ),
-        RefStorage(
+        RefStorage{EMB.AccumulatingEmissions}(
             "CO2 storage",              # Node id
             FixedProfile(60),           # Rate capacity in t/h
             FixedProfile(600),          # Storage capacity in t

--- a/examples/sink_source.jl
+++ b/examples/sink_source.jl
@@ -56,7 +56,7 @@ function generate_example_data()
         ),
         RefSink(
             "electricity demand",       # Node id
-            OperationalProfile([20 30 40 30]), # Demand in MW
+            OperationalProfile([20, 30, 40, 30]), # Demand in MW
             Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
             # Line above: Surplus and deficit penalty for the node in EUR/MWh
             Dict(Power => 1),           # Energy demand and corresponding ratio

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -60,7 +60,7 @@ export create_model, run_model
 export variables_node, create_node
 export constraints_capacity, constraints_capacity_installed
 export constraints_flow_in, constraints_flow_out
-export constraints_level_aux
+export constraints_level, constraints_level_aux
 export constraints_opex_fixed, constraints_opex_var
 export previous_level, previous_level_sp
 

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -19,6 +19,7 @@ include(joinpath("structures", "data.jl"))
 include(joinpath("structures", "node.jl"))
 include(joinpath("structures", "link.jl"))
 include(joinpath("structures", "model.jl"))
+include(joinpath("structures", "misc.jl"))
 
 include("utils.jl")
 include("model.jl")

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -84,4 +84,7 @@ export formulation
 # Export commonly used functions for extracting fields in `EnergyModel`
 export emission_limit, emission_price, co2_instance
 
+# Export commonly used functions for extracting fields in `PreviousPeriods` and `CyclicPeriods`
+export strat_per, rep_per, op_per, last_per, current_per
+
 end # module

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -51,6 +51,9 @@ export EmissionsProcess, EmissionsEnergy
 # Export the link types
 export Linear, Link, Direct
 
+# Export the miscellaneous types
+export PreviousPeriods, CyclicPeriods
+
 # Legacy data types
 export RefNetwork, RefNetworkEmissions, RefStorageEmissions
 

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -39,6 +39,10 @@ export Resource, ResourceCarrier, ResourceEmit
 export Source, NetworkNode, Sink, Storage, Availability
 export GenAvailability, RefSource, RefNetworkNode, RefSink, RefStorage
 
+# Export the storage behaviour types
+export Accumulating, AccumulatingEmissions
+export Cyclic, CyclicRepresentative, CyclicStrategic
+
 # Export the data types
 export Data, EmptyData, EmissionsData, CaptureData
 export CaptureProcessEnergyEmissions, CaptureProcessEmissions, CaptureEnergyEmissions
@@ -56,8 +60,9 @@ export create_model, run_model
 export variables_node, create_node
 export constraints_capacity, constraints_capacity_installed
 export constraints_flow_in, constraints_flow_out
-export constraints_level
+export constraints_level_aux
 export constraints_opex_fixed, constraints_opex_var
+export previous_level, previous_level_sp
 
 export constraints_data
 

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -118,6 +118,34 @@ function constraints_flow_in(m, n::Storage, 𝒯::TimeStructure, modeltype::Ener
     )
 
 end
+"""
+    constraints_flow_in(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
+
+Function for creating the constraint on the inlet flow to a generic `Storage`.
+This function serves as fallback option if no other function is specified for a `Storage`.
+"""
+function constraints_flow_in(
+    m,
+    n::Storage{AccumulatingEmissions},
+    𝒯::TimeStructure,
+    modeltype::EnergyModel,
+)
+    # Declaration of the required subsets
+    p_stor = storage_resource(n)
+    𝒫ᵃᵈᵈ   = setdiff(inputs(n), [p_stor])
+
+    # Constraint for additional required input
+    @constraint(m, [t ∈ 𝒯, p ∈ 𝒫ᵃᵈᵈ],
+        m[:flow_in][n, t, p] == m[:flow_in][n, t, p_stor] * inputs(n, p)
+    )
+
+    # Constraint for storage rate use
+    @constraint(m, [t ∈ 𝒯],
+        m[:stor_rate_use][n, t] ==
+            m[:flow_in][n, t, p_stor] - m[:emissions_node][n, t, p_stor]
+    )
+
+end
 
 
 """

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -367,7 +367,7 @@ end
 """
     constraints_level_rp(m, n::Storage{CyclicRepresentative}, per, modeltype::EnergyModel)
 
-When a `CyclicStorage` is used, the the change in the representative period
+When a `Storage{CyclicRepresentative}` is used, the change in the representative period
 is constrained to 0.
 """
 function constraints_level_rp(m, n::Storage{CyclicRepresentative}, per, modeltype::EnergyModel)
@@ -387,6 +387,23 @@ The default approach is to not provide any constraints.
 """
 function constraints_level_scp(m, n::Storage, per, modeltype::EnergyModel)
     return nothing
+end
+"""
+    constraints_level_scp(m, n::Storage{CyclicRepresentative}, per, modeltype::EnergyModel)
+
+When a Storage{CyclicRepresentative} is used, the final level in an operational scenario is
+constrained to be the same in all operational scenarios.
+"""
+function constraints_level_scp(m, n::Storage{CyclicRepresentative}, per, modeltype::EnergyModel)
+    # Declaration of the required subsets
+    𝒯ˢᶜ = opscenarios(per)
+    last_scp = [last(t_scp) for t_scp ∈ 𝒯ˢᶜ]
+
+    # Constraint that level is similar to the level in the first scenario
+    for t ∈ last_scp[2:end]
+        @constraint(m, m[:stor_level][n, t] == m[:stor_level][n, first(last_scp)])
+    end
+
 end
 
 """

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -386,8 +386,14 @@ end
 """
     constraints_level_rp(m, n::Storage{<:Accumulating}, per, modeltype::EnergyModel)
 
-When a `Storage{<:Accumulating}` is used, the cyclic constraint is not implemented as
-accumulation within a strategic period is desirable.
+When a `Storage{<:Accumulating}` is used, the cyclic constraint for restricting the level
+change within a strategic period to 0 (through setting the sum of `:stor_level_Δ_rp` within
+a strategic period to 0) is not implemented as accumulation within a strategic period is
+desirable.
+
+This implies that [`Accumulating`](@ref) behaviors require the developer to introduce
+the function [`previous_level`](@ref) in the case of
+`prev_pers = PreviousPeriods{<:NothingPeriod, Nothing, Nothing}`.
 """
 function constraints_level_rp(m, n::Storage{<:Accumulating}, per, modeltype::EnergyModel)
     return nothing
@@ -467,7 +473,7 @@ end
         modeltype::EnergyModel,
     )
 
-When representative periods are used and the previous opeartional period is nothing, then
+When representative periods are used and the previous operational  period is `nothing`, then
 bounds are incorporated to avoid that the initial level storage level is violating the
 maximum and minimum level.
 """

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -319,7 +319,7 @@ function constraints_level_iterate(
         prev_pers = PrevPeriods(prev_pers.sp, prev_pers.rp, t_prev, prev_pers.last);
 
         # Extract the previous level
-        prev_level = previous_level(m, n, prev_pers, t, modeltype)
+        prev_level = previous_level(m, n, prev_pers, modeltype)
 
         # Mass balance constraint in the storage
         @constraint(
@@ -329,7 +329,7 @@ function constraints_level_iterate(
 
         # Constraint for avoiding starting below 0 if the previous operational level is
         # nothing
-        constraints_level_bounds(m, n, t, prev_pers, modeltype)
+        constraints_level_bounds(m, n, t, prev_pers.last, modeltype)
     end
 end
 
@@ -415,7 +415,7 @@ end
         m,
         n::Storage,
         t::TS.TimePeriod,
-        prev_pers::PrevPeriods,
+        prev_pers::TS.TimePeriod,
         modeltype::EnergyModel,
     )
 
@@ -428,7 +428,7 @@ function constraints_level_bounds(
     m,
     n::Storage,
     t::TS.TimePeriod,
-    prev_pers::PrevPeriods,
+    prev_pers::TS.TimePeriod,
     modeltype::EnergyModel,
 )
 
@@ -439,7 +439,7 @@ end
         m,
         n::Storage,
         t::TS.TimePeriod,
-        prev_pers::PrevPeriods{<:nt, <:nt, Nothing, <:TS.AbstractRepresentativePeriod},
+        prev_pers::TS.AbstractRepresentativePeriod,
         modeltype::EnergyModel,
     )
 
@@ -451,7 +451,7 @@ function constraints_level_bounds(
     m,
     n::Storage,
     t::TS.TimePeriod,
-    prev_pers::PrevPeriods{<:nt, <:nt, Nothing, <:TS.AbstractRepresentativePeriod},
+    prev_pers::TS.AbstractRepresentativePeriod,
     modeltype::EnergyModel,
 )
 

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -52,7 +52,7 @@ end
 """
     constraints_capacity_installed(m, n, 𝒯::TimeStructure, modeltype::EnergyModel)
 
-Function for limiting the the installed capacity to the available capacity.
+Constrain the installed capacity to the available capacity.
 
 This function should only be used to dispatch on the modeltype for providing investments.
 If you create new capacity variables, it is beneficial to include as well a method for this
@@ -121,7 +121,7 @@ end
 """
     constraints_flow_in(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
 
-Function for creating the constraint on the inlet flow to a generic `Storage`.
+Create the constraint on the inlet flow to a generic `Storage`.
 This function serves as fallback option if no other function is specified for a `Storage`.
 """
 function constraints_flow_in(
@@ -194,7 +194,7 @@ end
 """
     constraints_level_aux(m, n::Storage, 𝒯, 𝒫, modeltype::EnergyModel)
 
-Function for creating the Δ constraint for the level of a reference storage node with a
+Create the Δ constraint for the level of a reference storage node with a
 `ResourceCarrier` resource.
 """
 function constraints_level_aux(m, n::Storage, 𝒯, 𝒫, modeltype::EnergyModel)

--- a/src/legacy_constructor.jl
+++ b/src/legacy_constructor.jl
@@ -96,13 +96,13 @@ function RefStorageEmissions(
     data::Vector,
 )
 
-    @warn("The implementation of a `RefStorageEmissions` will be discontinued in \
-    the near future. See the documentation for the new implementation using a parametric \
-    type. In practice, the only thing changing is to use `RefStorage` instead of \
-    `RefStorageEmissions`. It is recommended to update the existing version to the new \
-    version.")
+    @warn("The implementation of a `RefStorageEmissions` will be discontinued in the near future. \
+    See the documentation for the new implementation using a parametric type describing the
+    storage behaviour. In practice, the only thing changing is to use \
+    `RefStorage{AccumulatingEmissions}()` instead of `RefStorage`. It is recommended to \
+    update the existing version to the new version.")
 
-    tmp = RefStorage(
+    tmp = RefStorage{AccumulatingEmissions}(
         id,
         rate_cap,
         stor_cap,
@@ -112,6 +112,150 @@ function RefStorageEmissions(
         input,
         output,
         Vector{Data}(data),
+    )
+    return tmp
+end
+
+"""
+Legacy constructor for a `RefStorage{ResourceEmit}`.
+This version will be discontinued in the near future and replaced with the new version of
+`RefStorage{StorageBehavior}` in which the parametric input defines the behaviour of the
+storage.
+
+See the documentation for further information. In this case, the key difference is that we
+changed the parameteric descriptions from the stored `Resource` to the behaviour of the
+`Storage` node
+"""
+function RefStorage(
+    id,
+    rate_cap::TimeProfile,
+    stor_cap::TimeProfile,
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+    stor_res::ResourceEmit,
+    input::Dict{<:Resource,<:Real},
+    output::Dict{<:Resource,<:Real},
+    data::Vector,
+)
+
+    @warn("The implementation of a `RefStorage` will be discontinued in the near future. \
+    See the documentation for the new implementation using a parametric type describing \
+    the storage behaviour. In practice, the only thing changing is to use \
+    `RefStorage{AccumulatingEmissions}()` instead of `RefStorage`. It is recommended to \
+    update the existing version to the new version.")
+
+    tmp = RefStorage{AccumulatingEmissions}(
+        id,
+        rate_cap,
+        stor_cap,
+        opex_var,
+        opex_fixed,
+        stor_res,
+        input,
+        output,
+        Vector{Data}(data),
+    )
+    return tmp
+end
+function RefStorage(
+    id,
+    rate_cap::TimeProfile,
+    stor_cap::TimeProfile,
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+    stor_res::ResourceEmit,
+    input::Dict{<:Resource,<:Real},
+    output::Dict{<:Resource,<:Real},
+)
+
+    @warn("The implementation of a `RefStorage` will be discontinued in the near future. \
+    See the documentation for the new implementation using a parametric type describing \
+    the storage behaviour. In practice, the only thing changing is to use \
+    `RefStorage{AccumulatingEmissions}()` instead of `RefStorage`. It is recommended to \
+    update the existing version to the new version.")
+
+    tmp = RefStorage{AccumulatingEmissions}(
+        id,
+        rate_cap,
+        stor_cap,
+        opex_var,
+        opex_fixed,
+        stor_res,
+        input,
+        output,
+        Data[],
+    )
+    return tmp
+end
+
+"""
+Legacy constructor for a `RefStorage{ResourceCarrier}`.
+This version will be discontinued in the near future and replaced with the new version of
+`RefStorage{StorageBehavior}` in which the parametric input defines the behaviour of the
+storage.
+
+See the documentation for further information. In this case, the key difference is that we
+changed the parameteric descriptions from the stored `Resource` to the behaviour of the
+`Storage` node
+"""
+function RefStorage(
+    id,
+    rate_cap::TimeProfile,
+    stor_cap::TimeProfile,
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+    stor_res::ResourceCarrier,
+    input::Dict{<:Resource,<:Real},
+    output::Dict{<:Resource,<:Real},
+    data::Vector,
+)
+
+    @warn("The implementation of a `RefStorage` will be discontinued in the near future. \
+    See the documentation for the new implementation using a parametric type describing \
+    the storage behaviour. In practice, the only thing changing is to use \
+    `RefStorage{CyclicStrategic}()` instead of `RefStorage`. It is recommended to \
+    update the existing version to the new version.")
+
+    tmp = RefStorage{CyclicStrategic}(
+        id,
+        rate_cap,
+        stor_cap,
+        opex_var,
+        opex_fixed,
+        stor_res,
+        input,
+        output,
+        Vector{Data}(data),
+    )
+    return tmp
+end
+function RefStorage(
+    id,
+    rate_cap::TimeProfile,
+    stor_cap::TimeProfile,
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+    stor_res::ResourceCarrier,
+    input::Dict{<:Resource,<:Real},
+    output::Dict{<:Resource,<:Real},
+)
+
+    @warn("The implementation of a `RefStorage` will be discontinued in the near future. \
+    See the documentation for the new implementation using a parametric type describing \
+    the storage behaviour. In practice, the only thing changing is to use \
+    `RefStorage{CyclicStrategic}()` instead of `RefStorage`. It is recommended to \
+    update the existing version to the new version.")
+
+    tmp = RefStorage{CyclicStrategic}(
+        id,
+        rate_cap,
+        stor_cap,
+        opex_var,
+        opex_fixed,
+        stor_res,
+        input,
+        output,
+        Data[],
     )
     return tmp
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -295,7 +295,7 @@ function objective(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
 
     # Calculation of the objective function.
     @objective(m, Max,
-        -sum((opex[t_inv] + emissions[t_inv]) * duration(t_inv) for t_inv ∈ 𝒯ᴵⁿᵛ)
+        -sum((opex[t_inv] + emissions[t_inv]) * duration_strat(t_inv) for t_inv ∈ 𝒯ᴵⁿᵛ)
     )
 end
 

--- a/src/structures/link.jl
+++ b/src/structures/link.jl
@@ -32,7 +32,8 @@ Direct(id, from::Node, to::Node) = Direct(id, from, to, Linear())
 """
     link_sub(ℒ::Vector{<:Link}, n::Node)
 
-Return connected links for a given node `n`.
+Return connected links from the vector `ℒ` for a given node `n` as array.
+The first subarray corresponds to the `from` field, while the second to the `to` field.
 """
 function link_sub(ℒ::Vector{<:Link}, n::Node)
     return [filter(x -> x.from == n, ℒ),

--- a/src/structures/misc.jl
+++ b/src/structures/misc.jl
@@ -2,9 +2,9 @@
 
 
 nt = Union{Nothing, TS.TimePeriod, TS.TimeStructure{T}} where {T}
-struct PrevPeriods{S<:nt, T<:nt, U<:nt,  V<:nt}
+struct PrevPeriods{S<:nt, T<:nt, U<:nt}
     sp::S
     rp::T
     op::U
-    last::V
+    last::nt
 end

--- a/src/structures/misc.jl
+++ b/src/structures/misc.jl
@@ -1,14 +1,69 @@
+NothingPeriod = Union{Nothing, TS.TimePeriod, TS.TimeStructure{T}} where {T}
 
+"""
+    PreviousPeriods{S<:NothingPeriod, T<:NothingPeriod, U<:NothingPeriod}
 
+Contains the previous strategic, representative, and operational period used through the
+application of the `with_prev` iterator developed in `TimeStruct`.
 
-nt = Union{Nothing, TS.TimePeriod, TS.TimeStructure{T}} where {T}
-struct PrevPeriods{S<:nt, T<:nt, U<:nt}
+# Fields
+- **`sp::S`** the previous strategic period.
+- **`rp::T`** the previous representative period.
+- **`op::U`** the previous operational period.
+"""
+struct PreviousPeriods{S<:NothingPeriod, T<:NothingPeriod, U<:NothingPeriod}
     sp::S
     rp::T
     op::U
 end
 
-struct CyclicPeriods{S<:nt}
-    last::S
-    current::S
+"""
+    strat_per(prev_periods::PreviousPeriods)
+
+Extracts the previous strategic period (fields `sp`) from a [`PreviousPeriods`](@ref) type.
+"""
+strat_per(prev_periods::PreviousPeriods) = prev_periods.sp
+"""
+    rep_per(prev_periods::PreviousPeriods)
+
+Extracts the previous representative period (fields `sp`) from a [`PreviousPeriods`](@ref) type.
+"""
+rep_per(prev_periods::PreviousPeriods) = prev_periods.rp
+"""
+    op_perop_per(prev_periods::PreviousPeriods)
+
+Extracts the previous operational period (fields `sp`) from a [`PreviousPeriods`](@ref) type.
+"""
+op_per(prev_periods::PreviousPeriods) = prev_periods.op
+
+"""
+    CyclicPeriods{S<:NothingPeriod}
+
+Contains information for calculating the cyclic constraints. The parameter `S` should be
+either an `AbstractStrategicPeriod` or `AbstractRepresentativePeriod`.
+
+# Fields
+- **`last_per::S`** the last period in the case of `S<:AbstractRepresentativePeriod` or the
+  current period in the case of `S<:AbstractStrategicPeriod` as the last strategic period
+  is not relevant.
+- **`current_per::S`** the current period in both the case of `S<:AbstractRepresentativePeriod`
+  and `S<:AbstractStrategicPeriod`.
+"""
+struct CyclicPeriods{S<:NothingPeriod}
+    last_per::S
+    current_per::S
 end
+
+"""
+    last_per(cyclic_pers::CyclicPeriods)
+
+Extracts the last period (fields `last_per`) from a [`CyclicPeriods`](@ref) type.
+"""
+last_per(cyclic_pers::CyclicPeriods) = cyclic_pers.last_per
+
+"""
+    current_per(cyclic_pers::CyclicPeriods)
+
+Extracts the current period (fields `current_per`) from a [`CyclicPeriods`](@ref) type.
+"""
+current_per(cyclic_pers::CyclicPeriods) = cyclic_pers.current_per

--- a/src/structures/misc.jl
+++ b/src/structures/misc.jl
@@ -1,0 +1,10 @@
+
+
+
+nt = Union{Nothing, TS.TimePeriod, TS.TimeStructure{T}} where {T}
+struct PrevPeriods{S<:nt, T<:nt, U<:nt,  V<:nt}
+    sp::S
+    rp::T
+    op::U
+    last::V
+end

--- a/src/structures/misc.jl
+++ b/src/structures/misc.jl
@@ -6,5 +6,9 @@ struct PrevPeriods{S<:nt, T<:nt, U<:nt}
     sp::S
     rp::T
     op::U
-    last::nt
+end
+
+struct CyclicPeriods{S<:nt}
+    last::S
+    current::S
 end

--- a/src/structures/node.jl
+++ b/src/structures/node.jl
@@ -145,6 +145,66 @@ function RefStorage(
     )
 end
 
+
+"""
+    CyclicStorage <: Storage
+
+A cyclic `Storage` node.
+
+This node is designed to store a `ResourceCarrier` and should only be relevant in the case
+of implementation of representative periods. In this situation, the storage balance is
+cyclic within a representative period.
+
+A `CyclicStorage` node behaves similar to a `RefStorage{ResourceCarrier}` node, if there are
+no representative periods.
+
+# Fields
+- **`id`** is the name/identifier of the node.\n
+- **`rate_cap::TimeProfile`** is the installed rate capacity, that is e.g. power or mass flow.\n
+- **`stor_cap::TimeProfile`** is the installed storage capacity, that is e.g. energy or mass.\n
+- **`opex_var::TimeProfile`** is the variational operational costs per energy unit stored.\n
+- **`opex_fixed::TimeProfile`** is the fixed operational costs.\n
+- **`stor_res::T`** is the stored `Resource`.\n
+- **`input::Dict{<:Resource, <:Real}`** are the input `Resource`s with conversion value `Real`.
+- **`output::Dict{<:Resource, <:Real}`** are the generated `Resource`s with conversion value `Real`. \
+Only relevant for linking and the stored `Resource`.\n
+- **`data::Vector{<:Data}`** is the additional data (e.g. for investments). The field \
+`data` is conditional through usage of a constructor.
+"""
+struct CyclicStorage <: Storage
+    id
+    rate_cap::TimeProfile
+    stor_cap::TimeProfile
+    opex_var::TimeProfile
+    opex_fixed::TimeProfile
+    stor_res::ResourceCarrier
+    input::Dict{<:Resource, <:Real}
+    output::Dict{<:Resource, <:Real}
+    data::Vector{<:Data}
+end
+function CyclicStorage(
+    id,
+    rate_cap::TimeProfile,
+    stor_cap::TimeProfile,
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+    stor_res::ResourceCarrier,
+    input::Dict{<:Resource, <:Real},
+    output::Dict{<:Resource, <:Real},
+)
+    return CyclicStorage(
+        id,
+        rate_cap,
+        stor_cap,
+        opex_var,
+        opex_fixed,
+        stor_res,
+        input,
+        output,
+        Data[],
+    )
+end
+
 """ A reference `Sink` node.
 
 This node corresponds to a demand given by the field `cap`.

--- a/src/structures/node.jl
+++ b/src/structures/node.jl
@@ -2,13 +2,31 @@
 abstract type Node end
 Base.show(io::IO, n::Node) = print(io, "n_$(n.id)")
 
-""" `StorageBehavior` as supertype for individual storage behaviours."""
+"""
+`StorageBehavior` as supertype for individual storage behaviours.
+
+Storage behaviour is used to identify how a storage node should behave within the individual
+`TimeStructure`s of a strategic period.
+"""
 abstract type StorageBehavior end
 
-""" `Accumulating` as supertype for an accumulating storage level."""
+"""
+`Accumulating` as supertype for an accumulating storage level.
+
+Accumulating storage behaviour implies that the change in the overall storage level in a
+strategic period can be both positive or negative.
+
+Examples for potential usage of `Accumulating` are CO₂ storages in which the CO₂ is
+permanently stored or multi year hydropower magazines.
+"""
 abstract type Accumulating <: StorageBehavior end
 
-""" `Cyclic` as supertype for a cyclic storage level."""
+"""
+`Cyclic` as supertype for a cyclic storage level.
+
+Cyclic storage behaviour implies that the change in the overall storage level in a strategic
+period behaves cyclic.
+"""
 abstract type Cyclic <: StorageBehavior end
 
 """
@@ -20,14 +38,6 @@ represent a soft constraint on storing the captured emissions.
 """
 struct AccumulatingEmissions <: Accumulating end
 
-"""
-    CyclicStrategic <: Cyclic
-
-`StorageBehavior` in which the the cyclic behaviour is achieved within a strategic period.
-This implies that the initial level in individual representative periods can be different
-when using `RepresentativePeriods`
-"""
-struct CyclicStrategic <: Cyclic end
 
 """
     CyclicRepresentative <: Cyclic
@@ -40,6 +50,15 @@ In the case of `TwoLevel{RepresentativePeriods{SimpleTimes}}`, this approach dif
 `CyclicStrategic` as the cyclic constraint is enforeced within each representative period.
 """
 struct CyclicRepresentative <: Cyclic end
+
+"""
+    CyclicStrategic <: Cyclic
+
+`StorageBehavior` in which the the cyclic behaviour is achieved within a strategic period.
+This implies that the initial level in individual representative periods can be different
+when using `RepresentativePeriods`
+"""
+struct CyclicStrategic <: Cyclic end
 
 """ `Source` node with only output."""
 abstract type Source <: Node end
@@ -135,7 +154,9 @@ GenAvailability(id, 𝒫::Vector{<:Resource}) = GenAvailability(id, 𝒫, 𝒫)
 """ A reference `Storage` node.
 
 This node is designed to store either a `ResourceCarrier` or a `ResourceEmit`.
-It is designed as a composite type to differentiate between different cyclic behaviour.
+It is designed as a parametric type to differentiate between different cyclic behaviours.
+The current implemented cyclic behaviours are [`CyclicRepresentative`](@ref),
+[`CyclicStrategic`](@ref), and [`AccumulatingEmissions`](@ref).
 
 # Fields
 - **`id`** is the name/identifier of the node.\n

--- a/src/structures/node.jl
+++ b/src/structures/node.jl
@@ -154,7 +154,11 @@ GenAvailability(id, 𝒫::Vector{<:Resource}) = GenAvailability(id, 𝒫, 𝒫)
 """ A reference `Storage` node.
 
 This node is designed to store either a `ResourceCarrier` or a `ResourceEmit`.
-It is designed as a parametric type to differentiate between different cyclic behaviours.
+It is designed as a parametric type through the type parameter `T` to differentiate between
+different cyclic behaviours. Note that the parameter T is only used for dispatching, but
+does not carry any other information. Hence, it is simple to fast switch between different
+[`StorageBehavior`](@ref)s.
+
 The current implemented cyclic behaviours are [`CyclicRepresentative`](@ref),
 [`CyclicStrategic`](@ref), and [`AccumulatingEmissions`](@ref).
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -104,13 +104,13 @@ end
     previous_level(
         m,
         n::Storage,
-        prev_pers::PrevPeriods,
+        prev_pers::PreviousPeriods,
         cyclic_pers::CyclicPeriods,
         modeltype::EnergyModel,
     )
 
 Returns the level used as previous level of a `Storage` node depending on the type of
-[`PrevPeriods`](@ref).
+[`PreviousPeriods`](@ref).
 
 The basic functionality is used in the case when the previous operational period is a
 `TimePeriod`, in which case it just returns the previous operational period.
@@ -118,90 +118,65 @@ The basic functionality is used in the case when the previous operational period
 function previous_level(
     m,
     n::Storage,
-    prev_pers::PrevPeriods,
+    prev_pers::PreviousPeriods,
     cyclic_pers::CyclicPeriods,
     modeltype::EnergyModel,
 )
 
     # Previous storage level, as there are no changes
-    return @expression(m, m[:stor_level][n, prev_pers.op])
+    return @expression(m, m[:stor_level][n, op_per(prev_pers)])
 end
 """
     previous_level(
         m,
         n::Storage,
-        prev_pers::PrevPeriods{<:nt, Nothing, Nothing},
+        prev_pers::PreviousPeriods{<:NothingPeriod, Nothing, Nothing},
         cyclic_pers::CyclicPeriods,
         modeltype::EnergyModel,
     )
 
 When the previous operational and representative period are `Nothing`, the function
 returns the cyclic constraints within a strategic period. This is achieved through calling a
-subfunction [`_previous_level_sp`](@ref) to avoid method ambiguities.
+subfunction [`previous_level_sp`](@ref) to avoid method ambiguities.
 """
 function previous_level(
     m,
     n::Storage,
-    prev_pers::PrevPeriods{<:nt, Nothing, Nothing},
+    prev_pers::PreviousPeriods{<:NothingPeriod, Nothing, Nothing},
     cyclic_pers::CyclicPeriods,
     modeltype::EnergyModel,
 )
 
-    return _previous_level_sp(m, n, cyclic_pers, modeltype)
+    return previous_level_sp(m, n, cyclic_pers, modeltype)
 end
-function _previous_level_sp(
-    m,
-    n::Storage{<:Cyclic},
-    cyclic_pers::CyclicPeriods,
-    modeltype::EnergyModel
-)
-    # Return the previous storage level based on cyclic constraints
-    t_last = last(collect(cyclic_pers.current))
-    return @expression(m, m[:stor_level][n, t_last])
-end
-function _previous_level_sp(
-    m,
-    n::Storage{CyclicStrategic},
-    cyclic_pers::CyclicPeriods{<:TS.AbstractRepresentativePeriod},
-    modeltype::EnergyModel,
-)
-    # Return the previous storage level based on cyclic constraints when representative
-    # periods are included
-    return @expression(
+"""
+    previous_level(
         m,
-        # Initial storage in previous representative period
-        m[:stor_level][n, first(cyclic_pers.last)] -
-        m[:stor_level_Δ_op][n, first(cyclic_pers.last)] * duration(first(cyclic_pers.last)) +
-        # Increase in previous representative period
-        m[:stor_level_Δ_rp][n, cyclic_pers.last]
+        n::Storage,
+        prev_pers::PreviousPeriods{<:NothingPeriod, Nothing, Nothing},
+        cyclic_pers::CyclicPeriods,
+        modeltype::EnergyModel,
     )
-end
-function _previous_level_sp(
-    m,
-    n::Storage{CyclicRepresentative},
-    cyclic_pers::CyclicPeriods{<:TS.AbstractRepresentativePeriod},
-    modeltype::EnergyModel,
-)
-    # Return the previous storage level based on cyclic constraints within the representative
-    # period
-    return @expression(m, m[:stor_level][n, last(collect(cyclic_pers.current))])
-end
+
+When the previous operational and representative period are `Nothing` and the storage node
+is an [`AccumulatingEmissions`](@ref) storage node, the function returns a value of 0.
+"""
 function previous_level(
     m,
     n::Storage{AccumulatingEmissions},
-    prev_pers::PrevPeriods{<:nt, Nothing, Nothing},
+    prev_pers::PreviousPeriods{<:NothingPeriod, Nothing, Nothing},
     cyclic_pers::CyclicPeriods,
     modeltype::EnergyModel,
 )
     # Return the previous storage level as 0 for the reference storage unit
     return @expression(m, 0)
 end
-
 """
     previous_level(
         m,
         n::Storage,
-        prev_pers::PrevPeriods{<:nt, <:TS.AbstractRepresentativePeriod, Nothing},
+        prev_pers::PreviousPeriods{<:NothingPeriod, <:TS.AbstractRepresentativePeriod, Nothing},
+        cyclic_pers::CyclicPeriods,
         modeltype::EnergyModel,
     )
 
@@ -214,19 +189,8 @@ period while accounting for the number of  repetitions of the representative per
 """
 function previous_level(
     m,
-    n::Storage{CyclicRepresentative},
-    prev_pers::PrevPeriods{<:nt, <:TS.AbstractRepresentativePeriod, Nothing},
-    cyclic_pers::CyclicPeriods,
-    modeltype::EnergyModel,
-)
-    # Return the previous storage level based on cyclic constraints within the representative
-    # period
-    return @expression(m, m[:stor_level][n, last(collect(cyclic_pers.current))])
-end
-function previous_level(
-    m,
     n::Storage,
-    prev_pers::PrevPeriods{<:nt, <:TS.AbstractRepresentativePeriod, Nothing},
+    prev_pers::PreviousPeriods{<:NothingPeriod, <:TS.AbstractRepresentativePeriod, Nothing},
     cyclic_pers::CyclicPeriods,
     modeltype::EnergyModel,
 )
@@ -235,11 +199,120 @@ function previous_level(
     return @expression(
         m,
         # Initial storage in previous rp
-        m[:stor_level][n, first(prev_pers.rp)] -
-        m[:stor_level_Δ_op][n, first(prev_pers.rp)] * duration(first(prev_pers.rp)) +
+        m[:stor_level][n, first(rep_per(prev_pers))] -
+        m[:stor_level_Δ_op][n, first(rep_per(prev_pers))] * duration(first(rep_per(prev_pers))) +
         # Increase in previous representative period
-        m[:stor_level_Δ_rp][n, prev_pers.rp]
+        m[:stor_level_Δ_rp][n, rep_per(prev_pers)]
     )
+end
+"""
+    previous_level(
+        m,
+        n::Storage{CyclicRepresentative},
+        prev_pers::PreviousPeriods{<:NothingPeriod, <:TS.AbstractRepresentativePeriod, Nothing},
+        cyclic_pers::CyclicPeriods,
+        modeltype::EnergyModel,
+    )
+
+When the previous operational period is `Nothing` and the previous representative period an
+`AbstractRepresentativePeriod` then the time structure *does* include `RepresentativePeriods`.
+
+The cyclic constraint for a [`CyclicRepresentative`](@ref) storage nodereturns the value at
+the end of the *current* representative period.
+"""
+function previous_level(
+    m,
+    n::Storage{CyclicRepresentative},
+    prev_pers::PreviousPeriods{<:NothingPeriod, <:TS.AbstractRepresentativePeriod, Nothing},
+    cyclic_pers::CyclicPeriods,
+    modeltype::EnergyModel,
+)
+    # Return the previous storage level based on cyclic constraints within the representative
+    # period
+    return @expression(m, m[:stor_level][n, last(collect(current_per(cyclic_pers)))])
+end
+"""
+    previous_level_sp(
+        m,
+        n::Storage{<:Cyclic},
+        cyclic_pers::CyclicPeriods,
+        modeltype::EnergyModel
+    )
+
+Returns the previous period in the case of the first operational period (in the first
+representative period) of a strategic period.
+
+The default functionality in the case of a [`Cyclic`](@ref) storage node in a `TimeStructure`
+without `RepresentativePeriods` returns the last operational period in the strategic period.
+"""
+function previous_level_sp(
+    m,
+    n::Storage{<:Cyclic},
+    cyclic_pers::CyclicPeriods,
+    modeltype::EnergyModel
+)
+    # Return the previous storage level based on cyclic constraints
+    last_op = last(collect(current_per(cyclic_pers)))
+    return @expression(m, m[:stor_level][n, last_op])
+end
+"""
+    previous_level_sp(
+        m,
+        n::Storage{CyclicStrategic},
+        cyclic_pers::CyclicPeriods{<:TS.AbstractRepresentativePeriod},
+        modeltype::EnergyModel,
+    )
+
+When a [`CyclicStrategic`](@ref) `Storage` node is coupled with a `TimeStructure` containing
+`RepresentativePeriods`, then the function calculates the level at the beginning of the
+first representative period through the changes in the level in the last representative
+period.
+"""
+function previous_level_sp(
+    m,
+    n::Storage{CyclicStrategic},
+    cyclic_pers::CyclicPeriods{<:TS.AbstractRepresentativePeriod},
+    modeltype::EnergyModel,
+)
+    # Extract the last representative period from the type CyclicPeriods
+    last_rp = last_per(cyclic_pers)
+
+    # Return the previous storage level based on cyclic constraints when representative
+    # periods are included
+    return @expression(
+        m,
+        # Initial storage in previous representative period
+        m[:stor_level][n, first(last_rp)] -
+        m[:stor_level_Δ_op][n, first(last_rp)] * duration(first(last_rp)) +
+        # Increase in previous representative period
+        m[:stor_level_Δ_rp][n, last_rp]
+    )
+end
+"""
+    previous_level_sp(
+        m,
+        n::Storage{CyclicRepresentative},
+        cyclic_pers::CyclicPeriods{<:TS.AbstractRepresentativePeriod},
+        modeltype::EnergyModel,
+    )
+
+When a [`CyclicRepresentative`](@ref) `Storage` node is coupled with a `TimeStructure` containing
+`RepresentativePeriods`, then the function returns the previous level as the level at the
+end of the current representative period.
+"""
+function previous_level_sp(
+    m,
+    n::Storage{CyclicRepresentative},
+    cyclic_pers::CyclicPeriods{<:TS.AbstractRepresentativePeriod},
+    modeltype::EnergyModel,
+)
+    # Extract the last operational period in the representative period from the type
+    # `CyclicPeriods`
+    last_op = last(collect(current_per(cyclic_pers)))
+
+    # Return the previous storage level based on cyclic constraints within the representative
+    # period
+    return @expression(m, m[:stor_level][n, last_op])
 end
 
 """

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -672,7 +672,7 @@ end
     @testset "Test checks - Storage" begin
 
         # Test that a wrong capacities are caught by the checks.
-        storage = RefStorage(
+        storage = RefStorage{EMB.CyclicStrategic}(
             "storage",
             FixedProfile(-10),
             FixedProfile(1e8),
@@ -683,7 +683,7 @@ end
             Dict(Power => 1),
         )
         @test_throws AssertionError simple_graph(storage)
-        storage = RefStorage(
+        storage = RefStorage{EMB.CyclicStrategic}(
             "storage",
             FixedProfile(10),
             FixedProfile(-1e8),
@@ -697,7 +697,7 @@ end
 
 
         # Test that a wrong fixed OPEX is caught by the checks.
-        storage = RefStorage(
+        storage = RefStorage{EMB.CyclicStrategic}(
             "storage",
             FixedProfile(10),
             FixedProfile(1e8),
@@ -711,7 +711,7 @@ end
 
 
         # Test that a wrong input dictionary is caught by the checks.
-        storage = RefStorage(
+        storage = RefStorage{EMB.CyclicStrategic}(
             "storage",
             FixedProfile(10),
             FixedProfile(1e8),
@@ -722,7 +722,7 @@ end
             Dict(Power => 1),
         )
         @test_throws AssertionError simple_graph(storage)
-        storage = RefStorage(
+        storage = RefStorage{EMB.CyclicStrategic}(
             "storage",
             FixedProfile(10),
             FixedProfile(1e8),
@@ -735,7 +735,7 @@ end
         @test_throws AssertionError simple_graph(storage)
 
         # Test that a wrong output dictionary is caught by the checks.
-        storage = RefStorage(
+        storage = RefStorage{EMB.CyclicStrategic}(
             "storage",
             FixedProfile(10),
             FixedProfile(1e8),
@@ -748,7 +748,7 @@ end
         @test_throws AssertionError simple_graph(storage)
 
         # Test that correct input solves the model to optimality.
-        storage = RefStorage(
+        storage = RefStorage{EMB.CyclicStrategic}(
             "storage",
             FixedProfile(10),
             FixedProfile(1e8),

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -672,7 +672,7 @@ end
     @testset "Test checks - Storage" begin
 
         # Test that a wrong capacities are caught by the checks.
-        storage = RefStorage{EMB.CyclicStrategic}(
+        storage = RefStorage{CyclicStrategic}(
             "storage",
             FixedProfile(-10),
             FixedProfile(1e8),
@@ -683,7 +683,7 @@ end
             Dict(Power => 1),
         )
         @test_throws AssertionError simple_graph(storage)
-        storage = RefStorage{EMB.CyclicStrategic}(
+        storage = RefStorage{CyclicStrategic}(
             "storage",
             FixedProfile(10),
             FixedProfile(-1e8),
@@ -697,7 +697,7 @@ end
 
 
         # Test that a wrong fixed OPEX is caught by the checks.
-        storage = RefStorage{EMB.CyclicStrategic}(
+        storage = RefStorage{CyclicStrategic}(
             "storage",
             FixedProfile(10),
             FixedProfile(1e8),
@@ -711,7 +711,7 @@ end
 
 
         # Test that a wrong input dictionary is caught by the checks.
-        storage = RefStorage{EMB.CyclicStrategic}(
+        storage = RefStorage{CyclicStrategic}(
             "storage",
             FixedProfile(10),
             FixedProfile(1e8),
@@ -722,7 +722,7 @@ end
             Dict(Power => 1),
         )
         @test_throws AssertionError simple_graph(storage)
-        storage = RefStorage{EMB.CyclicStrategic}(
+        storage = RefStorage{CyclicStrategic}(
             "storage",
             FixedProfile(10),
             FixedProfile(1e8),
@@ -735,7 +735,7 @@ end
         @test_throws AssertionError simple_graph(storage)
 
         # Test that a wrong output dictionary is caught by the checks.
-        storage = RefStorage{EMB.CyclicStrategic}(
+        storage = RefStorage{CyclicStrategic}(
             "storage",
             FixedProfile(10),
             FixedProfile(1e8),
@@ -748,7 +748,7 @@ end
         @test_throws AssertionError simple_graph(storage)
 
         # Test that correct input solves the model to optimality.
-        storage = RefStorage{EMB.CyclicStrategic}(
+        storage = RefStorage{CyclicStrategic}(
             "storage",
             FixedProfile(10),
             FixedProfile(1e8),

--- a/test/test_general.jl
+++ b/test/test_general.jl
@@ -34,7 +34,7 @@ function generate_data()
             RefStorage{AccumulatingEmissions}(6, FixedProfile(60),   FixedProfile(600), FixedProfile(9.1),
                                 FixedProfile(0), CO2, Dict(CO2 => 1, Power => 0.02), Dict(CO2 => 1),
             ),
-            RefSink(7,          OperationalProfile([20 30 40 30]),
+            RefSink(7,          OperationalProfile([20, 30, 40, 30]),
                                 Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
                                 Dict(Power => 1),
             ),

--- a/test/test_general.jl
+++ b/test/test_general.jl
@@ -134,7 +134,7 @@ end
     # Check that the objective value is properly calculated
     # - objective(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
     @test -sum((value.(m[:opex_var][n, t_inv]) + value.(m[:opex_fixed][n, t_inv])) *
-            duration(t_inv) for t_inv ∈ 𝒯ᴵⁿᵛ, n ∈ 𝒩ⁿᵒᵗ) ≈
+            duration_strat(t_inv) for t_inv ∈ 𝒯ᴵⁿᵛ, n ∈ 𝒩ⁿᵒᵗ) ≈
                 objective_value(m) atol=TEST_ATOL
 
     # Check that the inlet and outlet flowrates in the links are correctly calculated

--- a/test/test_general.jl
+++ b/test/test_general.jl
@@ -31,7 +31,7 @@ function generate_data()
                                 Dict(Power => 1),
                                 [emission_data],
             ),
-            RefStorage{EMB.AccumulatingEmissions}(6, FixedProfile(60),   FixedProfile(600), FixedProfile(9.1),
+            RefStorage{AccumulatingEmissions}(6, FixedProfile(60),   FixedProfile(600), FixedProfile(9.1),
                                 FixedProfile(0), CO2, Dict(CO2 => 1, Power => 0.02), Dict(CO2 => 1),
             ),
             RefSink(7,          OperationalProfile([20 30 40 30]),

--- a/test/test_general.jl
+++ b/test/test_general.jl
@@ -31,7 +31,7 @@ function generate_data()
                                 Dict(Power => 1),
                                 [emission_data],
             ),
-            RefStorage(6, FixedProfile(60),   FixedProfile(600), FixedProfile(9.1),
+            RefStorage{EMB.AccumulatingEmissions}(6, FixedProfile(60),   FixedProfile(600), FixedProfile(9.1),
                                 FixedProfile(0), CO2, Dict(CO2 => 1, Power => 0.02), Dict(CO2 => 1),
             ),
             RefSink(7,          OperationalProfile([20 30 40 30]),

--- a/test/test_modeltype.jl
+++ b/test/test_modeltype.jl
@@ -25,7 +25,7 @@
 
         resources = [Power, CO2]
         ops = SimpleTimes(5, 2)
-        T = TwoLevel(2, 2, ops; op_per_strat=duration(ops))
+        T = TwoLevel(2, 2, ops; op_per_strat=TS._total_duration(ops))
 
         nodes = [source, sink]
         links = [Direct(12, source, sink)]

--- a/test/test_modeltype.jl
+++ b/test/test_modeltype.jl
@@ -25,7 +25,7 @@
 
         resources = [Power, CO2]
         ops = SimpleTimes(5, 2)
-        T = TwoLevel(2, 2, ops; op_per_strat=TS._total_duration(ops))
+        T = TwoLevel(2, 2, ops; op_per_strat=10)
 
         nodes = [source, sink]
         links = [Direct(12, source, sink)]

--- a/test/test_nodes.jl
+++ b/test/test_nodes.jl
@@ -224,7 +224,7 @@
     end
 end
 
-@testset "Test RefNetworkNode with various emission variables" begin
+@testset "Test RefNetworkNode with various EmissionData" begin
     # Resources used in the analysis
     NG = ResourceEmit("NG", 0.2)
     Power = ResourceCarrier("Power", 0.0)
@@ -371,7 +371,7 @@ end
         # Check that the total and strategic emissions are correctly calculated
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype, data::EmissionsEnergy)
         @test sum(value.(m[:emissions_node][net, t, CO2]) ≈
-                sum(value.(m[:flow_in][net, t, p]) * EMB.co2_int(p) for p ∈ inputs(net))
+                sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net))
                 for t ∈ 𝒯, atol=TEST_ATOL) ≈
                     length(𝒯)
         @test sum(value.(m[:emissions_node][net, t, NG]) ≈ 0
@@ -406,7 +406,7 @@ end
         # Check that the total and strategic emissions are correctly calculated
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype, data::EmissionsProcess)
         @test sum(value.(m[:emissions_node][net, t, CO2]) ≈
-                sum(value.(m[:flow_in][net, t, p]) * EMB.co2_int(p) for p ∈ inputs(net)) +
+                sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) +
                 value.(m[:cap_use][net, t]) * process_emissions(em_data, CO2, t)
                 for t ∈ 𝒯, atol=TEST_ATOL) ≈
                     length(𝒯)
@@ -443,7 +443,7 @@ end
         # Check that the total and strategic emissions are correctly calculated
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype, data::EmissionsProcess)
         @test sum(value.(m[:emissions_node][net, t, CO2]) ≈
-                sum(value.(m[:flow_in][net, t, p]) * EMB.co2_int(p) for p ∈ inputs(net)) +
+                sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) +
                 value.(m[:cap_use][net, t]) * process_emissions(em_data, CO2, t)
                 for t ∈ 𝒯, atol=TEST_ATOL) ≈
                     length(𝒯)
@@ -480,8 +480,8 @@ end
         # Check that the total and strategic emissions are correctly calculated
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
         @test sum(value.(m[:emissions_node][net, t, CO2]) ≈
-                sum(value.(m[:flow_in][net, t, p]) * EMB.co2_int(p) for p ∈ inputs(net)) *
-                (1 - EMB.co2_capture(em_data)) +
+                sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) *
+                (1 - co2_capture(em_data)) +
                 value.(m[:cap_use][net, t]) * process_emissions(em_data, CO2, t)
                 for t ∈ 𝒯, atol=TEST_ATOL) ≈
                     length(𝒯) atol=TEST_ATOL
@@ -493,8 +493,8 @@ end
         # Test that the CO2 capture is calculated correctly
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
         @test sum(value.(m[:flow_out][net, t, CO2]) ≈
-                sum(value.(m[:flow_in][net, t, p]) * EMB.co2_int(p) for p ∈ inputs(net)) *
-                EMB.co2_capture(em_data) for t ∈ 𝒯, atol=TEST_ATOL) ≈
+                sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) *
+                co2_capture(em_data) for t ∈ 𝒯, atol=TEST_ATOL) ≈
                     length(𝒯) atol=TEST_ATOL
     end
 
@@ -525,9 +525,9 @@ end
         # Check that the total and strategic emissions are correctly calculated
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
         @test sum(value.(m[:emissions_node][net, t, CO2]) ≈
-                sum(value.(m[:flow_in][net, t, p]) * EMB.co2_int(p) for p ∈ inputs(net)) +
+                sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) +
                 value.(m[:cap_use][net, t]) * process_emissions(em_data, CO2, t) *
-                (1 - EMB.co2_capture(em_data))
+                (1 - co2_capture(em_data))
                 for t ∈ 𝒯, atol=TEST_ATOL) ≈
                     length(𝒯) atol=TEST_ATOL
         @test sum(value.(m[:emissions_node][net, t, NG]) ≈
@@ -539,7 +539,7 @@ end
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
         @test sum(value.(m[:flow_out][net, t, CO2]) ≈
                 value.(m[:cap_use][net, t]) * process_emissions(em_data, CO2, t) *
-                EMB.co2_capture(em_data) for t ∈ 𝒯, atol=TEST_ATOL) ≈
+                co2_capture(em_data) for t ∈ 𝒯, atol=TEST_ATOL) ≈
                     length(𝒯) atol=TEST_ATOL
     end
 
@@ -570,9 +570,9 @@ end
         # Check that the total and strategic emissions are correctly calculated
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
         @test sum(value.(m[:emissions_node][net, t, CO2]) ≈
-                (sum(value.(m[:flow_in][net, t, p]) * EMB.co2_int(p) for p ∈ inputs(net)) +
+                (sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) +
                 value.(m[:cap_use][net, t]) * process_emissions(em_data, CO2, t)) *
-                (1 - EMB.co2_capture(em_data))
+                (1 - co2_capture(em_data))
                 for t ∈ 𝒯, atol=TEST_ATOL) ≈
                     length(𝒯) atol=TEST_ATOL
         @test sum(value.(m[:emissions_node][net, t, NG]) ≈
@@ -583,14 +583,14 @@ end
         # Test that the CO2 capture is calculated correctly
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
         @test sum(value.(m[:flow_out][net, t, CO2]) ≈
-                (sum(value.(m[:flow_in][net, t, p]) * EMB.co2_int(p) for p ∈ inputs(net)) +
+                (sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) +
                 value.(m[:cap_use][net, t]) * process_emissions(em_data, CO2, t)) *
-                EMB.co2_capture(em_data) for t ∈ 𝒯, atol=TEST_ATOL) ≈
+                co2_capture(em_data) for t ∈ 𝒯, atol=TEST_ATOL) ≈
                     length(𝒯) atol=TEST_ATOL
     end
 end
 
-@testset "Test RefStorage{<:ResourceCarrier}" begin
+@testset "Test RefStorage{CyclicStrategic}" begin
     # Resources used in the analysis
     Power = ResourceCarrier("Power", 0.0)
     aux = ResourceCarrier("aux", 0.0)
@@ -614,7 +614,306 @@ end
             FixedProfile(0),
             Dict(aux => 1),
         )
-        storage = RefStorage{EMB.CyclicStrategic}(
+        storage = RefStorage{CyclicStrategic}(
+            "storage",
+            FixedProfile(10),
+            FixedProfile(1e8),
+            FixedProfile(10),
+            FixedProfile(2),
+            Power,
+            Dict(Power => 1, aux => 0.05),
+            Dict(Power => 1),
+        )
+
+        sink = RefSink(
+            "sink",
+            demand,
+            Dict(:surplus => FixedProfile(4), :deficit => FixedProfile(1000)),
+            Dict(Power => 1),
+        )
+
+        op_per_strat = TS._total_duration(ops)
+        T = TwoLevel(2, 2, ops; op_per_strat)
+
+        nodes = [source, aux_source, storage, sink]
+        links = [
+            Direct(13, source, storage)
+            Direct(23, aux_source, storage)
+            Direct(34, storage, sink)
+            ]
+        resources = [Power, aux, CO2]
+
+        model = OperationalModel(
+            Dict(CO2 => FixedProfile(100)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2
+        )
+        case = Dict(
+                    :T => T,
+                    :nodes => nodes,
+                    :links => links,
+                    :products => resources,
+        )
+        return run_model(case, model, HiGHS.Optimizer), case, model
+    end
+
+    # General tests function
+    function general_tests(m, case, model)
+
+        # Extract the data
+        𝒯    = case[:T]
+        𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+        𝒩    = case[:nodes]
+        stor = 𝒩[3]
+        sink = 𝒩[4]
+
+        # Test that the capacity is correctly limited
+        # - constraints_capacity(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
+        @test sum(value.(m[:stor_level][stor, t]) - value.(m[:stor_cap_inst][stor, t])
+                     ≤ TEST_ATOL for t ∈ 𝒯) ≈
+                        length(𝒯) atol=TEST_ATOL
+        @test sum(value.(m[:stor_rate_use][stor, t]) - value.(m[:stor_rate_inst][stor, t])
+                     ≤ TEST_ATOL for t ∈ 𝒯) ≈
+                        length(𝒯) atol=TEST_ATOL
+
+        # Test that the design for rate usage is correct
+        # - constraints_flow_in(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
+        @test sum(value.(m[:flow_in][stor, t, Power]) ≈ value.(m[:stor_rate_use][stor, t])
+                    for t ∈ 𝒯, atol=TEST_ATOL) ≈
+                        length(𝒯) atol=TEST_ATOL
+        @test sum(value.(m[:flow_in][stor, t, aux]) ≈
+                    value.(m[:stor_rate_use][stor, t]) * inputs(stor, aux)
+                    for t ∈ 𝒯, atol=TEST_ATOL) ≈
+                        length(𝒯) atol=TEST_ATOL
+
+        # Test that the inlet flow is equivalent to the total usage of the demand
+        @test sum(value.(m[:stor_rate_use][stor, t]) * duration(t) * multiple(t) for t ∈ 𝒯) ≈
+                sum(value.(m[:cap_use][sink,t]) * duration(t) * multiple(t)  for t ∈ 𝒯) atol=TEST_ATOL
+
+        # Test that the total inlet flow is equivalent to the total outlet flow rate
+        @test sum(value.(m[:flow_in][stor, t, Power]) * duration(t) * multiple(t)  for t ∈ 𝒯) ≈
+                sum(value.(m[:flow_out][stor, t, Power]) * duration(t) * multiple(t)  for t ∈ 𝒯)  atol=TEST_ATOL
+
+
+        # Test that the Δ in the storage level is correctly calculated
+        # - constraints_level_aux(m, n::Storage, 𝒯, 𝒫, modeltype::EnergyModel)
+        @test sum(value.(value.(m[:stor_level_Δ_op][stor, t])) ≈
+                value.(m[:flow_in][stor, t, Power]) - value.(m[:flow_out][stor, t, Power])
+                    for t ∈ 𝒯, atol=TEST_ATOL) ≈
+                        length(𝒯) atol=TEST_ATOL
+
+    end
+
+    @testset "SimpleTimes without storage" begin
+
+        # Run the model and extract the data
+        m, case, model = simple_graph()
+        𝒯    = case[:T]
+        𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+        𝒩    = case[:nodes]
+        stor = 𝒩[3]
+        cap = EMB.capacity(stor)
+
+        # Run the general tests
+        general_tests(m, case, model);
+
+        # Test that we get the proper parameteric type
+        @test typeof(stor) <: RefStorage{CyclicStrategic}
+
+        # Test that the capacity is correctly limited
+        # - constraints_capacity_installed(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
+        @test sum(value.(m[:stor_cap_inst][stor, t]) ≈ cap.level[t]
+                    for t ∈ 𝒯, atol=TEST_ATOL) ≈
+                        length(𝒯) atol=TEST_ATOL
+        @test sum(value.(m[:stor_rate_inst][stor, t]) ≈ cap.rate[t]
+                    for t ∈ 𝒯, atol=TEST_ATOL) ≈
+                        length(𝒯) atol=TEST_ATOL
+
+        # Test that the input flow is equal to the output flow in the standard scenario as
+        # storage does not pay off
+        # - constraints_level_aux(m, n::Storage, 𝒯, 𝒫, modeltype::EnergyModel)
+        @test sum(value.(m[:stor_level_Δ_op][stor, t]) ≈ 0 for t ∈ 𝒯, atol=TEST_ATOL) ≈
+                length(𝒯) atol=TEST_ATOL
+
+        # Test that the fixed OPEX is correctly calculated
+        # - constraints_opex_fixed(m, n::Storage, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
+        @test sum(value.(m[:opex_fixed][stor, t_inv]) ≈
+                EMB.opex_fixed(stor, t_inv) * value.(m[:stor_cap_inst][stor, first(t_inv)])
+                    for t_inv ∈ 𝒯ᴵⁿᵛ, atol=TEST_ATOL) ≈
+                length(𝒯ᴵⁿᵛ) atol=TEST_ATOL
+
+        # Test that variable OPEX is correctly calculated
+        # - constraints_opex_var(m, n::Storage, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
+        @test sum(value.(m[:opex_var][stor, t_inv]) ≈
+                sum(EMB.opex_var(stor, t_inv) * value.(m[:flow_in][stor, t, Power]) *
+                    duration(t) for t ∈ t_inv)
+                for t_inv ∈ 𝒯ᴵⁿᵛ, atol=TEST_ATOL) ≈
+                length(𝒯ᴵⁿᵛ) atol=TEST_ATOL
+    end
+
+    @testset "SimpleTimes with storage" begin
+
+        # Run the model and extract the data
+        m, case, model = simple_graph(demand=OperationalProfile([10, 15, 5, 15, 5]))
+        𝒯    = case[:T]
+        𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+        𝒩    = case[:nodes]
+        stor = 𝒩[3]
+        cap = EMB.capacity(stor)
+
+        # Run the general tests
+        general_tests(m, case, model);
+
+        # All the tests following are for the function, its individual methods, and the
+        # called functions within the function.
+        # constraints_level_iterate(
+        #     m,
+        #     n::Storage,
+        #     prev_pers::PreviousPeriods,
+        #     cyclic_pers::CyclicPeriods,
+        #     per,
+        #     _::,
+        #     modeltype::EnergyModel,
+        # )
+        # Test that the level balance is correct for standard periods (6 times)
+        @test sum(sum(value.(m[:stor_level][stor, t]) ≈
+                    value.(m[:stor_level][stor, t_prev]) +
+                    value.(m[:stor_level_Δ_op][stor, t]) * duration(t)
+                    for (t_prev, t) ∈ withprev(t_inv) if !isnothing(t_prev))
+                    for t_inv ∈ 𝒯ᴵⁿᵛ, atol=TEST_ATOL) ≈
+                        length(𝒯)-2 atol=TEST_ATOL
+
+        # Test that the level balance is correct in the first period (2 times)
+        @test sum(sum(value.(m[:stor_level][stor, t]) ≈
+                    value.(m[:stor_level][stor, last(collect(t_inv))]) +
+                    value.(m[:stor_level_Δ_op][stor, t]) * duration(t)
+                    for (t_prev, t) ∈ withprev(t_inv) if isnothing(t_prev))
+                    for t_inv ∈ 𝒯ᴵⁿᵛ, atol=TEST_ATOL) ≈
+                        2 atol=TEST_ATOL
+
+        # Test that the level is 0 exactly 4 times
+        @test sum(value.(m[:stor_level][stor, t]) ≈ 0 for t ∈ 𝒯, atol=TEST_ATOL) == 4
+    end
+
+    @testset "RepresentativePeriods with storage" begin
+
+        # Run the model and extract the data
+        op_profile_1 = FixedProfile(0)
+        op_profile_2 = FixedProfile(20)
+        demand = RepresentativeProfile([op_profile_1, op_profile_2])
+
+        op_1 = SimpleTimes(100, 2)
+        op_2 = SimpleTimes(800, 2)
+
+        ops = RepresentativePeriods(2, 8760, [.5, .5], [op_1, op_2])
+
+        m, case, model = simple_graph(ops=ops, demand=demand)
+
+        𝒯    = case[:T]
+        𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+        𝒩    = case[:nodes]
+        stor = 𝒩[3]
+        cap = EMB.capacity(stor)
+
+        # Run the general tests
+        general_tests(m, case, model);
+
+        # All the tests following are for the function, its individual methods, and the
+        # called functions within the function.
+        # constraints_level_iterate(
+        #     m,
+        #     n::Storage,
+        #     prev_pers::PreviousPeriods,
+        #     cyclic_pers::CyclicPeriods,
+        #     per,
+        #     _::,
+        #     modeltype::EnergyModel,
+        # )
+        for t_inv ∈ 𝒯ᴵⁿᵛ
+            𝒯ʳᵖ = repr_periods(t_inv)
+            for (t_rp_prev, t_rp) ∈ withprev(𝒯ʳᵖ), (t_prev, t) ∈ withprev(t_rp)
+                if isnothing(t_rp_prev) && isnothing(t_prev)
+                    # Test for the correct accounting in the first operational period of the
+                    # first representative period of a strategic period
+                    t_rp_last = last(𝒯ʳᵖ)
+                    @test value.(m[:stor_level][stor, t]) ≈
+                            value.(m[:stor_level][stor, first(t_rp_last)]) -
+                            value.(m[:stor_level_Δ_op][stor, first(t_rp_last)]) *
+                                duration(first(t_rp_last)) +
+                            value.(m[:stor_level_Δ_rp][stor, t_rp_last]) +
+                            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) atol=TEST_ATOL
+
+                    @test value.(m[:stor_level][stor, t]) -
+                            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) ≥
+                            -TEST_ATOL
+
+                    @test value.(m[:stor_level][stor, t]) -
+                            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) ≤
+                            value.(m[:stor_cap_inst][stor, t]) + TEST_ATOL
+
+                elseif isnothing(t_prev)
+                    # Test for the correct accounting in the first operational period of the
+                    # other representative periods of a strategic period
+                    @test value.(m[:stor_level][stor, t]) ≈
+                            value.(m[:stor_level][stor, first(t_rp_prev)]) -
+                            value.(m[:stor_level_Δ_op][stor, first(t_rp_prev)]) *
+                                duration(first(t_rp_prev)) +
+                            value.(m[:stor_level_Δ_rp][stor, t_rp_prev]) +
+                            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) atol=TEST_ATOL
+
+                    @test value.(m[:stor_level][stor, t]) -
+                            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) ≥
+                            -TEST_ATOL
+
+                    @test value.(m[:stor_level][stor, t]) -
+                            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) ≤
+                            value.(m[:stor_cap_inst][stor, t]) + TEST_ATOL
+                end
+            end
+        end
+        # Test for the correct accounting in all other operational periods
+        @test sum(value.(m[:stor_level][stor, t]) ≈
+                value.(m[:stor_level][stor, t_prev]) +
+                value.(m[:stor_level_Δ_op][stor, t]) * duration(t)
+                for (t_prev, t) ∈ withprev(𝒯), atol= TEST_ATOL if !isnothing(t_prev)) ≈
+                    length(𝒯) - length(𝒯ᴵⁿᵛ) * ops.len atol= TEST_ATOL
+
+        # Check that there is no outflow in the first representative period of each
+        # strategic period as the demand is set to 0, and larger than 0 in the second
+        # representative period
+        @test sum(value.(m[:flow_out][stor, t, Power]) ≈ 0 for t ∈ 𝒯) ≈
+            length(𝒯ᴵⁿᵛ)*length(op_1)
+        @test sum(value.(m[:flow_out][stor, t, Power]) > 0 for t ∈ 𝒯) ≈
+            length(𝒯ᴵⁿᵛ)*length(op_2)
+    end
+end
+
+
+@testset "Test RefStorage{CyclicRepresentative}" begin
+    # Resources used in the analysis
+    Power = ResourceCarrier("Power", 0.0)
+    aux = ResourceCarrier("aux", 0.0)
+    CO2 = ResourceEmit("CO2", 1.0)
+
+    # Function for setting up the system
+    function simple_graph(;ops=SimpleTimes(5, 2), demand=FixedProfile(10))
+
+        # Used source, network, and sink
+        source = RefSource(
+            "source",
+            FixedProfile(10),
+            FixedProfile(10),
+            FixedProfile(0),
+            Dict(Power => 1),
+        )
+        aux_source = RefSource(
+            "aux",
+            FixedProfile(10),
+            FixedProfile(10),
+            FixedProfile(0),
+            Dict(aux => 1),
+        )
+        storage = RefStorage{CyclicRepresentative}(
             "storage",
             FixedProfile(10),
             FixedProfile(1e8),
@@ -695,9 +994,8 @@ end
         @test sum(value.(m[:flow_in][stor, t, Power]) * duration(t) * multiple(t)  for t ∈ 𝒯) ≈
                 sum(value.(m[:flow_out][stor, t, Power]) * duration(t) * multiple(t)  for t ∈ 𝒯)  atol=TEST_ATOL
 
-
-        # Test that the Δ in the storage level is correctly calculated
-        # - constraints_level_aux(m, n::RefStorage{T}, 𝒯, modeltype::EnergyModel) where {S<:ResourceCarrier}
+        # Test that the Δ_op in the storage level is correctly calculated
+        # - constraints_level_aux(m, n::RefStorage, 𝒯, modeltype::EnergyModel)
         @test sum(value.(value.(m[:stor_level_Δ_op][stor, t])) ≈
                 value.(m[:flow_in][stor, t, Power]) - value.(m[:flow_out][stor, t, Power])
                     for t ∈ 𝒯, atol=TEST_ATOL) ≈
@@ -719,7 +1017,7 @@ end
         general_tests(m, case, model);
 
         # Test that we get the proper parameteric type
-        @test typeof(stor) <: RefStorage{EMB.CyclicStrategic}
+        @test typeof(stor) <: EMB.Storage{CyclicRepresentative}
 
         # Test that the capacity is correctly limited
         # - constraints_capacity_installed(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
@@ -765,14 +1063,17 @@ end
         # Run the general tests
         general_tests(m, case, model);
 
-        # All the tests following are for the function
-        # - constraints_level_sp(
-        #       m,
-        #       n::RefStorage{S},
-        #       t_inv::TS.StrategicPeriod{T, U},
-        #       𝒫,
-        #       modeltype::EnergyModel
-        #       ) where {S<:ResourceCarrier, T, U<:SimpleTimes}
+        # All the tests following are for the function, its individual methods, and the
+        # caleed functions within the function.
+        # function constraints_level_iterate(
+        #     m,
+        #     n::Storage,
+        #     prev_pers::PreviousPeriods,
+        #     cyclic_pers::CyclicPeriods,
+        #     per,
+        #     _::,
+        #     modeltype::EnergyModel,
+        # )
 
         # Test that the level balance is correct for standard periods (6 times)
         @test sum(sum(value.(m[:stor_level][stor, t]) ≈
@@ -797,12 +1098,12 @@ end
     @testset "RepresentativePeriods with storage" begin
 
         # Run the model and extract the data
-        op_profile_1 = FixedProfile(0)
-        op_profile_2 = FixedProfile(20)
+        op_profile_1 = OperationalProfile([15, 5, 15, 5, 15, 5, 15, 5, 15, 5])
+        op_profile_2 = OperationalProfile([20, 20, 0, 0, 20, 0, 20, 0, 20, 0])
         demand = RepresentativeProfile([op_profile_1, op_profile_2])
 
-        op_1 = SimpleTimes(100, 2)
-        op_2 = SimpleTimes(800, 2)
+        op_1 = SimpleTimes(10, 2)
+        op_2 = SimpleTimes(10, 2)
 
         ops = RepresentativePeriods(2, 8760, [.5, .5], [op_1, op_2])
 
@@ -810,6 +1111,7 @@ end
 
         𝒯    = case[:T]
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+        𝒯ʳᵖ = repr_periods(𝒯)
         𝒩    = case[:nodes]
         stor = 𝒩[3]
         cap = EMB.capacity(stor)
@@ -817,53 +1119,48 @@ end
         # Run the general tests
         general_tests(m, case, model);
 
-        # All the tests following er for the function
-        # - constraints_level_sp(
-        #       m,
-        #       n::RefStorage{S},
-        #       t_inv::TS.StrategicPeriod{T, RepresentativePeriods{U, T, SimpleTimes{T}}},
-        #       𝒫,
-        #       modeltype::EnergyModel
-        #       ) where {S<:ResourceCarrier, T, U}
+        # Test that the Δ_rp in the storage level is correctly fixed to 0
+        # - constraints_level_rp(m, n::Storage, per, modeltype::EnergyModel)
+        @test sum(value.(value.(m[:stor_level_Δ_rp][stor, t_rp])) ≈ 0
+                    for t_rp ∈ 𝒯ʳᵖ, atol=TEST_ATOL) ≈
+                        length(𝒯ʳᵖ) atol=TEST_ATOL
+
+        # All the tests following are for the function, its individual methods, and the
+        # caleed functions within the function.
+        # function constraints_level_iterate(
+        #     m,
+        #     n::Storage,
+        #     prev_pers::PreviousPeriods,
+        #     cyclic_pers::CyclicPeriods,
+        #     per,
+        #     _::,
+        #     modeltype::EnergyModel,
+        # )
+
+        # Test that the level for starting a representative period is not required to be the
+        # same in the different representative periods
+        first_rp = [first(t_rp) for t_rp ∈ 𝒯ʳᵖ]
+        @test sum(
+            value.(m[:stor_level][stor, t]) -
+            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) ≈ 10
+            for t ∈ first_rp, atol = TEST_ATOL) ≈
+                length(𝒯ᴵⁿᵛ)  atol = TEST_ATOL
+        @test sum(
+            value.(m[:stor_level][stor, t]) -
+            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) ≈ 40
+            for t ∈ first_rp, atol = TEST_ATOL) ≈
+                length(𝒯ᴵⁿᵛ)  atol = TEST_ATOL
+
+
         for t_inv ∈ 𝒯ᴵⁿᵛ
             𝒯ʳᵖ = repr_periods(t_inv)
             for (t_rp_prev, t_rp) ∈ withprev(𝒯ʳᵖ), (t_prev, t) ∈ withprev(t_rp)
-                if isnothing(t_rp_prev) && isnothing(t_prev)
-                    # Test for the correct accounting in the first operational period of the
-                    # first representative period of a strategic period
-                    t_rp_last = last(𝒯ʳᵖ)
+
+                if isnothing(t_prev)
+                    # Test for the linking between the first and the last operational period
                     @test value.(m[:stor_level][stor, t]) ≈
-                            value.(m[:stor_level][stor, first(t_rp_last)]) -
-                            value.(m[:stor_level_Δ_op][stor, first(t_rp_last)]) *
-                                duration(first(t_rp_last)) +
-                            value.(m[:stor_level_Δ_rp][stor, t_rp_last]) +
+                            value.(m[:stor_level][stor, last(collect(t_rp))]) +
                             value.(m[:stor_level_Δ_op][stor, t]) * duration(t) atol=TEST_ATOL
-
-                    @test value.(m[:stor_level][stor, t]) -
-                            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) ≥
-                            -TEST_ATOL
-
-                    @test value.(m[:stor_level][stor, t]) -
-                            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) ≤
-                            value.(m[:stor_cap_inst][stor, t]) + TEST_ATOL
-
-                elseif isnothing(t_prev)
-                    # Test for the correct accounting in the first operational period of the
-                    # other representative periods of a strategic period
-                    @test value.(m[:stor_level][stor, t]) ≈
-                            value.(m[:stor_level][stor, first(t_rp_prev)]) -
-                            value.(m[:stor_level_Δ_op][stor, first(t_rp_prev)]) *
-                                duration(first(t_rp_prev)) +
-                            value.(m[:stor_level_Δ_rp][stor, t_rp_prev]) +
-                            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) atol=TEST_ATOL
-
-                    @test value.(m[:stor_level][stor, t]) -
-                            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) ≥
-                            -TEST_ATOL
-
-                    @test value.(m[:stor_level][stor, t]) -
-                            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) ≤
-                            value.(m[:stor_cap_inst][stor, t]) + TEST_ATOL
                 end
             end
         end
@@ -871,20 +1168,13 @@ end
         @test sum(value.(m[:stor_level][stor, t]) ≈
                 value.(m[:stor_level][stor, t_prev]) +
                 value.(m[:stor_level_Δ_op][stor, t]) * duration(t)
-                for (t_prev, t) ∈ withprev(𝒯), atol= TEST_ATOL if !isnothing(t_prev)) ≈
-                    length(𝒯) - length(𝒯ᴵⁿᵛ) * ops.len atol= TEST_ATOL
+                for (t_prev, t) ∈ withprev(𝒯), atol = TEST_ATOL if !isnothing(t_prev)) ≈
+                    length(𝒯) - length(𝒯ᴵⁿᵛ) * ops.len atol = TEST_ATOL
 
-        # Check that there is no outflow in the first representative period of each
-        # strategic period as the demand is set to 0, and larger than 0 in the second
-        # representative period
-        @test sum(value.(m[:flow_out][stor, t, Power]) ≈ 0 for t ∈ 𝒯) ≈
-            length(𝒯ᴵⁿᵛ)*length(op_1)
-        @test sum(value.(m[:flow_out][stor, t, Power]) > 0 for t ∈ 𝒯) ≈
-            length(𝒯ᴵⁿᵛ)*length(op_2)
     end
 end
 
-@testset "Test RefStorage{<:ResourceEmit}" begin
+@testset "Test RefStorage{AccumulatingEmissions}" begin
     # Resources used in the analysis
     NG = ResourceEmit("NG", 0.2)
     Power = ResourceCarrier("Power", 0.0)
@@ -913,7 +1203,7 @@ end
             Dict(Power => 1, CO2 => 0),
             [em_data]
         )
-        storage = RefStorage{EMB.AccumulatingEmissions}(
+        storage = RefStorage{AccumulatingEmissions}(
             "storage",
             FixedProfile(10),
             FixedProfile(stor_cap),
@@ -985,14 +1275,14 @@ end
                         length(𝒯) atol=TEST_ATOL
 
         # Test that the Δ in the storage level is correctly calculated
-        # - constraints_level_aux(m, n::RefStorage{T}, 𝒯, modeltype::EnergyModel) where {S<:ResourceEmit}
+        # - constraints_level_aux(m, n::RefStorage{AccumulatingEmissions}, 𝒯, 𝒫, modeltype::EnergyModel)
         @test sum(value.(value.(m[:stor_level_Δ_op][stor, t])) ≈
                 value.(m[:flow_in][stor, t, CO2]) - value.(m[:emissions_node][stor, t, CO2])
                     for t ∈ 𝒯, atol=TEST_ATOL) ≈
                         length(𝒯) atol=TEST_ATOL
 
         # Test that the Δ in the storage level is larger than 0
-        # - constraints_level_aux(m, n::RefStorage{T}, 𝒯, modeltype::EnergyModel) where {S<:ResourceEmit}
+        # - constraints_level_aux(m, n::RefStorage{AccumulatingEmissions}, 𝒯, 𝒫, modeltype::EnergyModel)
         @test sum(value.(value.(m[:stor_level_Δ_op][stor, t])) ≥ -TEST_ATOL
                 for t ∈ 𝒯) ≈
                     length(𝒯) atol=TEST_ATOL
@@ -1016,7 +1306,7 @@ end
         general_tests(m, case, model);
 
         # Test that we get the proper parameteric type
-        @test typeof(stor) <: RefStorage{EMB.AccumulatingEmissions}
+        @test typeof(stor) <: RefStorage{AccumulatingEmissions}
 
         # Test that the capacity is correctly limited
         # - constraints_capacity_installed(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
@@ -1028,20 +1318,20 @@ end
                         length(𝒯) atol=TEST_ATOL
 
         # Test that the input flow is equal to the emissions as the limit allows it
-        # - constraints_level_aux(m, n::RefStorage{S}, 𝒯, 𝒫, modeltype::EnergyModel) where {S<:ResourceEmit}
+        # - constraints_level_aux(m, n::RefStorage{AccumulatingEmissions}, 𝒯, 𝒫, modeltype::EnergyModel)
         @test sum(value.(m[:flow_in][stor, t, CO2]) ≈ value.(m[:emissions_node][stor, t, CO2])
                 for t ∈ 𝒯, atol=TEST_ATOL) ≈
                     length(𝒯) atol=TEST_ATOL
 
         # Test that the fixed OPEX is correctly calculated
-        # - function constraints_opex_fixed(m, n::Storage, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
+        # - constraints_opex_fixed(m, n::Storage{AccumulatingEmissions}, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
         @test sum(value.(m[:opex_fixed][stor, t_inv]) ≈
                 EMB.opex_fixed(stor, t_inv) * value.(m[:stor_rate_inst][stor, first(t_inv)])
                     for t_inv ∈ 𝒯ᴵⁿᵛ, atol=TEST_ATOL) ≈
                 length(𝒯ᴵⁿᵛ) atol=TEST_ATOL
 
         # Test that variable OPEX is correctly calculated
-        # - function constraints_opex_var(m, n::Storage, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
+        # - constraints_opex_var(m, n::Storage{AccumulatingEmissions}, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
         @test sum(value.(m[:opex_var][stor, t_inv]) ≈ 0
                 for t_inv ∈ 𝒯ᴵⁿᵛ, atol=TEST_ATOL) ≈
                 length(𝒯ᴵⁿᵛ) atol=TEST_ATOL
@@ -1070,15 +1360,18 @@ end
                 for t_inv ∈ 𝒯ᴵⁿᵛ, atol=TEST_ATOL) ≈
                 length(𝒯ᴵⁿᵛ) atol=TEST_ATOL
 
-        # All the tests following er for the function
-        # - constraints_level_sp(
-        #       m,
-        #       n::RefStorage{S},
-        #       t_inv::TS.StrategicPeriod{T, U},
-        #       𝒫,
-        #       modeltype::EnergyModel
-        #       ) where {S<:ResourceCarrier, T, U<:SimpleTimes}
 
+        # All the tests following are for the function, its individual methods, and the
+        # called functions within the function.
+        # constraints_level_iterate(
+        #     m,
+        #     n::Storage,
+        #     prev_pers::PreviousPeriods,
+        #     cyclic_pers::CyclicPeriods,
+        #     per,
+        #     _::,
+        #     modeltype::EnergyModel,
+        # )
         # Test that the level balance is correct for standard periods (6 times)
         @test sum(sum(value.(m[:stor_level][stor, t]) ≈
                     value.(m[:stor_level][stor, t_prev]) +
@@ -1116,14 +1409,18 @@ end
         # Run the general tests
         general_tests(m, case, model);
 
-        # All the tests following er for the function
-        # - constraints_level_sp(
-        #       m,
-        #       n::RefStorage{S},
-        #       t_inv::TS.StrategicPeriod{T, RepresentativePeriods{U, T, SimpleTimes{T}}},
-        #       𝒫,
-        #       modeltype::EnergyModel
-        #       ) where {S<:ResourceCarrier, T, U}
+
+        # All the tests following are for the function, its individual methods, and the
+        # called functions within the function.
+        # constraints_level_iterate(
+        #     m,
+        #     n::Storage,
+        #     prev_pers::PreviousPeriods,
+        #     cyclic_pers::CyclicPeriods,
+        #     per,
+        #     _::,
+        #     modeltype::EnergyModel,
+        # )
         for t_inv ∈ 𝒯ᴵⁿᵛ
             𝒯ʳᵖ = repr_periods(t_inv)
             for (t_rp_prev, t_rp) ∈ withprev(𝒯ʳᵖ), (t_prev, t) ∈ withprev(t_rp)

--- a/test/test_nodes.jl
+++ b/test/test_nodes.jl
@@ -1424,8 +1424,9 @@ end
                         length(𝒯) atol=TEST_ATOL
 
         # Test that the design for rate usage is correct
-        # - constraints_flow_in(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(value.(m[:flow_in][stor, t, CO2]) ≈ value.(m[:stor_rate_use][stor, t])
+        # - constraints_flow_in(m, n::Storage{AccumulatingEmissions}, 𝒯::TimeStructure, modeltype::EnergyModel)
+        @test sum(value.(m[:flow_in][stor, t, CO2]) ≈
+                    value.(m[:stor_rate_use][stor, t]) + value.(m[:emissions_node][stor, t, CO2])
                     for t ∈ 𝒯, atol=TEST_ATOL) ≈
                         length(𝒯) atol=TEST_ATOL
 
@@ -1446,7 +1447,7 @@ end
 
     @testset "SimpleTimes without storage" begin
         # This test set is related to the approach of emissions in the storage node.
-        # In practice, a RefStorage{<:ResourceEmit} is also designed to act as an emission source
+        # In practice, a RefStorage{AccumulatingEmissions} is also designed to act as an emission source
         # This is currently not well implemented, but will be adjusted in a later stage,
 
         # Run the model and extract the data

--- a/test/test_nodes.jl
+++ b/test/test_nodes.jl
@@ -10,7 +10,7 @@
 
         resources = [Power, CO2]
         ops = SimpleTimes(5, 2)
-        op_per_strat = duration(ops)
+        op_per_strat = TS._total_duration(ops)
         T = TwoLevel(2, 2, ops; op_per_strat)
 
         nodes = [source, sink]
@@ -275,7 +275,7 @@ end
 
         resources = [NG, Power, CO2]
         ops = SimpleTimes(5, 2)
-        op_per_strat = duration(ops)
+        op_per_strat = TS._total_duration(ops)
         T = TwoLevel(2, 2, ops; op_per_strat)
 
         nodes = [source, network, sink]
@@ -632,7 +632,7 @@ end
             Dict(Power => 1),
         )
 
-        op_per_strat = duration(ops)
+        op_per_strat = TS._total_duration(ops)
         T = TwoLevel(2, 2, ops; op_per_strat)
 
         nodes = [source, aux_source, storage, sink]
@@ -931,7 +931,7 @@ end
             Dict(Power => 1),
         )
 
-        op_per_strat = duration(ops)
+        op_per_strat = TS._total_duration(ops)
         T = TwoLevel(2, 2, ops; op_per_strat)
 
         nodes = [source, network, storage, sink]

--- a/test/test_nodes.jl
+++ b/test/test_nodes.jl
@@ -10,7 +10,7 @@
 
         resources = [Power, CO2]
         ops = SimpleTimes(5, 2)
-        op_per_strat = TS._total_duration(ops)
+        op_per_strat = 10
         T = TwoLevel(2, 2, ops; op_per_strat)
 
         nodes = [source, sink]
@@ -275,7 +275,7 @@ end
 
         resources = [NG, Power, CO2]
         ops = SimpleTimes(5, 2)
-        op_per_strat = TS._total_duration(ops)
+        op_per_strat = 10
         T = TwoLevel(2, 2, ops; op_per_strat)
 
         nodes = [source, network, sink]
@@ -597,7 +597,7 @@ end
     CO2 = ResourceEmit("CO2", 1.0)
 
     # Function for setting up the system
-    function simple_graph(;ops=SimpleTimes(5, 2), demand=FixedProfile(10))
+    function simple_graph(;ops=SimpleTimes(5, 2), op_per_strat=10, demand=FixedProfile(10))
 
         # Used source, network, and sink
         source = RefSource(
@@ -632,7 +632,6 @@ end
             Dict(Power => 1),
         )
 
-        op_per_strat = TS._total_duration(ops)
         T = TwoLevel(2, 2, ops; op_per_strat)
 
         nodes = [source, aux_source, storage, sink]
@@ -754,7 +753,7 @@ end
     @testset "SimpleTimes with storage" begin
 
         # Run the model and extract the data
-        m, case, model = simple_graph(demand=OperationalProfile([10, 15, 5, 15, 5]))
+        m, case, model = simple_graph(;demand=OperationalProfile([10, 15, 5, 15, 5]))
         𝒯    = case[:T]
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
         𝒩    = case[:nodes]
@@ -807,7 +806,7 @@ end
 
         ops = RepresentativePeriods(2, 8760, [.5, .5], [op_1, op_2])
 
-        m, case, model = simple_graph(ops=ops, demand=demand)
+        m, case, model = simple_graph(;ops, op_per_strat=8760, demand)
 
         𝒯    = case[:T]
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
@@ -896,7 +895,7 @@ end
     CO2 = ResourceEmit("CO2", 1.0)
 
     # Function for setting up the system
-    function simple_graph(;ops=SimpleTimes(5, 2), demand=FixedProfile(10))
+    function simple_graph(;ops=SimpleTimes(5, 2), op_per_strat=10, demand=FixedProfile(10))
 
         # Used source, network, and sink
         source = RefSource(
@@ -931,7 +930,6 @@ end
             Dict(Power => 1),
         )
 
-        op_per_strat = TS._total_duration(ops)
         T = TwoLevel(2, 2, ops; op_per_strat)
 
         nodes = [source, aux_source, storage, sink]
@@ -1052,7 +1050,7 @@ end
     @testset "SimpleTimes with storage" begin
 
         # Run the model and extract the data
-        m, case, model = simple_graph(demand=OperationalProfile([10, 15, 5, 15, 5]))
+        m, case, model = simple_graph(;demand=OperationalProfile([10, 15, 5, 15, 5]))
         𝒯    = case[:T]
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
         𝒩    = case[:nodes]
@@ -1105,7 +1103,7 @@ end
 
         ops = OperationalScenarios(2, [op_1, op_2], [.5, .5])
 
-        m, case, model = simple_graph(ops=ops, demand=demand)
+        m, case, model = simple_graph(;ops, op_per_strat=20, demand)
 
         𝒯    = case[:T]
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
@@ -1174,7 +1172,7 @@ end
 
         ops = RepresentativePeriods(2, 8760, [.5, .5], [op_1, op_2])
 
-        m, case, model = simple_graph(ops=ops, demand=demand)
+        m, case, model = simple_graph(;ops, op_per_strat=8760, demand)
 
         𝒯    = case[:T]
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
@@ -1254,7 +1252,7 @@ end
         scps = OperationalScenarios(2, [op, op], [.5, .5])
         ops = RepresentativePeriods(2, 8760, [.5, .5], [scps, scps])
 
-        m, case, model = simple_graph(ops=ops, demand=demand)
+        m, case, model = simple_graph(;ops, op_per_strat=8760, demand)
 
         𝒯    = case[:T]
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
@@ -1337,7 +1335,7 @@ end
 
 
     # Function for setting up the system
-    function simple_graph(;ops=SimpleTimes(5, 2) , em_limit=[40, 40], stor_cap=0)
+    function simple_graph(;ops=SimpleTimes(5, 2), op_per_strat=10, em_limit=[40, 40], stor_cap=0)
 
         em_data = CaptureEnergyEmissions(0.9)
 
@@ -1376,7 +1374,6 @@ end
             Dict(Power => 1),
         )
 
-        op_per_strat = TS._total_duration(ops)
         T = TwoLevel(2, 2, ops; op_per_strat)
 
         nodes = [source, network, storage, sink]
@@ -1496,7 +1493,7 @@ end
     @testset "SimpleTimes with storage" begin
 
         # Run the model and extract the data
-        m, case, model = simple_graph(stor_cap=100, em_limit=[100, 4])
+        m, case, model = simple_graph(;stor_cap=100, em_limit=[100, 4])
         𝒯    = case[:T]
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
         𝒩    = case[:nodes]
@@ -1555,7 +1552,7 @@ end
         op_2 = SimpleTimes(2, 2)
         ops = RepresentativePeriods(2, 60, [.5, .5], [op_1, op_2])
 
-        m, case, model = simple_graph(ops=ops, stor_cap=1e6)
+        m, case, model = simple_graph(;ops, op_per_strat=60, stor_cap=1e6)
         𝒯    = case[:T]
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
         𝒩    = case[:nodes]

--- a/test/test_nodes.jl
+++ b/test/test_nodes.jl
@@ -784,7 +784,7 @@ end
 
         # Test that the level balance is correct in the first period (2 times)
         @test sum(sum(value.(m[:stor_level][stor, t]) ≈
-                    value.(m[:stor_level][stor, last(t_inv)]) +
+                    value.(m[:stor_level][stor, last(collect(t_inv))]) +
                     value.(m[:stor_level_Δ_op][stor, t]) * duration(t)
                     for (t_prev, t) ∈ withprev(t_inv) if isnothing(t_prev))
                     for t_inv ∈ 𝒯ᴵⁿᵛ, atol=TEST_ATOL) ≈
@@ -1102,8 +1102,8 @@ end
     @testset "RepresentativePeriods with storage" begin
 
         # Run the model and extract the data
-        op_1 = SimpleTimes(5, 2)
-        op_2 = SimpleTimes(10, 2)
+        op_1 = SimpleTimes(2, 2)
+        op_2 = SimpleTimes(2, 2)
         ops = RepresentativePeriods(2, 60, [.5, .5], [op_1, op_2])
 
         m, case, model = simple_graph(ops=ops, stor_cap=1e6)

--- a/test/test_nodes.jl
+++ b/test/test_nodes.jl
@@ -614,7 +614,7 @@ end
             FixedProfile(0),
             Dict(aux => 1),
         )
-        storage = RefStorage(
+        storage = RefStorage{EMB.CyclicStrategic}(
             "storage",
             FixedProfile(10),
             FixedProfile(1e8),
@@ -719,7 +719,7 @@ end
         general_tests(m, case, model);
 
         # Test that we get the proper parameteric type
-        @test typeof(stor) <: RefStorage{<:ResourceCarrier}
+        @test typeof(stor) <: RefStorage{EMB.CyclicStrategic}
 
         # Test that the capacity is correctly limited
         # - constraints_capacity_installed(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
@@ -913,7 +913,7 @@ end
             Dict(Power => 1, CO2 => 0),
             [em_data]
         )
-        storage = RefStorage(
+        storage = RefStorage{EMB.AccumulatingEmissions}(
             "storage",
             FixedProfile(10),
             FixedProfile(stor_cap),
@@ -1016,7 +1016,7 @@ end
         general_tests(m, case, model);
 
         # Test that we get the proper parameteric type
-        @test typeof(stor) <: RefStorage{<:ResourceEmit}
+        @test typeof(stor) <: RefStorage{EMB.AccumulatingEmissions}
 
         # Test that the capacity is correctly limited
         # - constraints_capacity_installed(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -36,9 +36,9 @@ end
     source = RefSource("src", FixedProfile(5), FixedProfile(10), FixedProfile(5),
         dict)
     sink = RefSink( "sink", FixedProfile(20), Dict{Symbol,TimeProfile}(), dict)
-    stor = RefStorage{EMB.CyclicStrategic}("stor", FixedProfile(60), FixedProfile(1), FixedProfile(1),
+    stor = RefStorage{CyclicStrategic}("stor", FixedProfile(60), FixedProfile(1), FixedProfile(1),
         FixedProfile(0), Power, dict, dict)
-    stor_em = RefStorage{EMB.AccumulatingEmissions}("stor-em", FixedProfile(1), FixedProfile(1),
+    stor_em = RefStorage{AccumulatingEmissions}("stor-em", FixedProfile(1), FixedProfile(1),
         FixedProfile(1), FixedProfile(1), CO2, dict, dict)
     av = GenAvailability("av", vec)
 
@@ -55,10 +55,10 @@ end
             @test node_types[NetworkNode] == 2
             @test node_types[Availability] == 3
             @test node_types[GenAvailability] == 4
-            @test node_types[Storage{EMB.CyclicStrategic}] == 3
-            @test node_types[Storage{EMB.AccumulatingEmissions}] == 3
-            @test node_types[RefStorage{EMB.CyclicStrategic}] == 4
-            @test node_types[RefStorage{EMB.AccumulatingEmissions}] == 4
+            @test node_types[Storage{CyclicStrategic}] == 3
+            @test node_types[Storage{AccumulatingEmissions}] == 3
+            @test node_types[RefStorage{CyclicStrategic}] == 4
+            @test node_types[RefStorage{AccumulatingEmissions}] == 4
         end
     end
 
@@ -69,11 +69,11 @@ end
         @test indexes[Source] < indexes[RefSource]
         @test indexes[Sink] < indexes[RefSink]
         if haskey(indexes, NetworkNode)
-            @test indexes[NetworkNode] < indexes[Storage{EMB.CyclicStrategic}]
-            @test indexes[NetworkNode] < indexes[Storage{EMB.AccumulatingEmissions}]
+            @test indexes[NetworkNode] < indexes[Storage{CyclicStrategic}]
+            @test indexes[NetworkNode] < indexes[Storage{AccumulatingEmissions}]
             @test indexes[NetworkNode] < indexes[Availability]
-            @test indexes[Storage{EMB.CyclicStrategic}] < indexes[RefStorage{EMB.CyclicStrategic}]
-            @test indexes[Storage{EMB.AccumulatingEmissions}] < indexes[RefStorage{EMB.AccumulatingEmissions}]
+            @test indexes[Storage{CyclicStrategic}] < indexes[RefStorage{CyclicStrategic}]
+            @test indexes[Storage{AccumulatingEmissions}] < indexes[RefStorage{AccumulatingEmissions}]
             @test indexes[Availability] < indexes[GenAvailability]
         end
     end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -36,9 +36,9 @@ end
     source = RefSource("src", FixedProfile(5), FixedProfile(10), FixedProfile(5),
         dict)
     sink = RefSink( "sink", FixedProfile(20), Dict{Symbol,TimeProfile}(), dict)
-    stor = RefStorage("stor", FixedProfile(60), FixedProfile(1), FixedProfile(1),
+    stor = RefStorage{EMB.CyclicStrategic}("stor", FixedProfile(60), FixedProfile(1), FixedProfile(1),
         FixedProfile(0), Power, dict, dict)
-    stor_em = RefStorage("stor-em", FixedProfile(1), FixedProfile(1),
+    stor_em = RefStorage{EMB.AccumulatingEmissions}("stor-em", FixedProfile(1), FixedProfile(1),
         FixedProfile(1), FixedProfile(1), CO2, dict, dict)
     av = GenAvailability("av", vec)
 
@@ -55,10 +55,10 @@ end
             @test node_types[NetworkNode] == 2
             @test node_types[Availability] == 3
             @test node_types[GenAvailability] == 4
-
-            @test node_types[Storage] == 3
-            @test node_types[RefStorage{ResourceCarrier{Float64}}] == 4
-            @test node_types[RefStorage{ResourceEmit{Float64}}] == 4
+            @test node_types[Storage{EMB.CyclicStrategic}] == 3
+            @test node_types[Storage{EMB.AccumulatingEmissions}] == 3
+            @test node_types[RefStorage{EMB.CyclicStrategic}] == 4
+            @test node_types[RefStorage{EMB.AccumulatingEmissions}] == 4
         end
     end
 
@@ -69,9 +69,11 @@ end
         @test indexes[Source] < indexes[RefSource]
         @test indexes[Sink] < indexes[RefSink]
         if haskey(indexes, NetworkNode)
-            @test indexes[NetworkNode] < indexes[Storage]
+            @test indexes[NetworkNode] < indexes[Storage{EMB.CyclicStrategic}]
+            @test indexes[NetworkNode] < indexes[Storage{EMB.AccumulatingEmissions}]
             @test indexes[NetworkNode] < indexes[Availability]
-            @test indexes[Storage] < indexes[RefStorage{ResourceCarrier{Float64}}]
+            @test indexes[Storage{EMB.CyclicStrategic}] < indexes[RefStorage{EMB.CyclicStrategic}]
+            @test indexes[Storage{EMB.AccumulatingEmissions}] < indexes[RefStorage{EMB.AccumulatingEmissions}]
             @test indexes[Availability] < indexes[GenAvailability]
         end
     end


### PR DESCRIPTION
## Background

The current implementation of the level balance in `Storage` nodes is unsatisfactory as it requires a large share of repetitions when different `TimeStructure`s are used. In practice, the level balance of a `Storage` node should be only depend on the behavior of a storage node, that is whether it is `Cyclic` (the last level has to be coupled to the first) or `Accumulating` (no coupling between the last and the first level. Within these two core behaviors, several subbehaviors can be present. This behavior furthermore translates only to the previous level that should be considered for defining the balance.

## Implementation

The implementation is achieved through automatically iterating through the `TimeStructure` and call the respective constraints on, _e.g._ , the level of `RepresentativePeriods` or `OperationalScenarios`. In the last structure, the level balance is solved through calling the function `previous_level`. The individual behavior of the storage node is included through changing `Storage` to be parametric including an `AbstractStorageBehaviour`.

## Advantages

The new implementation does not require the developer of new `Storage` nodes to think about how to solve the level balances for individual time structures. Instead, the developer can reuse the introduced level balances through the implemented `AbstractStorageBehaviour`.

When implementing a new `Storage` node and the existing `StorageBehaviour`s satisfy the needs, the developer only has to implement a new method `constraints_level_aux` to provide a constraint for the calculation of the variable `stor_level_Δ_op`.

When implementing a new `StorageBehaviour`, the following functions have to be potentially adjusted.

- `previous_level` and `previous_level_sp` for calculating the previous level. Note that one has to be careful to avoid method ambiguities.
- `constraints_level_rp` and `constraints_level_scp` to include constraints on the representative period and operational scenario level.
- `constraints_level_bounds` to include bounds on the level within an operational period.

## Way forward

This PR is design as draft. It requires [functionalities from `TimeStruct.jl`](https://github.com/sintefore/TimeStruct.jl/pull/9) not yet merged into the main branch. Hence, it is purely for illustrating purposes.

We plan to implement a new structure for `Storage` nodes. The new structure should allow for

1. Provide capacities for charge, level, and discharge as well as any combination of these (provided that `level` is always included).
2. Allow for inclusion of variable and fixed OPEX to charge, discharge, and level in any combination.

This current thought process is to design it the following way:
```julia
# Supertype for the different approaches.
abstract type AbstractStorageParameters end

# Description including a capacity as well as variable and fixed OPEX
struct StorCapOpex <: AbstractStorageParameters
    capacity::TimeProfile
    opex_var::TimeProfile
    opex_fixed::TimeProfile
end

# Description including only a capacity
struct StorCap <: AbstractStorageParameters
    capacity::TimeProfile
end
```

These types can then be implemented as, _e.g._, 

```julia
# Storage in which the charge, level, and discharge have a capacity
struct StorageA{T} <: Storage{T}
    id
    charge::AbstractStorageParameters
    level::AbstractStorageParameters
    discharge::AbstractStorageParameters
    stor_res::Resource
    input::Dict{<:Resource, <:Real}
    output::Dict{<:Resource, <:Real}
    data::Vector{<:Data}
end

# Storage in which only the level has a capacity
struct StorageB{T} <: Storage{T}
    id
    level::AbstractStorageParameters
    stor_res::Resource
    input::Dict{<:Resource, <:Real}
    output::Dict{<:Resource, <:Real}
    data::Vector{<:Data}
end
```

This approach will also be coupled with a reimplementation of `EnergyModelsInvestments`, although in a first step, `EnergyModelsInvestments` will just be adjusted to allow the investments in either the charge or discharge rate.

## Thinks to be done before merge

- [ ] Update NEWS.md (not included to avoid potential issues with potential rebases)
- [ ] Update version number (most likely breaking changes for node development, but not for application)
- [ ] Improve the documentation
- [ ] Implement the potential for charge/discharge, although that can also be done in a latter stage