### PR TITLE
Feature/Added the variable `stor_level_Δ_sp`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,14 @@
 
 ## Unversioned
 
+### Bugfixes
+
+* Fixed a bug in which it was possible to have wrong profiles if it must be indexed over an operational scenario or representative period.
+
 ### Minor updates
 
 * Included an option to deactive the checks entirely with printing a warning.
+* Introduced the variable ``\texttt{stor\_level\_Δ\_sp}`` using `SparseVariables` to simplify the extension in other `Storage` nodes.
 * Replaced the function `EMB.multiple` with the function `scale_op_sp` to avoid issues with respect to a function of the same name in `TimeStruct`.
   * This type is now exported, simplifying its application in other packages.
   * `EMB.multiple` is still included through a deprecation notice. It is however advisable to switch to the new function.

--- a/docs/src/manual/optimization-variables.md
+++ b/docs/src/manual/optimization-variables.md
@@ -86,12 +86,20 @@ The storage level is always defined for the end of the operational period it is 
 There are in addition two variables for the storage level that behave slightly different:
 
 - ``\texttt{stor\_level\_Δ\_op}[n, t]``: Change of the absolute level of energy/mass stored in a `Storage` node ``n`` in operational period ``t`` with a typical unit of GWh or t, and
-- ``\texttt{stor\_level\_Δ\_rp}[n, t_{rp}]``: Change of the absolute level of energy/mass stored in a `Storage` node ``n`` in representative period ``t_{rp}`` with a typical unit of GWh or t.
+- ``\texttt{stor\_level\_Δ\_rp}[n, t_{rp}]``: Change of the absolute level of energy/mass stored in a `Storage` node ``n`` in representative period ``t_{rp}`` with a typical unit of GWh or t, and
+- ``\texttt{stor\_level\_Δ\_sp}[n, t_\texttt{inv}]``: Change of the absolute level of energy/mass stored in a `Storage` node ``n`` in strategic period ``t_\texttt{inv}`` with a typical unit of GWh or t.
 
-These two variables are introduced to track the change in the storage level in a operational period and a representative period, respectively.
+These variables are introduced to track the change in the storage level in an operational period, a representative period, or an investment period, respectively.
 They can be considered as helper variables to account for the duration of the operational period as well as the total change within a representative period.
-``\texttt{stor\_level\_Δ\_rp}`` is only declared if the `TimeStructure` includes `RepresentativePeriods`.
+``\texttt{stor\_level\_Δ\_rp}`` is only declared if the `TimeStructure` includes `RepresentativePeriods` while ``\texttt{stor\_level\_Δ\_sp}`` is introduced as an empty `SparseVariables` container.
 The application of `RepresentativePeriods` is explained in *[How to use TimeStruct.jl](@ref how_to-utilize_TS-struct-rp)*.
+The utilization of ``\texttt{stor\_level\_Δ\_sp}`` requires to include in the function [`variables_node`](@ref) for the given `Storage` array `𝒩ˢᵘᵇ::Vector{<:NewStorageNode}` as, *e.g.*, the following loop
+
+```julia
+for t_inv ∈ 𝒯ᴵⁿᵛ, n ∈ 𝒩ˢᵘᵇ
+    insertvar!(stor_level_Δ_sp, n, t_inv)
+end
+```
 
 The variables ``\texttt{cap\_inst}``, ``\texttt{stor\_charge\_inst}``, ``\texttt{stor\_level\_inst}``, and ``\texttt{stor\_discharge\_inst}`` are used in `EnergyModelsInvestment` to allow for investments in capacity of individual nodes.
 
@@ -187,6 +195,7 @@ These variables are for the individual nodes given in the subsections below.
 - [``\texttt{stor\_discharge\_inst}``](@ref man-opt_var-cap), if the `Storage` node has a field `:discharge` with the `StorageParameters` corresponding to *[capacity storage parameters](@ref lib-pub-nodes-stor_par)*
 - [``\texttt{stor\_level\_Δ\_op}``](@ref man-opt_var-cap)
 - [``\texttt{stor\_level\_Δ\_rp}``](@ref man-opt_var-cap) if the `TimeStruct` includes `RepresentativePeriods`
+- [``\texttt{stor\_level\_Δ\_sp}``](@ref man-opt_var-cap) if the function [`variables_node`](@ref) is declared for the new `Storage` type
 - [``\texttt{flow\_in}``](@ref man-opt_var-flow)
 - [``\texttt{flow\_out}``](@ref man-opt_var-flow)
 - [``\texttt{emissions\_node}``](@ref man-opt_var-emissions) if `ResourceEmit` is stored

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -11,6 +11,7 @@ You can find the exported types and functions below or on the pages \
 module EnergyModelsBase
 
 using JuMP
+using SparseVariables
 using TimeStruct
 const TS = TimeStruct
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -96,7 +96,10 @@ These variables are:
 
 * `:stor_level` - storage level at the end of each operational period.
 * `:stor_level_Δ_op` - storage level change in each operational period.
-* `:stor_level_Δ_rp` - storage level change in each representative period.
+* `:stor_level_Δ_rp` - storage level change in each representative period. These variables
+  are only created if the time structure includes representative periods.
+* `:stor_level_Δ_op` - storage level change in each strategic period. These variables are
+  optional and created through `SparseVariables`.
 * `:stor_level_inst` - installed capacity for storage in each operational period, constrained
   in the operational case to the provided capacity in the [storage parameters](@ref lib-pub-nodes-stor_par)
   used in the field `:level`.
@@ -116,6 +119,7 @@ function variables_capacity(m, 𝒩, 𝒯, modeltype::EnergyModel)
     𝒩ˢᵗᵒʳ = filter(is_storage, 𝒩)
     𝒩ˢᵗᵒʳ⁻ᶜ = filter(has_charge, 𝒩ˢᵗᵒʳ)
     𝒩ˢᵗᵒʳ⁻ᵈᶜ = filter(has_discharge, 𝒩ˢᵗᵒʳ)
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     @variable(m, cap_use[𝒩ⁿᵒᵗ, 𝒯] >= 0)
     @variable(m, cap_inst[𝒩ⁿᵒᵗ, 𝒯] >= 0)
@@ -127,6 +131,7 @@ function variables_capacity(m, 𝒩, 𝒯, modeltype::EnergyModel)
         𝒯ʳᵖ = repr_periods(𝒯)
         @variable(m, stor_level_Δ_rp[𝒩ˢᵗᵒʳ, 𝒯ʳᵖ])
     end
+    @variable(m, stor_level_Δ_sp[𝒩ˢᵗᵒʳ, 𝒯ᴵⁿᵛ]; container = IndexedVarArray)
     @variable(m, stor_charge_use[𝒩ˢᵗᵒʳ, 𝒯] >= 0)
     @variable(m, stor_charge_inst[𝒩ˢᵗᵒʳ⁻ᶜ, 𝒯] >= 0)
     @variable(m, stor_discharge_use[𝒩ˢᵗᵒʳ, 𝒯] >= 0)


### PR DESCRIPTION
The variable `stor_level_Δ_sp` was previously created within `EnergyModelsCO2` to account for the changes within a strategic period. However, it may be as well useful for other storages which introduce new accumulating behaviors.

Hence, we decided to introduce it as an empty Container using [`SparseVariables.jl`](https://github.com/sintefore/SparseVariables.jl).

It subsequent application requires to add an entry as 

```julia
for t_inv ∈ 𝒯ᴵⁿᵛ, n ∈ 𝒩ˢᵘᵇ
    insertvar!(stor_level_Δ_sp, n, t_inv)
end
```

within the function `variables_node(m, 𝒩ˢᵘᵇ::Vector{<:NewStorageType}, 𝒯, modeltype::EnergyModel)`.