### PR TITLE
Replacement of `multiple` with `scale_op_sp`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 ### Minor updates
 
 * Included an option to deactive the checks entirely with printing a warning.
+* Replaced the function `EMB.multiple` with the function `scale_op_sp` to avoid issues with respect to a function of the same name in `TimeStruct`.
+  * This type is now exported, simplifying its application in other packages.
+  * `EMB.multiple` is still included through a deprecation notice. It is however advisable to switch to the new function.
 
 ### Rework of documentation
 

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -10,14 +10,14 @@ Pages = ["functions.md"]
 CurrentModule = EnergyModelsBase
 ```
 
-## Extension methods
+## Extension functions
 
 ```@docs
 create_link
 objective(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
 ```
 
-## Constraint methods
+## Constraint functions
 
 ```@docs
 constraints_emissions
@@ -29,7 +29,7 @@ constraints_level_scp
 constraints_level_bounds
 ```
 
-## Variable creation methods
+## Variable creation functions
 
 ```@docs
 variables_capacity
@@ -40,7 +40,7 @@ variables_opex
 variables_nodes
 ```
 
-## Check methods
+## Check functions
 
 ```@docs
 check_data
@@ -57,7 +57,7 @@ check_scenario_profile
 compile_logs
 ```
 
-## Identification methods
+## Identification functions
 
 ```@docs
 is_network_node
@@ -83,10 +83,9 @@ res_not
 res_sub
 ```
 
-## Miscellaneous methods
+## Miscellaneous functions
 
 ```@docs
-multiple
 collect_types
 sort_types
 ```

--- a/docs/src/library/public/functions.md
+++ b/docs/src/library/public/functions.md
@@ -67,3 +67,12 @@ These auxiliary functions provide the user with simple approaches for calculatin
 previous_level
 previous_level_sp
 ```
+
+## [Utility functions](@id lib-pub-fun-util)
+
+The following function can be used in newly developed nodes to scale from operational to strategic periods.
+The function replaced the previously used function [`EMB.multiple`] which is still available with a deprecation warning.
+
+```@docs
+scale_op_sp
+```

--- a/docs/src/manual/optimization-variables.md
+++ b/docs/src/manual/optimization-variables.md
@@ -24,7 +24,7 @@ m[:flow_in][n, t, p] * duration(t)
 
 The multiplication then leads to an energy/mass quantity in stead of an energy/mass flow.
 
-The coupling of strategic and operational periods can be achieved through the function `EMB.multiple(t, t_inv)`.
+The coupling of strategic and operational periods can be achieved through the function `scale_op_sp(t, t_inv)`.
 This functions allows for considering the scaling of the operational periods within a strategic period.
 
 ## [Operational cost variables](@id man-opt_var-opex)

--- a/docs/src/nodes/networknode.md
+++ b/docs/src/nodes/networknode.md
@@ -125,11 +125,11 @@ Hence, if you do not have to call additional functions, but only plan to include
 - `constraints_opex_var`:
 
   ```math
-  \texttt{opex\_var}[n, t_{inv}] = \sum_{t \in t_{inv}} opex\_var(n, t) \times \texttt{cap\_use}[n, t] \times EMB.multiple(t_{inv}, t)
+  \texttt{opex\_var}[n, t_{inv}] = \sum_{t \in t_{inv}} opex\_var(n, t) \times \texttt{cap\_use}[n, t] \times scale\_op\_sp(t_{inv}, t)
   ```
 
-  !!! tip "The function `EMB.multiple`"
-      The function [``EMB.multiple(t_{inv}, t)``](@ref EnergyModelsBase.multiple) calculates the scaling factor between operational and strategic periods.
+  !!! tip "The function `scale_op_sp`"
+      The function [``scale\_op\_sp(t_{inv}, t)``](@ref scale_op_sp) calculates the scaling factor between operational and strategic periods.
       It also takes into account potential operational scenarios and their probability as well as representative periods.
 
 - `constraints_data`:\

--- a/docs/src/nodes/sink.md
+++ b/docs/src/nodes/sink.md
@@ -113,12 +113,12 @@ Hence, if you do not have to call additional functions, but only plan to include
   \texttt{opex\_var}[n, t_{inv}] = & \\
     \sum_{t \in t_{inv}} & surplus\_penalty(n, t) \times \texttt{sink\_surplus}[n, t] + \\ &
     deficit\_penalty(n, t) \times \texttt{sink\_deficit}[n, t] \times \\ &
-    EMB.multiple(t_{inv}, t)
+    scale\_op\_sp(t_{inv}, t)
   \end{aligned}
   ```
 
-  !!! tip "The function `EMB.multiple`"
-      The function [``EMB.multiple(t_{inv}, t)``](@ref EnergyModelsBase.multiple) calculates the scaling factor between operational and strategic periods.
+  !!! tip "The function `scale_op_sp`"
+      The function [``scale\_op\_sp(t_{inv}, t)``](@ref scale_op_sp) calculates the scaling factor between operational and strategic periods.
       It also takes into account potential operational scenarios and their probability as well as representative periods.
 
 - `constraints_data`:\

--- a/docs/src/nodes/source.md
+++ b/docs/src/nodes/source.md
@@ -122,11 +122,11 @@ Hence, if you do not have to call additional functions, but only plan to include
 - `constraints_opex_var`:
 
   ```math
-  \texttt{opex\_var}[n, t_{inv}] = \sum_{t \in t_{inv}} opex\_var(n, t) \times \texttt{cap\_use}[n, t] \times EMB.multiple(t_{inv}, t)
+  \texttt{opex\_var}[n, t_{inv}] = \sum_{t \in t_{inv}} opex\_var(n, t) \times \texttt{cap\_use}[n, t] \times scale\_op\_sp(t_{inv}, t)
   ```
 
-  !!! tip "The function `EMB.multiple`"
-      The function [``EMB.multiple(t_{inv}, t)``](@ref EnergyModelsBase.multiple) calculates the scaling factor between operational and strategic periods.
+  !!! tip "The function `scale_op_sp`"
+      The function [``scale\_op\_sp(t_{inv}, t)``](@ref scale_op_sp) calculates the scaling factor between operational and strategic periods.
       It also takes into account potential operational scenarios and their probability as well as representative periods.
 
 - `constraints_data`:\

--- a/docs/src/nodes/storage.md
+++ b/docs/src/nodes/storage.md
@@ -222,14 +222,14 @@ Hence, if you do not have to call additional functions, but only plan to include
   ```math
   \begin{aligned}
   \texttt{opex\_var}&[n, t_{inv}] = \\ \sum_{t \in t_{inv}}&
-    opex\_var(level(n), t) \times \texttt{stor\_level}[n, t] \times EMB.multiple(t_{inv}, t) + \\ &
-    opex\_var(charge(n), t) \times \texttt{stor\_charge\_use}[n, t] \times EMB.multiple(t_{inv}, t) + \\ &
-    opex\_var(discharge(n), t) \times \texttt{stor\_discharge\_use}[n, t] \times EMB.multiple(t_{inv}, t)
+    opex\_var(level(n), t) \times \texttt{stor\_level}[n, t] \times scale\_op\_sp(t_{inv}, t) + \\ &
+    opex\_var(charge(n), t) \times \texttt{stor\_charge\_use}[n, t] \times scale\_op\_sp(t_{inv}, t) + \\ &
+    opex\_var(discharge(n), t) \times \texttt{stor\_discharge\_use}[n, t] \times scale\_op\_sp(t_{inv}, t)
   \end{aligned}
   ```
 
-  !!! tip "The function `EMB.multiple`"
-      The function [``EMB.multiple(t_{inv}, t)``](@ref EnergyModelsBase.multiple) calculates the scaling factor between operational and strategic periods.
+  !!! tip "The function `scale_op_sp`"
+      The function [``scale\_op\_sp(t_{inv}, t)``](@ref scale_op_sp) calculates the scaling factor between operational and strategic periods.
       It also takes into account potential operational scenarios and their probability as well as representative periods.
 
 - `constraints_data`:\
@@ -277,7 +277,7 @@ If the time structure includes representative periods, we calculate the change o
 
 ```math
 \texttt{stor\_level\_Δ\_rp}[n, t_{rp}] = \sum_{t \in t_{rp}}
-\texttt{stor\_level\_Δ\_op}[n, t] \times EMB.multiple(t_{rp}, t)
+\texttt{stor\_level\_Δ\_op}[n, t] \times scale_op_sp(t_{rp}, t)
 ```
 
 In the case of [`CyclicStrategic`](@ref), we add an additional constraint to the change in the function `constraints_level_rp`:

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -39,6 +39,9 @@ export Resource, ResourceCarrier, ResourceEmit
 export Source, NetworkNode, Sink, Storage, Availability
 export GenAvailability, RefSource, RefNetworkNode, RefSink, RefStorage
 
+# Export some of the utility functions
+export scale_op_sp
+
 # Export the storage behaviour types
 export Accumulating, AccumulatingEmissions
 export Cyclic, CyclicRepresentative, CyclicStrategic

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -294,7 +294,7 @@ function constraints_level_iterate(
     # Constraint for the total change in the level in a given representative period
     @constraint(m, [t_rp ∈ 𝒯ʳᵖ],
         m[:stor_level_Δ_rp][n, t_rp] ==
-        sum(m[:stor_level_Δ_op][n, t] * multiple(per, t) for t ∈ t_rp)
+        sum(m[:stor_level_Δ_op][n, t] * scale_op_sp(per, t) for t ∈ t_rp)
     )
 
     # Iterate through the operational structure
@@ -627,7 +627,7 @@ In the case of a `Sink` node, the variable OPEX is calculate through the penalti
 function constraints_opex_var(m, n::Node, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
         m[:opex_var][n, t_inv] ==
-        sum(m[:cap_use][n, t] * opex_var(n, t) * multiple(t_inv, t) for t ∈ t_inv)
+        sum(m[:cap_use][n, t] * opex_var(n, t) * scale_op_sp(t_inv, t) for t ∈ t_inv)
     )
 end
 function constraints_opex_var(m, n::Storage, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
@@ -636,7 +636,7 @@ function constraints_opex_var(m, n::Storage, 𝒯ᴵⁿᵛ, modeltype::EnergyMod
     if has_level_OPEX_var(n)
         opex_var_level = @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
             sum(
-                m[:stor_level][n, t] * opex_var(level(n), t) * multiple(t_inv, t) for
+                m[:stor_level][n, t] * opex_var(level(n), t) * scale_op_sp(t_inv, t) for
                 t ∈ t_inv
             )
         )
@@ -646,7 +646,7 @@ function constraints_opex_var(m, n::Storage, 𝒯ᴵⁿᵛ, modeltype::EnergyMod
     if has_charge_OPEX_var(n)
         opex_var_charge = @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
             sum(
-                m[:stor_charge_use][n, t] * opex_var(charge(n), t) * multiple(t_inv, t)
+                m[:stor_charge_use][n, t] * opex_var(charge(n), t) * scale_op_sp(t_inv, t)
                 for t ∈ t_inv
             )
         )
@@ -658,7 +658,7 @@ function constraints_opex_var(m, n::Storage, 𝒯ᴵⁿᵛ, modeltype::EnergyMod
             sum(
                 m[:stor_discharge_use][n, t] *
                 opex_var(discharge(n), t) *
-                multiple(t_inv, t) for t ∈ t_inv
+                scale_op_sp(t_inv, t) for t ∈ t_inv
             )
         )
     else
@@ -678,7 +678,7 @@ function constraints_opex_var(m, n::Sink, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
             (
                 m[:sink_surplus][n, t] * surplus_penalty(n, t) +
                 m[:sink_deficit][n, t] * deficit_penalty(n, t)
-            ) * multiple(t_inv, t) for t ∈ t_inv
+            ) * scale_op_sp(t_inv, t) for t ∈ t_inv
         )
     )
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -303,7 +303,7 @@ function constraints_emissions(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
     )
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ, p ∈ 𝒫ᵉᵐ],
         m[:emissions_strategic][t_inv, p] ==
-        sum(m[:emissions_total][t, p] * multiple(t_inv, t) for t ∈ t_inv)
+        sum(m[:emissions_total][t, p] * scale_op_sp(t_inv, t) for t ∈ t_inv)
     )
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -312,12 +312,37 @@ function previous_level_sp(
 end
 
 """
-    multiple(t_inv, t)
+    scale_op_sp(t_inv::TS.AbstractStrategicPeriod, t::TS.TimePeriod)
 
 Provides a simplified function for returning the multiplication
 
 ``duration(t) * multiple\\_strat(t\\_inv, t) * probability(t)``
 
-when operational periods are coupled with strategic periods (or representative periods).
+when operational periods are coupled with strategic periods. It is used to scale the value
+provided for operational periods to a duration of 1 of a strategic period.
+
+# Example
+
+```julia
+# Time structure representing to strategic periods with a duration of 4 years each and
+# including a single week with hourly resolution
+ts = TwoLevel(2, 4, SimpleTimes(168,1); op_per_strat=8760.0);
+
+# Extracting the first strategic period and its first operational period
+t_inv = first(strat_periods(ts))
+t = first(t_inv)
+
+# Calculating the value as 52.14 (number of weeks in a year)
+scale_op_sp(t_inv, t)
+```
 """
-multiple(t_inv, t) = duration(t) * multiple_strat(t_inv, t) * probability(t)
+scale_op_sp(t_inv::TS.AbstractStrategicPeriod, t::TS.TimePeriod) =
+    duration(t) * multiple_strat(t_inv, t) * probability(t)
+
+function multiple(t_inv, t)
+    @warn(
+        "`multiple(t_inv, t)` is deprecated, use scale_op_sp(t_inv, t)` instead.",
+        maxlog = 1
+    )
+    return scale_op_sp(t_inv, t)
+end

--- a/test/test_general.jl
+++ b/test/test_general.jl
@@ -123,7 +123,7 @@ end
     # - constraints_emissions(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
     @test sum(
         value.(m[:emissions_strategic][t_inv, CO2]) ≈
-        sum(value.(m[:emissions_total][t, CO2]) * EMB.multiple(t_inv, t) for t ∈ t_inv) for
+        sum(value.(m[:emissions_total][t, CO2]) * scale_op_sp(t_inv, t) for t ∈ t_inv) for
         t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
     ) ≈ length(𝒯ᴵⁿᵛ)
     @test sum(


### PR DESCRIPTION
As outlined in #40, there were some ambiguities with the function `multiple(t_inv, t)` declared in `EnergyModelsBase`:

The same function with the same input was also declared within `TimeStruct`. That is the reason we did not export it from `EnergyModelsBase`. However, we realized that this is unsatisfactory. Hence, we renamed it to `scale_op_sp` and exported the function.

`multiple(t_inv, t)` will be still available, but removed eventually.

This PR closes #40.