### PR TITLE
Name emissions constraints to allow for emissions extensions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 
 * Updated minor issues in the documentation (docstrings, indices, and quick start).
 * Use dev version of EMB for examples when running as part of tests, solving [Issue #17](https://github.com/EnergyModelsX/EnergyModelsBase.jl/issues/17).
+* Naming of the total emission constraint to allow for updates in the coefficients in other packages.
 
 ## Version 0.7.0 (2024-05-24)
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -272,8 +272,9 @@ function constraints_emissions(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # Creation of the individual constraints.
-    @constraint(m, [t ∈ 𝒯, p ∈ 𝒫ᵉᵐ],
-        m[:emissions_total][t, p] == sum(m[:emissions_node][n, t, p] for n ∈ 𝒩ᵉᵐ)
+    @constraint(m, con_em_tot[t ∈ 𝒯, p ∈ 𝒫ᵉᵐ],
+        m[:emissions_total][t, p] ==
+            sum(m[:emissions_node][n, t, p] for n ∈ 𝒩ᵉᵐ)
     )
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ, p ∈ 𝒫ᵉᵐ],
         m[:emissions_strategic][t_inv, p] ==


### PR DESCRIPTION
The current version does not allow changes in the calculation of the total emissions. This leads to issues if one wants to add emissions to, _e.g._, transmission modes or links as outlined in [Issue #9 of EnergyModelsGeography](https://github.com/EnergyModelsX/EnergyModelsGeography.jl/issues/9).

As we did not manage to follow up the 

```julia
abstract type TransmissionMode <: EMB.Link
```

approach in time, it is necessary to incorporate the "hacky" solution