### PR TITLE
Fixed profile checks

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,11 +10,29 @@ const TS = TimeStruct
 const TEST_ATOL = 1e-6
 ENV["EMB_TEST"] = true # Set flag for example scripts to check if they are run as part of the tests
 
-@testset "EnergyModelsBase" begin
-    include("test_general.jl")
-    include("test_nodes.jl")
-    include("test_modeltype.jl")
-    include("test_examples.jl")
-    include("test_utils.jl")
-    include("test_checks.jl")
+
+@testset "Base" begin
+    @testset "Base | General" begin
+        include("test_general.jl")
+    end
+
+    @testset "Base | Node" begin
+        include("test_nodes.jl")
+    end
+
+    @testset "Base | Modeltype" begin
+        include("test_modeltype.jl")
+    end
+
+    @testset "Base | Utilities" begin
+        include("test_utils.jl")
+    end
+
+    @testset "Base | Checks" begin
+        include("test_checks.jl")
+    end
+
+    @testset "Base | examples" begin
+        include("test_examples.jl")
+    end
 end


### PR DESCRIPTION
The profile checks had the potential to let unwanted time profiles slip through, specifically when it checked the representative profiles. This was adjusted in this PR.

Furthermore, I simplified the calculations through creation of relevant subchecks to reduced the number of lines required. It can always be further simplified, obviously, but I think it is in the current state reasonable.