### PR TITLE
Use dev version for examples when running tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## Unversioned
+
+* Use dev version of EMB for examples when running as part of tests (#33)
+
 ## Version 0.7.0 (2024-05-24)
 
 ### Introduction of `AbstractStorageParameters` type for increasing potential for `Storage` variations

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -1,6 +1,8 @@
 using Pkg
 # Activate the local environment including EnergyModelsBase, HiGHS, PrettyTables
 Pkg.activate(@__DIR__)
+# Use dev version if run as part of tests
+haskey(ENV, "EMB_TEST") && Pkg.develop(path=joinpath(@__DIR__,".."))
 # Install the dependencies.
 Pkg.instantiate()
 

--- a/examples/sink_source.jl
+++ b/examples/sink_source.jl
@@ -1,6 +1,8 @@
 using Pkg
 # Activate the local environment including EnergyModelsBase, HiGHS, PrettyTables
 Pkg.activate(@__DIR__)
+# Use dev version if code checked out
+contains(@__DIR__, "EnergyModelsBase.jl") && Pkg.develop(path=joinpath(@__DIR__,".."))
 # Install the dependencies.
 Pkg.instantiate()
 

--- a/examples/sink_source.jl
+++ b/examples/sink_source.jl
@@ -1,8 +1,8 @@
 using Pkg
 # Activate the local environment including EnergyModelsBase, HiGHS, PrettyTables
 Pkg.activate(@__DIR__)
-# Use dev version if code checked out
-contains(@__DIR__, "EnergyModelsBase.jl") && Pkg.develop(path=joinpath(@__DIR__,".."))
+# Use dev version if run as part of tests
+haskey(ENV, "EMB_TEST") && Pkg.develop(path=joinpath(@__DIR__,".."))
 # Install the dependencies.
 Pkg.instantiate()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ const EMB = EnergyModelsBase
 const TS = TimeStruct
 
 const TEST_ATOL = 1e-6
+ENV["EMB_TEST"] = true # Set flag for example scripts to check if they are run as part of the tests
 
 @testset "EnergyModelsBase" begin
     include("test_general.jl")


### PR DESCRIPTION
Using a  heuristic for whether the code is checked out and not installed is to check if the containing folder includes the full package name, ending with `.jl`. 
Let's see if it works on github. I'm sure there is a better way to check if a package is installed or checked out? The idea is to develop the package if checked out locally or in CI, and use the registered version otherwise.