### PR TITLE
Adjust/EnergyModelsInvestment changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
           - version: '1'  # The latest point-release (Windows)
             os: windows-latest
             arch: x64
-          - version: '1.9'  # 1.9 
+          - version: '1.10'  # 1.10
             os: ubuntu-latest
             arch: x64
-          - version: '1.9'  # 1.9
+          - version: '1.10'  # 1.10
             os: ubuntu-latest
             arch: x86
           # - version: 'nightly'

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,13 @@
   * This type is now exported, simplifying its application in other packages.
   * `EMB.multiple` is still included through a deprecation notice. It is however advisable to switch to the new function.
 
+### Adjustment to EnergyModelsInvestments changes
+
+* Adjusted the ivnestment data checks.
+* Provided legacy constructors for the previous usage of `SingleInvData`.
+* Introduced the investment examples to the example sections.
+* Added investment options tests.
+
 ### Rework of documentation
 
 * The documentation received a significant rework.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,18 +1,10 @@
 # Release notes
 
-## Unversioned
+## Version 0.8.1 (2024-10-16)
 
 ### Bugfixes
 
 * Fixed a bug in which it was possible to have wrong profiles if it must be indexed over an operational scenario or representative period.
-
-### Minor updates
-
-* Included an option to deactive the checks entirely with printing a warning.
-* Introduced the variable ``\texttt{stor\_level\_Δ\_sp}`` using `SparseVariables` to simplify the extension in other `Storage` nodes.
-* Replaced the function `EMB.multiple` with the function `scale_op_sp` to avoid issues with respect to a function of the same name in `TimeStruct`.
-  * This type is now exported, simplifying its application in other packages.
-  * `EMB.multiple` is still included through a deprecation notice. It is however advisable to switch to the new function.
 
 ### Adjustment to EnergyModelsInvestments changes
 
@@ -25,8 +17,16 @@
 
 * The documentation received a significant rework.
   The rework consists of:
-  * Provide webpages for the individual nodal descriptions in which the fields are described more in detail as well as a description of the math involved in the nodes.
+  * Providing webpages for the individual nodal descriptions in which the fields are described more in detail as well as a description of the constraints of the individual nodes.
   * Restructured both the public and internal libraries
+
+### Minor updates
+
+* Included an option to deactive the checks entirely with printing a warning.
+* Introduced the variable ``\texttt{stor\_level\_Δ\_sp}`` using `SparseVariables` to simplify the extension in other `Storage` nodes.
+* Replaced the function `EMB.multiple` with the function `scale_op_sp` to avoid issues with respect to a function of the same name in `TimeStruct`.
+  * This type is now exported, simplifying its application in other packages.
+  * `EMB.multiple` is still included through a deprecation notice. It is however advisable to switch to the new function.
 
 ## Version 0.8.0 (2024-08-20)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 ### Adjustment to EnergyModelsInvestments changes
 
-* Adjusted the ivnestment data checks.
+* Adjusted the investment data checks.
 * Provided legacy constructors for the previous usage of `SingleInvData`.
 * Introduced the investment examples to the example sections.
 * Added investment options tests.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsBase"
 uuid = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
@@ -15,8 +15,8 @@ EnergyModelsInvestments = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 EMIExt = "EnergyModelsInvestments"
 
 [compat]
-EnergyModelsInvestments = "0.7"
+EnergyModelsInvestments = "0.8"
 JuMP = "1"
 SparseVariables = "0.7.3"
-TimeStruct = "^0.8"
-julia = "1.9"
+TimeStruct = "0.9"
+julia = "1.10"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
+EnergyModelsInvestments = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/examples/network_invest.jl
+++ b/examples/network_invest.jl
@@ -8,20 +8,21 @@ Pkg.instantiate()
 
 # Import the required packages
 using EnergyModelsBase
+using EnergyModelsInvestments
 using JuMP
 using HiGHS
 using PrettyTables
 using TimeStruct
 
 """
-    generate_example_network()
+    generate_example_network_investment()
 
 Generate the data for an example consisting of a simple electricity network.
-The more stringent CO₂ emission in latter investment periods force the utilization of the
-more expensive natural gas power plant with CCS to reduce emissions.
+The more stringent CO₂ emission in latter investment periods force the investment into both
+the natural gas power plant with CCS and the CO₂ storage node.
 """
-function generate_example_network()
-    @info "Generate case data - Simple network example"
+function generate_example_network_investment()
+    @info "Generate case data - Simple network example with investments"
 
     # Define the different resources and their emission intensity in tCO2/MWh
     NG = ResourceEmit("NG", 0.2)
@@ -35,24 +36,26 @@ function generate_example_network()
     op_number = 4   # There are in total 4 operational periods
     operational_periods = SimpleTimes(op_number, op_duration)
 
-    # The number of operational periods times the duration of the operational periods, which
-    # can also be extracted using the function `duration` of a `SimpleTimes` structure.
-    # This implies, that a strategic period is 8 times longer than an operational period,
-    # resulting in the values below as "/8h".
-    op_per_strat = op_duration * op_number
+    # Each operational period should correspond to a duration of 2 h while a duration if 1
+    # of a strategic period should correspond to a year.
+    # This implies, that a strategic period is 8760 times longer than an operational period,
+    # resulting in the values below as "/year".
+    op_per_strat = 8760
 
     # Creation of the time structure and global data
     T = TwoLevel(4, 1, operational_periods; op_per_strat)
-    model = OperationalModel(
-        Dict(   # Emission cap for CO₂ in t/8h and for NG in MWh/8h
-            CO2 => StrategicProfile([160, 140, 120, 100]),
+    model = InvestmentModel(
+        Dict(   # Emission cap for CO₂ in t/year and for NG in MWh/year
+            CO2 => StrategicProfile([170, 150, 130, 110]) * 1000,
             NG => FixedProfile(1e6),
         ),
         Dict(   # Emission price for CO₂ in EUR/t and for NG in EUR/MWh
+
             CO2 => FixedProfile(0),
             NG => FixedProfile(0),
         ),
         CO2,    # CO2 instance
+        0.07,   # Discount rate in absolute value
     )
 
     # Creation of the emission data for the individual nodes.
@@ -66,33 +69,43 @@ function generate_example_network()
         RefSource(
             "NG source",                # Node id
             FixedProfile(100),          # Capacity in MW
-            FixedProfile(30),           # Variable OPEX in EUR/MW
-            FixedProfile(0),            # Fixed OPEX in EUR/MW/8h
+            FixedProfile(30),           # Variable OPEX in EUR/MWh
+            FixedProfile(0),            # Fixed OPEX in EUR/MW/year
             Dict(NG => 1),              # Output from the Node, in this case, NG
         ),
         RefSource(
             "coal source",              # Node id
             FixedProfile(100),          # Capacity in MW
             FixedProfile(9),            # Variable OPEX in EUR/MWh
-            FixedProfile(0),            # Fixed OPEX in EUR/MW/8h
+            FixedProfile(0),            # Fixed OPEX in EUR/MW/year
             Dict(Coal => 1),            # Output from the Node, in this case, coal
         ),
         RefNetworkNode(
             "NG+CCS power plant",       # Node id
-            FixedProfile(25),           # Capacity in MW
+            FixedProfile(0),            # Capacity in MW
             FixedProfile(5.5),          # Variable OPEX in EUR/MWh
-            FixedProfile(0),            # Fixed OPEX in EUR/MW/8h
+            FixedProfile(0),            # Fixed OPEX in EUR/MW/year
             Dict(NG => 2),              # Input to the node with input ratio
-            Dict(Power => 1, CO2 => 1), # Output from the node with output ratio
+            Dict(Power => 1, CO2 => 0), # Output from the node with output ratio
             # Line above: CO2 is required as output for variable definition, but the
             # value does not matter
-            [capture_data],             # Additonal data for emissions and CO₂ capture
+            [
+                capture_data,           # Additonal data for emissions and CO₂ capture
+                SingleInvData(
+                    FixedProfile(600 * 1e3),  # Capex in EUR/MW
+                    FixedProfile(40),       # Max installed capacity [MW]
+                    SemiContinuousInvestment(FixedProfile(5), FixedProfile(40)),
+                    # Line above: Investment mode with the following arguments:
+                    # 1. argument: min added capactity per sp [MW]
+                    # 2. argument: max added capactity per sp [MW]
+                ),
+            ],
         ),
         RefNetworkNode(
             "coal power plant",         # Node id
-            FixedProfile(25),           # Capacity in MW
+            FixedProfile(40),           # Capacity in MW
             FixedProfile(6),            # Variable OPEX in EUR/MWh
-            FixedProfile(0),            # Fixed OPEX in EUR/MW/8h
+            FixedProfile(0),            # Fixed OPEX in EUR/MW/year
             Dict(Coal => 2.5),          # Input to the node with input ratio
             Dict(Power => 1),           # Output from the node with output ratio
             [emission_data],            # Additonal data for emissions
@@ -100,16 +113,29 @@ function generate_example_network()
         RefStorage{AccumulatingEmissions}(
             "CO2 storage",              # Node id
             StorCapOpex(
-                FixedProfile(60),       # Charge capacity in t/h
+                FixedProfile(0),       # Charge capacity in t/h
                 FixedProfile(9.1),      # Storage variable OPEX for the charging in EUR/t
-                FixedProfile(0)        # Storage fixed OPEX for the charging in EUR/(t/h 8h)
+                FixedProfile(0)         # Storage fixed OPEX for the charging in EUR/(t/h year)
             ),
-            StorCap(FixedProfile(600)), # Storage capacity in t
+            StorCap(FixedProfile(1e8)), # Storage capacity in t
             CO2,                        # Stored resource
             Dict(CO2 => 1, Power => 0.02), # Input resource with input ratio
             # Line above: This implies that storing CO₂ requires Power
             Dict(CO2 => 1),             # Output from the node with output ratio
             # In practice, for CO₂ storage, this is never used.
+            [
+                StorageInvData(
+                    charge = NoStartInvData(
+                        FixedProfile(200 * 1e3),  # CAPEX [EUR/(t/h)]
+                        FixedProfile(60),       # Max installed capacity [EUR/(t/h)]
+                        ContinuousInvestment(FixedProfile(0), FixedProfile(5)),
+                        # Line above: Investment mode with the following arguments:
+                        # 1. argument: min added capactity per sp [t/h]
+                        # 2. argument: max added capactity per sp [t/h]
+                        UnlimitedLife(),        # Lifetime mode
+                    ),
+                ),
+            ],
         ),
         RefSink(
             "electricity demand",       # Node id
@@ -144,25 +170,27 @@ function generate_example_network()
 end
 
 # Generate the case and model data and run the model
-case, model = generate_example_network()
+case, model = generate_example_network_investment()
 optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
 m = run_model(case, model, optimizer)
 
 # Display some results
-ng_ccs_pp, coal_pp, = case[:nodes][[4, 5]]
-@info "Capacity usage of the coal power plant"
+ng_ccs_pp, CO2_stor, = case[:nodes][[4, 6]]
+@info "Invested capacity for the natural gas plant in the beginning of the \
+individual strategic periods"
 pretty_table(
     JuMP.Containers.rowtable(
         value,
-        m[:cap_use][coal_pp, :];
-        header = [:t, :Value],
+        m[:cap_add][ng_ccs_pp, :];
+        header = [:StrategicPeriod, :InvestCapacity],
     ),
 )
-@info "Capacity usage of the natural gas + CCS power plant"
+@info "Invested capacity for the CO2 storage in the beginning of the
+individual strategic periods"
 pretty_table(
     JuMP.Containers.rowtable(
         value,
-        m[:cap_use][ng_ccs_pp, :];
-        header = [:t, :Value],
+        m[:stor_charge_add][CO2_stor, :];
+        header = [:StrategicPeriod, :InvestCapacity],
     ),
 )

--- a/examples/sink_source.jl
+++ b/examples/sink_source.jl
@@ -14,12 +14,12 @@ using PrettyTables
 using TimeStruct
 
 """
-    generate_example_data_ss()
+    generate_example_ss()
 
 Generate the data for an example consisting of an electricity source and sink. It shows how
 the source adjusts to the demand.
 """
-function generate_example_data_ss()
+function generate_example_ss()
     @info "Generate case data - Simple sink-source example"
 
     # Define the different resources and their emission intensity in tCO2/MWh
@@ -51,9 +51,9 @@ function generate_example_data_ss()
     nodes = [
         RefSource(
             "electricity source",       # Node id
-            FixedProfile(1e12),         # Capacity in MW
+            FixedProfile(50),           # Capacity in MW
             FixedProfile(30),           # Variable OPEX in EUR/MW
-            FixedProfile(0),            # Fixed OPEX in EUR/8h
+            FixedProfile(0),            # Fixed OPEX in EUR/MW/8h
             Dict(Power => 1),           # Output from the Node, in this case, Power
         ),
         RefSink(
@@ -81,7 +81,7 @@ function generate_example_data_ss()
 end
 
 # Generate the case and model data and run the model
-case, model = generate_example_data_ss()
+case, model = generate_example_ss()
 optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
 m = run_model(case, model, optimizer)
 

--- a/examples/sink_source_invest.jl
+++ b/examples/sink_source_invest.jl
@@ -1,0 +1,129 @@
+using Pkg
+# Activate the local environment including EnergyModelsBase, HiGHS, PrettyTables
+Pkg.activate(@__DIR__)
+# Use dev version if run as part of tests
+haskey(ENV, "EMB_TEST") && Pkg.develop(path = joinpath(@__DIR__, ".."))
+# Install the dependencies.
+Pkg.instantiate()
+
+# Import the required packages
+using EnergyModelsBase
+using EnergyModelsInvestments
+using JuMP
+using HiGHS
+using PrettyTables
+using TimeStruct
+
+"""
+    generate_example_ss_investment(lifemode = RollingLife; discount_rate = 0.05)
+
+Generate the data for an example consisting of an electricity source and sink.
+The electricity source has initially no capacity. Hence, investments are required.
+"""
+function generate_example_ss_investment(lifemode = RollingLife; discount_rate = 0.05)
+    @info "Generate case data - Simple sink-source example"
+
+    # Define the different resources and their emission intensity in tCO2/MWh
+    Power = ResourceCarrier("Power", 0.0)
+    CO2 = ResourceEmit("CO2", 1.0)
+    products = [Power, CO2]
+
+    # Variables for the individual entries of the time structure
+    op_duration = 2 # Each operational period has a duration of 2
+    op_number = 4   # There are in total 4 operational periods
+    operational_periods = SimpleTimes(op_number, op_duration)
+
+    # Each operational period should correspond to a duration of 2 h while a duration if 1
+    # of a strategic period should correspond to a year.
+    # This implies, that a strategic period is 8760 times longer than an operational period,
+    # resulting in the values below as "/year".
+    op_per_strat = 8760
+
+    sp_duration = 5 # The duration of a investment period is given as 5 years
+
+    # Creation of the time structure and global data
+    T = TwoLevel(4, sp_duration, operational_periods; op_per_strat)
+
+    # Create the global data
+    model = InvestmentModel(
+        Dict(CO2 => FixedProfile(10)),  # Emission cap for CO₂ in t/year
+        Dict(CO2 => FixedProfile(0)),   # Emission price for CO₂ in EUR/t
+        CO2,                            # CO₂ instance
+        discount_rate,                  # Discount rate in absolute value
+    )
+
+
+    # The lifetime of the technology is 15 years, requiring reinvestment in the
+    # 5th investment period
+    lifetime = FixedProfile(15)
+
+    # Create the investment data for the source node
+    investment_data_source = SingleInvData(
+        FixedProfile(300 * 1e3),  # capex [€/MW]
+        FixedProfile(50),       # max installed capacity [MW]
+        ContinuousInvestment(FixedProfile(0), FixedProfile(30)),
+        # Line above: Investment mode with the following arguments:
+        # 1. argument: min added capactity per sp [MW]
+        # 2. argument: max added capactity per sp [MW]
+        lifemode(lifetime),     # Lifetime mode
+    )
+
+
+    # Create the individual test nodes, corresponding to a system with an electricity
+    # demand/sink and source
+    nodes = [
+        RefSource(
+            "electricity source",       # Node id
+            FixedProfile(0),            # Capacity in MW
+            FixedProfile(10),           # Variable OPEX in EUR/MW
+            FixedProfile(5),            # Fixed OPEX in EUR/MW/year
+            Dict(Power => 1),           # Output from the Node, in this case, Power
+            [investment_data_source],   # Additional data used for adding the investment data
+        ),
+        RefSink(
+            "electricity demand",       # Node id
+            OperationalProfile([20, 30, 40, 30]), # Demand in MW
+            Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
+            # Line above: Surplus and deficit penalty for the node in EUR/MWh
+            Dict(Power => 1),           # Energy demand and corresponding ratio
+        ),
+    ]
+
+    # Connect all nodes with the availability node for the overall energy/mass balance
+    links = [
+        Direct("source-demand", nodes[1], nodes[2], Linear()),
+    ]
+
+    # WIP data structure
+    case = Dict(
+        :nodes => nodes,
+        :links => links,
+        :products => products,
+        :T => T,
+    )
+    return case, model
+end
+
+# Generate the case and model data and run the model
+case, model = generate_example_ss_investment()
+optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
+m = run_model(case, model, optimizer)
+
+# Display some results
+source, sink = case[:nodes]
+@info "Invested capacity for the source in the beginning of the individual strategic periods"
+pretty_table(
+    JuMP.Containers.rowtable(
+        value,
+        m[:cap_add][source, :];
+        header = [:StrategicPeriod, :InvestCapacity],
+    ),
+)
+@info "Retired capacity of the source at the end of the individual strategic periods"
+pretty_table(
+    JuMP.Containers.rowtable(
+        value,
+        m[:cap_rem][source, :];
+        header = [:StrategicPeriod, :InvestCapacity],
+    ),
+)

--- a/ext/EMIExt/structures/inv_data.jl
+++ b/ext/EMIExt/structures/inv_data.jl
@@ -45,7 +45,7 @@ end
 function EMB.SingleInvData(
     capex_trans::TimeProfile,
     trans_max_inst::TimeProfile,
-    initial::Real,
+    initial::TimeProfile,
     inv_mode::Investment,
 )
     return SingleInvData(StartInvData(capex_trans, trans_max_inst, initial, inv_mode))
@@ -53,7 +53,7 @@ end
 function EMB.SingleInvData(
     capex_trans::TimeProfile,
     trans_max_inst::TimeProfile,
-    initial::Real,
+    initial::TimeProfile,
     inv_mode::Investment,
     life_mode::LifetimeMode,
 )

--- a/ext/EMIExt/structures/legacy_constructor.jl
+++ b/ext/EMIExt/structures/legacy_constructor.jl
@@ -1,9 +1,38 @@
-"""
-    EMB.InvData(;kwargs)
 
-Internal method for [`InvData`](@ref EMB.InvData). The introduction of an internal method
-is necessary as extensions do not allow to export functions or types.
-"""
+function EMB.SingleInvData(
+    capex_trans::TimeProfile,
+    trans_max_inst::TimeProfile,
+    initial::Real,
+    inv_mode::Investment,
+)
+    @warn(
+        "The used implementation of a `StartInvData` will be discontinued in the near future.\n" *
+        "You have to only change the value of the field `initial` to a `FixedProfile` " *
+        "for utilizing the new version.",
+        maxlog = 1
+    )
+    return SingleInvData(
+        StartInvData(capex_trans, trans_max_inst, FixedProfile(initial), inv_mode)
+    )
+end
+function EMB.SingleInvData(
+    capex_trans::TimeProfile,
+    trans_max_inst::TimeProfile,
+    initial::Real,
+    inv_mode::Investment,
+    life_mode::LifetimeMode,
+)
+    @warn(
+        "The used implementation of a `StartInvData` will be discontinued in the near future.\n" *
+        "You have to only change the value of the field `initial` to a `FixedProfile` " *
+        "for utilizing the new version.",
+        maxlog = 1
+    )
+    return SingleInvData(
+        StartInvData(capex_trans, trans_max_inst, FixedProfile(initial), inv_mode, life_mode),
+    )
+end
+
 function EMB.InvData(;
     capex_cap::TimeProfile,
     cap_max_inst::TimeProfile,
@@ -73,12 +102,6 @@ function EMB.InvData(;
     end
 end
 
-"""
-    InvDataStorage(;kwargs)
-
-Internal method for [`InvDataStorage`](@ref EMB.InvDataStorage). The introduction of an
-internal method is necessary as extensions do not allow to export functions or types.
-"""
 function EMB.InvDataStorage(;
     #Investment data related to storage power
     capex_rate::TimeProfile,

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -378,7 +378,7 @@ function check_profile(
     for t_rp ∈ repr_periods(ts)
         check_profile(
             fieldname,
-            value.vals[minimum([t_rp.rper, length(value.vals)])],
+            value.vals[minimum([t_rp.rp, length(value.vals)])],
             t_rp.operational,
             sp,
         )

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -341,7 +341,7 @@ scale_op_sp(t_inv::TS.AbstractStrategicPeriod, t::TS.TimePeriod) =
 
 function multiple(t_inv, t)
     @warn(
-        "`multiple(t_inv, t)` is deprecated, use scale_op_sp(t_inv, t)` instead.",
+        "`multiple(t_inv, t)` is deprecated, use `scale_op_sp(t_inv, t)` instead.",
         maxlog = 1
     )
     return scale_op_sp(t_inv, t)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+EnergyModelsInvestments = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,10 @@ ENV["EMB_TEST"] = true # Set flag for example scripts to check if they are run a
         include("test_checks.jl")
     end
 
+    @testset "Base | Investments" begin
+        include("test_investments.jl")
+    end
+
     @testset "Base | examples" begin
         include("test_examples.jl")
     end

--- a/test/test_investments.jl
+++ b/test/test_investments.jl
@@ -1,0 +1,524 @@
+using EnergyModelsInvestments
+
+@testset "Simple network" begin
+    # Create simple model
+    function investment_model()
+        # Define the different resources
+        NG = ResourceEmit("NG", 0.2)
+        Coal = ResourceCarrier("Coal", 0.35)
+        Power = ResourceCarrier("Power", 0.0)
+        CO2 = ResourceEmit("CO2", 1.0)
+        products = [NG, Coal, Power, CO2]
+
+        op_profile = OperationalProfile([
+            20,
+            20,
+            20,
+            20,
+            25,
+            30,
+            35,
+            35,
+            40,
+            40,
+            40,
+            40,
+            40,
+            35,
+            35,
+            30,
+            25,
+            30,
+            35,
+            30,
+            25,
+            20,
+            20,
+            20,
+        ])
+
+        nodes = [
+            GenAvailability(1, products),
+            RefSink(
+                2,
+                op_profile,
+                Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
+                Dict(Power => 1),
+            ),
+            RefSource(
+                3,
+                FixedProfile(30),
+                FixedProfile(30),
+                FixedProfile(100),
+                Dict(NG => 1),
+                [
+                    SingleInvData(
+                        FixedProfile(1000), # capex [€/kW]
+                        FixedProfile(200),  # max installed capacity [kW]
+                        FixedProfile(15),   # initial capacity [kW]
+                        ContinuousInvestment(FixedProfile(10), FixedProfile(200)), # investment mode
+                    ),
+                ],
+            ),
+            RefSource(
+                4,
+                FixedProfile(9),
+                FixedProfile(9),
+                FixedProfile(100),
+                Dict(Coal => 1),
+                [
+                    SingleInvData(
+                        FixedProfile(1000), # capex [€/kW]
+                        FixedProfile(200),  # max installed capacity [kW]
+                        ContinuousInvestment(FixedProfile(0), FixedProfile(200)), # investment mode
+                    ),
+                ],
+            ),
+            RefNetworkNode(
+                5,
+                FixedProfile(0),
+                FixedProfile(5.5),
+                FixedProfile(100),
+                Dict(NG => 2),
+                Dict(Power => 1, CO2 => 0),
+                [
+                    SingleInvData(
+                        FixedProfile(600),  # capex [€/kW]
+                        FixedProfile(25),   # max installed capacity [kW]
+                        ContinuousInvestment(FixedProfile(0), FixedProfile(25)), # investment mode
+                    ),
+                    CaptureEnergyEmissions(0.9),
+                ],
+            ),
+            RefNetworkNode(
+                6,
+                FixedProfile(0),
+                FixedProfile(6),
+                FixedProfile(100),
+                Dict(Coal => 2.5),
+                Dict(Power => 1),
+                [
+                    SingleInvData(
+                        FixedProfile(800),  # capex [€/kW]
+                        FixedProfile(25),   # max installed capacity [kW]
+                        ContinuousInvestment(FixedProfile(0), FixedProfile(25)), # investment mode
+                    ),
+                    EmissionsEnergy(),
+                ],
+            ),
+            RefStorage{AccumulatingEmissions}(
+                7,
+                StorCapOpex(FixedProfile(0), FixedProfile(9.1), FixedProfile(100)),
+                StorCap(FixedProfile(0)),
+                CO2,
+                Dict(CO2 => 1, Power => 0.02),
+                Dict(CO2 => 1),
+                [
+                    StorageInvData(
+                        charge = NoStartInvData(
+                            FixedProfile(0),
+                            FixedProfile(600),
+                            ContinuousInvestment(FixedProfile(0), FixedProfile(600)),
+                            UnlimitedLife(),
+                        ),
+                        level = NoStartInvData(
+                            FixedProfile(500),
+                            FixedProfile(600),
+                            ContinuousInvestment(FixedProfile(0), FixedProfile(600)),
+                            UnlimitedLife(),
+                        ),
+                    ),
+                ],
+            ),
+            RefNetworkNode(
+                8,
+                FixedProfile(2),
+                FixedProfile(0),
+                FixedProfile(0),
+                Dict(Coal => 2.5),
+                Dict(Power => 1),
+                [
+                    SingleInvData(
+                        FixedProfile(0),    # capex [€/kW]
+                        FixedProfile(25),    # max installed capacity [kW]
+                        ContinuousInvestment(FixedProfile(2), FixedProfile(2)), # investment mode
+                    ),
+                    EmissionsEnergy(),
+                ],
+            ),
+            RefStorage{AccumulatingEmissions}(
+                9,
+                StorCapOpex(FixedProfile(3), FixedProfile(0), FixedProfile(0)),
+                StorCap(FixedProfile(5)),
+                CO2,
+                Dict(CO2 => 1, Power => 0.02),
+                Dict(CO2 => 1),
+                [
+                    StorageInvData(
+                        charge = NoStartInvData(
+                            FixedProfile(0),
+                            FixedProfile(30),
+                            ContinuousInvestment(FixedProfile(3), FixedProfile(3)),
+                            UnlimitedLife(),
+                        ),
+                        level = NoStartInvData(
+                            FixedProfile(0),
+                            FixedProfile(50),
+                            ContinuousInvestment(FixedProfile(5), FixedProfile(5)),
+                            UnlimitedLife(),
+                        ),
+                    ),
+                ],
+            ),
+            RefNetworkNode(
+                10,
+                FixedProfile(0),
+                FixedProfile(0),
+                FixedProfile(0),
+                Dict(Coal => 2.5),
+                Dict(Power => 1),
+                [
+                    SingleInvData(
+                        FixedProfile(10000),        # capex [€/kW]
+                        FixedProfile(10000),     # max installed capacity [kW]
+                        ContinuousInvestment(FixedProfile(0), FixedProfile(10000)),  # investment mode
+                    ),
+                    EmissionsEnergy(),
+                ],
+            ),
+        ]
+        links = [
+            Direct(15, nodes[1], nodes[5], Linear())
+            Direct(16, nodes[1], nodes[6], Linear())
+            Direct(17, nodes[1], nodes[7], Linear())
+            Direct(18, nodes[1], nodes[8], Linear())
+            Direct(19, nodes[1], nodes[9], Linear())
+            Direct(110, nodes[1], nodes[10], Linear())
+            Direct(12, nodes[1], nodes[2], Linear())
+            Direct(31, nodes[3], nodes[1], Linear())
+            Direct(41, nodes[4], nodes[1], Linear())
+            Direct(51, nodes[5], nodes[1], Linear())
+            Direct(61, nodes[6], nodes[1], Linear())
+            Direct(71, nodes[7], nodes[1], Linear())
+            Direct(81, nodes[8], nodes[1], Linear())
+            Direct(91, nodes[9], nodes[1], Linear())
+            Direct(101, nodes[10], nodes[1], Linear())
+        ]
+
+        # Creation of the time structure and global data
+        T = TwoLevel(4, 1, SimpleTimes(24, 1), op_per_strat = 24)
+        em_limits = Dict(NG => FixedProfile(1e6), CO2 => StrategicProfile([450, 400, 350, 300]))
+        em_cost = Dict(NG => FixedProfile(0), CO2 => FixedProfile(0))
+        modeltype = InvestmentModel(em_limits, em_cost, CO2, 0.07)
+
+        # WIP case structure
+        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+        return case, modeltype
+    end
+
+    case, modeltype = investment_model()
+    m = run_model(case, modeltype, HiGHS.Optimizer)
+
+    # Test for the total number of variables
+    # (-80 ((6+4)*2*4) compared to 0.5.x as binaries only defined, if required through SparseVariables)
+    # (+192 (2*4*24) compared to 0.5.x as stor_discharge_use added as variable)
+    @test size(all_variables(m))[1] == 10224
+
+    # Test results
+    # (-724 compared to 0.5.x as RefStorage as emission source does not require a charge
+    #  capacity any longer in 0.7.x)
+    @test round(objective_value(m)) ≈ -302624
+
+    # Test that investments are happening
+    𝒯ᴵⁿᵛ = strategic_periods(case[:T])
+    𝒩 = case[:nodes]
+    𝒩ᴵⁿᵛ = filter(has_investment, filter(!EMB.is_storage, 𝒩))
+    𝒩ˢᵗᵒʳ = filter(EMB.is_storage, 𝒩)
+    𝒩ˡᵉᵛᵉˡ = filter(n -> has_investment(n, :level), 𝒩ˢᵗᵒʳ)
+    𝒩ᶜʰᵃʳᵍᵉ = filter(n -> has_investment(n, :charge), 𝒩ˢᵗᵒʳ)
+
+    @test sum(
+        sum(value.(m[:cap_add][n, t_inv]) > 0 for n ∈ 𝒩ᴵⁿᵛ)
+        for t_inv ∈ 𝒯ᴵⁿᵛ) > 0
+    @test sum(
+        sum(value.(m[:stor_level_add][n, t_inv]) > 0 for n ∈ 𝒩ˡᵉᵛᵉˡ)
+        for t_inv ∈ 𝒯ᴵⁿᵛ) > 0
+    @test sum(
+        sum(value.(m[:stor_charge_add][n, t_inv]) > 0 for n ∈ 𝒩ᶜʰᵃʳᵍᵉ)
+        for t_inv ∈ 𝒯ᴵⁿᵛ) > 0
+
+end
+
+# Set the global to true to suppress the error message
+EMB.TEST_ENV = true
+
+@testset "Test checks - InvestmentData" begin
+
+    # Testing, that the checks for NoStartInvData and StartInvData are working
+    # - EMB.check_node_data(n::EMB.Node, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel)
+    @testset "SingleInvData" begin
+
+        function build_simple_graph(;
+            cap = FixedProfile(0),
+            min_add = FixedProfile(0),
+            max_add = FixedProfile(10),
+            inv_data = nothing,
+        )
+            if isnothing(inv_data)
+                inv_data = [
+                    SingleInvData(
+                        FixedProfile(1000),     # capex [€/kW]
+                        FixedProfile(30),       # max installed capacity [kW]
+                        ContinuousInvestment(min_add, max_add),   # investment mode
+                    ),
+                ]
+            end
+
+            CO2 = ResourceEmit("CO2", 1.0)
+            Power = ResourceCarrier("Power", 0.0)
+            products = [Power, CO2]
+
+            source = RefSource(
+                "-src",
+                cap,
+                FixedProfile(10),
+                FixedProfile(5),
+                Dict(Power => 1),
+                inv_data,
+            )
+            sink = RefSink(
+                "-snk",
+                FixedProfile(20),
+                Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e4)),
+                Dict(Power => 1),
+            )
+            nodes = [source, sink]
+            links = [Direct("scr-sink", nodes[1], nodes[2], Linear())]
+            T = TwoLevel(4, 10, SimpleTimes(4, 1))
+            case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+
+            em_limits = Dict(CO2 => StrategicProfile([450, 400, 350, 300]))
+            em_cost = Dict(CO2 => FixedProfile(0))
+            modeltype = InvestmentModel(em_limits, em_cost, CO2, 0.05)
+
+            return create_model(case, modeltype)
+        end
+
+        # Check that we receive an error if we provide two `InvestmentData`
+        inv_data = [
+            SingleInvData(
+                FixedProfile(1000),     # capex [€/kW]
+                FixedProfile(30),       # max installed capacity [kW]
+                ContinuousInvestment(FixedProfile(0), FixedProfile(20)), # investment mode
+            ),
+            SingleInvData(
+                FixedProfile(1000),     # capex [€/kW]
+                FixedProfile(30),       # max installed capacity [kW]
+                ContinuousInvestment(FixedProfile(0), FixedProfile(20)),   # investment mode
+            ),
+        ]
+        @test_throws AssertionError build_simple_graph(;inv_data)
+
+        # Check that we receive an error if the profiles are wrong
+        rprofile = RepresentativeProfile([FixedProfile(4)])
+        scprofile = ScenarioProfile([FixedProfile(4)])
+        oprofile = OperationalProfile(ones(4))
+
+        max_add = oprofile
+        @test_throws AssertionError build_simple_graph(;max_add)
+        max_add = scprofile
+        @test_throws AssertionError build_simple_graph(;max_add)
+        max_add = rprofile
+        @test_throws AssertionError build_simple_graph(;max_add)
+        max_add = StrategicProfile([4])
+        @test_throws AssertionError build_simple_graph(;max_add)
+
+        max_add = StrategicProfile([oprofile, oprofile, oprofile, oprofile])
+        @test_throws AssertionError build_simple_graph(;max_add)
+        max_add = StrategicProfile([scprofile, scprofile, scprofile, scprofile])
+        @test_throws AssertionError build_simple_graph(;max_add)
+        max_add = StrategicProfile([rprofile, rprofile, rprofile, rprofile])
+        @test_throws AssertionError build_simple_graph(;max_add)
+
+        # Check that we receive an error if the capacity is an operational profile
+        cap = OperationalProfile(ones(4))
+        @test_throws AssertionError build_simple_graph(;cap)
+        inv_data = [SingleInvData(
+            FixedProfile(1000),     # capex [€/kW]
+            FixedProfile(10),       # max installed capacity [kW]
+            cap,                    # initial capacity
+            ContinuousInvestment(FixedProfile(0), FixedProfile(20)),   # investment mode
+        )]
+        @test_throws AssertionError build_simple_graph(;inv_data)
+
+        # Check that we receive an error if the initial capacity is higher than the
+        # allowed maximum installed
+        cap = FixedProfile(50)
+        @test_throws AssertionError build_simple_graph(;cap)
+        inv_data = [SingleInvData(
+            FixedProfile(1000),     # capex [€/kW]
+            FixedProfile(10),       # max installed capacity [kW]
+            FixedProfile(50),       # initial capacity
+            ContinuousInvestment(FixedProfile(0), FixedProfile(20)),   # investment mode
+        )]
+        @test_throws AssertionError build_simple_graph(;inv_data)
+
+        # Check that we receive an error if we provide a larger `min_add` than `max_add`
+        min_add = FixedProfile(20)
+        @test_throws AssertionError build_simple_graph(;min_add)
+    end
+
+    # Testing, that the checks for StorageInvData are working
+    # - EMB.check_node_data(n::EMB.Storage, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel)
+    @testset "StorageInvData" begin
+
+        function build_simple_graph(;
+            charge_cap = FixedProfile(0),
+            level_cap = FixedProfile(0),
+            min_add = FixedProfile(0),
+            max_add = FixedProfile(10),
+            inv_data = nothing,
+        )
+            if isnothing(inv_data)
+                inv_data = [
+                    StorageInvData(
+                        charge = StartInvData(
+                            FixedProfile(20),
+                            FixedProfile(30),
+                            charge_cap,
+                            ContinuousInvestment(min_add, max_add),
+                            UnlimitedLife(),
+                        ),
+                        level = NoStartInvData(
+                            FixedProfile(500),
+                            FixedProfile(6000),
+                            ContinuousInvestment(FixedProfile(5), FixedProfile(600)),
+                            UnlimitedLife(),
+                        ),
+                    ),
+                ]
+            end
+
+            CO2 = ResourceEmit("CO2", 1.0)
+            Power = ResourceCarrier("Power", 0.0)
+            products = [Power, CO2]
+
+            source = RefSource(
+                "-src",
+                FixedProfile(20),
+                FixedProfile(10),
+                FixedProfile(5),
+                Dict(Power => 1),
+            )
+            storage = RefStorage{CyclicStrategic}(
+                "stor",
+                StorCapOpexVar(charge_cap, FixedProfile(0)),
+                StorCapOpexFixed(level_cap, FixedProfile(100)),
+                Power,
+                Dict(Power => 1.0),
+                Dict(Power => 1.0),
+                inv_data,
+            )
+            sink = RefSink(
+                "-snk",
+                FixedProfile(20),
+                Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e4)),
+                Dict(Power => 1),
+            )
+            nodes = [source, storage, sink]
+            links = [
+                Direct("src-stor", nodes[1], nodes[2], Linear())
+                Direct("src-snk", nodes[1], nodes[3], Linear())
+                Direct("stor-snk", nodes[2], nodes[3], Linear())
+            ]
+            T = TwoLevel(4, 10, SimpleTimes(4, 1))
+            case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+
+            em_limits = Dict(CO2 => StrategicProfile([450, 400, 350, 300]))
+            em_cost = Dict(CO2 => FixedProfile(0))
+            modeltype = InvestmentModel(em_limits, em_cost, CO2, 0.05)
+
+            return create_model(case, modeltype)
+        end
+
+        # Check that we receive an error if we provide the wrong `InvestmentData`
+        inv_data = [
+            SingleInvData(
+                FixedProfile(1000),     # capex [€/kW]
+                FixedProfile(30),       # max installed capacity [kW]
+                ContinuousInvestment(FixedProfile(0), FixedProfile(20)), # investment mode
+            )
+        ]
+        @test_throws AssertionError build_simple_graph(;inv_data)
+
+        # Check that we receive an error if we provide two `InvestmentData`
+        inv_data = [
+            StorageInvData(
+                charge = NoStartInvData(
+                    FixedProfile(20),
+                    FixedProfile(30),
+                    ContinuousInvestment(FixedProfile(5), FixedProfile(20)),
+                ),
+                level = NoStartInvData(
+                    FixedProfile(500),
+                    FixedProfile(600),
+                    ContinuousInvestment(FixedProfile(5), FixedProfile(600)),
+                ),
+            ),
+            StorageInvData(
+                charge = NoStartInvData(
+                    FixedProfile(20),
+                    FixedProfile(30),
+                    ContinuousInvestment(FixedProfile(5), FixedProfile(20)),
+                ),
+                level = NoStartInvData(
+                    FixedProfile(500),
+                    FixedProfile(600),
+                    ContinuousInvestment(FixedProfile(5), FixedProfile(600)),
+                ),
+            ),
+        ]
+        @test_throws AssertionError build_simple_graph(;inv_data)
+
+        # Check that we receive an error if the profiles are wrong
+        rprofile = RepresentativeProfile([FixedProfile(4)])
+        scprofile = ScenarioProfile([FixedProfile(4)])
+        oprofile = OperationalProfile(ones(4))
+
+        max_add = oprofile
+        @test_throws AssertionError build_simple_graph(;max_add)
+        max_add = scprofile
+        @test_throws AssertionError build_simple_graph(;max_add)
+        max_add = rprofile
+        @test_throws AssertionError build_simple_graph(;max_add)
+        max_add = StrategicProfile([4])
+        @test_throws AssertionError build_simple_graph(;max_add)
+
+        max_add = StrategicProfile([oprofile, oprofile, oprofile, oprofile])
+        @test_throws AssertionError build_simple_graph(;max_add)
+        max_add = StrategicProfile([scprofile, scprofile, scprofile, scprofile])
+        @test_throws AssertionError build_simple_graph(;max_add)
+        max_add = StrategicProfile([rprofile, rprofile, rprofile, rprofile])
+        @test_throws AssertionError build_simple_graph(;max_add)
+
+        # Check that we receive an error if the capacity is an operational profile
+        charge_cap = OperationalProfile(ones(4))
+        @test_throws AssertionError build_simple_graph(;charge_cap)
+        level_cap = OperationalProfile(ones(4))
+        @test_throws AssertionError build_simple_graph(;level_cap)
+
+        # Check that we receive an error if the initial capacity is higher than the
+        # allowed maximum installed
+        charge_cap = FixedProfile(50)
+        @test_throws AssertionError build_simple_graph(;charge_cap)
+        level_cap = FixedProfile(10000)
+        @test_throws AssertionError build_simple_graph(;level_cap)
+
+        # Check that we receive an error if we provide a larger `min_add` than `max_add`
+        min_add = FixedProfile(20)
+        @test_throws AssertionError build_simple_graph(;min_add)
+    end
+end
+
+# Set the global again to false
+EMB.TEST_ENV = false


### PR DESCRIPTION
Due to the changes in [`EnergyModelsInvestments` 0.8](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/releases/tag/v0.8.0), we had to do minor adjustments in EnergyModelsBase. These adjustments are:

- switch the initial capacity to a `TimeProfile` in the constructors of `SingleInvData` (also in checks),
- move of the investment examples and tests to `EnergyModelsBase` to be certain that they are working, and
- a minor change in the checks due to a naming change in `TimeStruct`.

Furthermore, we switched the Julia requirement to 1.10, corresponding to the LTS.

This is the last PR before registering the new version 0.8.1.