### PR TITLE
Add option to skip all checks when creating model.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## Unversioned
+
+* Included an option to deactive the checks entirely with printing a warning.
+
 ## Version 0.8.0 (2024-08-20)
 
 ### Introduced `EnergyModelsInvestments` as extension

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -306,7 +306,7 @@ function constraints_level_iterate(
     # Constraint for the total change in the level in a given representative period
     @constraint(m, [t_rp ∈ 𝒯ʳᵖ],
         m[:stor_level_Δ_rp][n, t_rp] ==
-            sum(m[:stor_level_Δ_op][n, t] * multiple(per, t) for t ∈ t_rp)
+        sum(m[:stor_level_Δ_op][n, t] * multiple(per, t) for t ∈ t_rp)
     )
 
     # Iterate through the operational structure

--- a/src/model.jl
+++ b/src/model.jl
@@ -21,11 +21,14 @@ function create_model(
     modeltype::EnergyModel,
     m::JuMP.Model;
     check_timeprofiles::Bool = true,
+    check_any_data::Bool = true,
 )
     @debug "Construct model"
 
     # Check if the case data is consistent before the model is created.
-    check_data(case, modeltype::EnergyModel, check_timeprofiles)
+    if check_any_data
+        check_data(case, modeltype::EnergyModel, check_timeprofiles)
+    end
 
     # WIP Data structure
     𝒯 = case[:T]
@@ -274,7 +277,7 @@ function constraints_emissions(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
     # Creation of the individual constraints.
     @constraint(m, con_em_tot[t ∈ 𝒯, p ∈ 𝒫ᵉᵐ],
         m[:emissions_total][t, p] ==
-            sum(m[:emissions_node][n, t, p] for n ∈ 𝒩ᵉᵐ)
+        sum(m[:emissions_node][n, t, p] for n ∈ 𝒩ᵉᵐ)
     )
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ, p ∈ 𝒫ᵉᵐ],
         m[:emissions_strategic][t_inv, p] ==

--- a/src/model.jl
+++ b/src/model.jl
@@ -15,6 +15,9 @@ Create the model and call all required functions.
   nodes should be checked or not. It is advised to not deactivate the check, except if you
   are testing new components. It may lead to unexpected behaviour and potential
   inconsistencies in the input data, if the time profiles are not checked.
+- `check_any_data::Bool=true` - A boolean indicator whether the input data is checked or not.
+  It is advised to not deactivate the check, except if you are testing new features.
+  It may lead to unexpected behaviour and even infeasible models.
 """
 function create_model(
     case,
@@ -27,7 +30,15 @@ function create_model(
 
     # Check if the case data is consistent before the model is created.
     if check_any_data
-        check_data(case, modeltype::EnergyModel, check_timeprofiles)
+        check_data(case, modeltype, check_timeprofiles)
+    else
+        @warn(
+            "Checking of the input data is deactivated:\n" *
+            "Deactivating the checks for the input data is strongly discouraged. " *
+            "It can lead to an infeasible model, if the input data is wrongly specified. " *
+            "In addition, even if feasible, weird results can occur.",
+            maxlog = 1
+        )
     end
 
     # WIP Data structure
@@ -54,9 +65,14 @@ function create_model(
 
     return m
 end
-function create_model(case, modeltype::EnergyModel; check_timeprofiles::Bool = true)
+function create_model(
+    case,
+    modeltype::EnergyModel;
+    check_timeprofiles::Bool = true,
+    check_any_data::Bool = true,
+)
     m = JuMP.Model()
-    create_model(case, modeltype, m; check_timeprofiles)
+    create_model(case, modeltype, m; check_timeprofiles, check_any_data)
 end
 
 """


### PR DESCRIPTION
Several of the checks fail when used with `ParametricOptInterface`.

We may of course consider improving the checks, but I thinks allowing to override all checks would be useful anyways. This is just a quick implementation with no warning, we can discuss improvements.