### PR TITLE
Removed unncessary last(collect())

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -229,7 +229,7 @@ function previous_level(
 )
     # Return the previous storage level based on cyclic constraints within the representative
     # period
-    return @expression(m, m[:stor_level][n, last(collect(current_per(cyclic_pers)))])
+    return @expression(m, m[:stor_level][n, last(current_per(cyclic_pers))])
 end
 """
     previous_level_sp(
@@ -252,7 +252,7 @@ function previous_level_sp(
     modeltype::EnergyModel
 )
     # Return the previous storage level based on cyclic constraints
-    last_op = last(collect(current_per(cyclic_pers)))
+    last_op = last(current_per(cyclic_pers))
     return @expression(m, m[:stor_level][n, last_op])
 end
 """
@@ -308,7 +308,7 @@ function previous_level_sp(
 )
     # Extract the last operational period in the representative period from the type
     # `CyclicPeriods`
-    last_op = last(collect(current_per(cyclic_pers)))
+    last_op = last(current_per(cyclic_pers))
 
     # Return the previous storage level based on cyclic constraints within the representative
     # period

--- a/test/test_nodes.jl
+++ b/test/test_nodes.jl
@@ -780,7 +780,7 @@ end
 
         # Test that the level balance is correct in the first period (2 times)
         @test sum(sum(value.(m[:stor_level][stor, t]) ≈
-                    value.(m[:stor_level][stor, last(collect(t_inv))]) +
+                    value.(m[:stor_level][stor, last(t_inv)]) +
                     value.(m[:stor_level_Δ_op][stor, t]) * duration(t)
                     for (t_prev, t) ∈ withprev(t_inv) if isnothing(t_prev))
                     for t_inv ∈ 𝒯ᴵⁿᵛ, atol=TEST_ATOL) ≈
@@ -1072,7 +1072,7 @@ end
 
         # Test that the level balance is correct in the first period (2 times)
         @test sum(sum(value.(m[:stor_level][stor, t]) ≈
-                    value.(m[:stor_level][stor, last(collect(t_inv))]) +
+                    value.(m[:stor_level][stor, last(t_inv)]) +
                     value.(m[:stor_level_Δ_op][stor, t]) * duration(t)
                     for (t_prev, t) ∈ withprev(t_inv) if isnothing(t_prev))
                     for t_inv ∈ 𝒯ᴵⁿᵛ, atol=TEST_ATOL) ≈
@@ -1133,7 +1133,7 @@ end
                 if isnothing(t_prev)
                     # Test for the linking between the first and the last operational period
                     @test value.(m[:stor_level][stor, t]) ≈
-                            value.(m[:stor_level][stor, last(collect(t_rp))]) +
+                            value.(m[:stor_level][stor, last(t_rp)]) +
                             value.(m[:stor_level_Δ_op][stor, t]) * duration(t) atol=TEST_ATOL
                 end
             end
@@ -1212,7 +1212,7 @@ end
                 if isnothing(t_prev)
                     # Test for the linking between the first and the last operational period
                     @test value.(m[:stor_level][stor, t]) ≈
-                            value.(m[:stor_level][stor, last(collect(t_rp))]) +
+                            value.(m[:stor_level][stor, last(t_rp)]) +
                             value.(m[:stor_level_Δ_op][stor, t]) * duration(t) atol=TEST_ATOL
                 end
             end
@@ -1295,7 +1295,7 @@ end
                 if isnothing(t_prev)
                     # Test for the linking between the first and the last operational period
                     @test value.(m[:stor_level][stor, t]) ≈
-                            value.(m[:stor_level][stor, last(collect(t_rp))]) +
+                            value.(m[:stor_level][stor, last(t_rp)]) +
                             value.(m[:stor_level_Δ_op][stor, t]) * duration(t) atol=TEST_ATOL
                 end
             end


### PR DESCRIPTION
Last for different TimeStructures was introduced in a later version of `TimeStruct` in the [PR 9](https://github.com/sintefore/TimeStruct.jl/pull/9) while it initially was not supported. Hence, it is no longer necessary to use `last(collect())`.