### PR TITLE
Enhanc/Potential in links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Since EnergyModelsBase doesn't have binary dependencies, 
+        # Since EnergyModelsBase doesn't have binary dependencies,
         # only test on a subset of possible platforms.
         include:
           - version: '1'  # The latest point-release (Linux)
@@ -22,18 +22,18 @@ jobs:
           - version: '1'  # The latest point-release (Windows)
             os: windows-latest
             arch: x64
-          - version: '1.10'  # 1.10
+          - version: 'lts'  # lts 
             os: ubuntu-latest
             arch: x64
-          - version: '1.10'  # 1.10
-            os: ubuntu-latest
-            arch: x86
+          - version: 'lts'  # lts
+            os: windows-latest
+            arch: x64
           # - version: 'nightly'
           #   os: ubuntu-latest
           #   arch: x64
     steps:
-      - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -51,4 +51,3 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         with:
           depwarn: error
-      - uses: julia-actions/julia-processcoverage@v1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,26 @@
 # Release notes
 
+## Unversioned
+
+### Incorporation of bidirectional flow
+
+* Allow (in theory) for nodes and links with bidirectional flow through avoiding hard-coding a lower bound on flow variables.
+* No existing links and nodes allow for bidirectional flow.
+* Bidirectional flow requires new links and nodes with new methods for the function `is_unidirectional`.
+
+### Rework of links
+
+* Extended the functionality of links significantly.
+* Allow for
+  * differing input and output resources of links as well as specifying these directly,
+  * emissions of links,
+  * OPEX of links (with both fixed and variable OPEX created at the same time),
+  * capacity of links,
+  * inclusion of specific link variables, and
+  * investments in links if the links have a capacity.
+* The majority of changes are incorporated through filter functions and require the user to define new methods for the included functions (*i.e.*, `has_opex`, `has_emissions`, and `has_capacity`)
+* Inclusion of variables follows principle of additional node variables.
+
 ## Version 0.8.1 (2024-10-16)
 
 ### Bugfixes

--- a/docs/src/how-to/contribute.md
+++ b/docs/src/how-to/contribute.md
@@ -7,7 +7,7 @@ Contributing to `EnergyModelsBase` can be achieved in several different ways.
 The main focus of `EnergyModelsBase` is to provide an easily extensible energy system optimization modelling framework.
 Hence, a first approach to contributing to `EnergyModelsBase` is to create a new package with, *e.g.*, the introduction of new node descriptions.
 
-This is explained in [_How to create a new node_](@ref how_to-create_node).
+This is explained in *[How to create a new node](@ref how_to-create_node)*.
 
 !!! tip
     If you are uncertain how you could incorporate new nodal descriptions, take a look at [`EnergyModelsRenewableProducers`](https://github.com/EnergyModelsX/EnergyModelsRenewableProducers.jl).
@@ -90,8 +90,8 @@ It is in general preferable to work on a separate branch when developing new com
 
 Incorporate your changes in your new branch.
 The changes should be commented to understand the thought process behind them.
-In addition, please provide new tests for the added functionality and be certain that the tests run.
-The tests should be based on a minimum working example.
+In addition, please provide new tests for the added functionality and be certain that the existing tests run.
+New tests should be based on a minimum working example in which the new concept is evaluated.
 
 Some existing tests may potentially require changes when incorporating new features (especially within the test set `General tests`).
 In this case, it is ok that they are failing and we will comment on the required changes in the pull request.
@@ -103,7 +103,7 @@ It is not necessary to provide changes directly in the documentation.
 It can be easier to include these changes after the pull request is accepted in principal.
 It is however a requirement to update the [`NEWS.md`](https://github.com/EnergyModelsX/EnergyModelsBase.jl/blob/main/NEWS.md) file under a new subheading titled "Unversioned".
 
-!!! note
+!!! note "Used style in EnergyModelsBase"
     Currently, we have not written a style guide for the framework.
     We follow in general the conventions of the *[Blue style guide](https://github.com/JuliaDiff/BlueStyle)* with minor modifications.
 
@@ -116,4 +116,4 @@ Once you are satisified with your changes, create a pull request towards the mai
 We will internally assign the relevant person to the pull request.
 
 You may receive quite a few comments with respect to the incorporation and how it may potentially affect other parts of the code.
-Please remaing patient as it may take potentially some time before we can respond to the changes, although we try to answer as fast as possible.
+Please remain patient as it may take potentially some time before we can respond to the changes, although we try to answer as fast as possible.

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -14,7 +14,7 @@ CurrentModule = EnergyModelsBase
 
 ```@docs
 create_link
-objective(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
+objective(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype::EnergyModel)
 ```
 
 ## Constraint functions
@@ -38,6 +38,7 @@ variables_emission
 variables_flow
 variables_opex
 variables_nodes
+variables_links_opex
 ```
 
 ## Check functions

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -38,6 +38,7 @@ variables_emission
 variables_flow
 variables_opex
 variables_nodes
+variables_links
 variables_links_capacity
 variables_links_opex
 ```

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -33,7 +33,7 @@ constraints_level_bounds
 
 ```@docs
 variables_capacity
-variables_capex(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
+variables_capex(m, 𝒩, 𝒯, modeltype::EnergyModel)
 variables_emission
 variables_flow
 variables_opex
@@ -41,6 +41,7 @@ variables_nodes
 variables_links
 variables_links_capacity
 variables_links_opex
+variables_links_capex(m, ℒ, 𝒯, modeltype::EnergyModel)
 ```
 
 ## Check functions

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -38,6 +38,7 @@ variables_emission
 variables_flow
 variables_opex
 variables_nodes
+variables_links_capacity
 variables_links_opex
 ```
 

--- a/docs/src/library/internals/reference_EMIExt.md
+++ b/docs/src/library/internals/reference_EMIExt.md
@@ -34,7 +34,7 @@ check_inv_data
 ```@docs
 EMB.variables_capex(m, 𝒩, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
 EMB.constraints_capacity_installed(m, n::EMB.Node, 𝒯::TimeStructure, modeltype::AbstractInvestmentModel)
-EMB.objective(m, 𝒩, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
+EMB.objective(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype::AbstractInvestmentModel)
 EMB.check_node_data(n::EMB.Node, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel, check_timeprofiles::Bool)
 ```
 

--- a/docs/src/library/internals/reference_EMIExt.md
+++ b/docs/src/library/internals/reference_EMIExt.md
@@ -32,7 +32,8 @@ check_inv_data
 ### Methods
 
 ```@docs
-EMB.variables_capex(m, 𝒩, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
+EMB.variables_capex(m, 𝒩, 𝒯, modeltype::AbstractInvestmentModel)
+EMB.variables_links_capex(m, ℒ, 𝒯, modeltype::AbstractInvestmentModel)
 EMB.constraints_capacity_installed(m, n::EMB.Node, 𝒯::TimeStructure, modeltype::AbstractInvestmentModel)
 EMB.objective(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype::AbstractInvestmentModel)
 EMB.check_node_data(n::EMB.Node, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel, check_timeprofiles::Bool)

--- a/docs/src/library/public/functions.md
+++ b/docs/src/library/public/functions.md
@@ -32,6 +32,7 @@ See the page *[Creating a new node](@ref how_to-create_node)* for a detailed exp
 ```@docs
 variables_node
 create_node
+variables_link
 ```
 
 ## [Constraint functions](@id lib-pub-fun-con)

--- a/docs/src/library/public/links.md
+++ b/docs/src/library/public/links.md
@@ -25,7 +25,7 @@ Linear
 
 The following functions are declared for accessing fields from a `Link` type.
 
-!!! warning
+!!! warning "New link types"
     If you want to introduce new `Link` types, it is important that the function `formulation` is either functional for your new types or you have to declare a corresponding function.
     The first approach can be achieved through using the same name for the respective fields.
 
@@ -33,6 +33,7 @@ The following functions are declared for accessing fields from a `Link` type.
 inputs(n::Link)
 outputs(n::Link)
 formulation
+link_data
 ```
 
 ## [Functions for identifying `Link`s](@id lib-pub-links-fun_identify)

--- a/docs/src/library/public/links.md
+++ b/docs/src/library/public/links.md
@@ -40,6 +40,7 @@ formulation
 The following functions are declared for filtering on `Link` types.
 
 ```@docs
+has_capacity(l::Link)
 has_emissions(l::Link)
 has_opex(l::Link)
 is_unidirectional(l::Link)

--- a/docs/src/library/public/links.md
+++ b/docs/src/library/public/links.md
@@ -41,5 +41,6 @@ The following functions are declared for filtering on `Link` types.
 
 ```@docs
 has_emissions(l::Link)
+has_opex(l::Link)
 is_unidirectional(l::Link)
 ```

--- a/docs/src/library/public/links.md
+++ b/docs/src/library/public/links.md
@@ -21,7 +21,7 @@ Direct
 Linear
 ```
 
-## [Functions for accessing fields of `Link` types](@id lib-pub-fun_field)
+## [Functions for accessing fields of `Link` types](@id lib-pub-links-fun_field)
 
 The following functions are declared for accessing fields from a `Link` type.
 
@@ -33,4 +33,12 @@ The following functions are declared for accessing fields from a `Link` type.
 inputs(n::Link)
 outputs(n::Link)
 formulation
+```
+
+## [Functions for identifying `Link`s](@id lib-pub-links-fun_identify)
+
+The following functions are declared for filtering on `Link` types.
+
+```@docs
+is_unidirectional(l::Link)
 ```

--- a/docs/src/library/public/links.md
+++ b/docs/src/library/public/links.md
@@ -40,5 +40,6 @@ formulation
 The following functions are declared for filtering on `Link` types.
 
 ```@docs
+has_emissions(l::Link)
 is_unidirectional(l::Link)
 ```

--- a/docs/src/library/public/links.md
+++ b/docs/src/library/public/links.md
@@ -30,5 +30,7 @@ The following functions are declared for accessing fields from a `Link` type.
     The first approach can be achieved through using the same name for the respective fields.
 
 ```@docs
+inputs(n::Link)
+outputs(n::Link)
 formulation
 ```

--- a/docs/src/library/public/nodes.md
+++ b/docs/src/library/public/nodes.md
@@ -133,4 +133,5 @@ has_output
 has_emissions
 has_charge
 has_discharge
+is_unidirectional(n::EnergyModelsBase.Node)
 ```

--- a/docs/src/library/public/nodes.md
+++ b/docs/src/library/public/nodes.md
@@ -130,7 +130,7 @@ nodes_output
 nodes_emissions
 has_input
 has_output
-has_emissions
+has_emissions(n::EnergyModelsBase.Node)
 has_charge
 has_discharge
 is_unidirectional(n::EnergyModelsBase.Node)

--- a/docs/src/library/public/nodes.md
+++ b/docs/src/library/public/nodes.md
@@ -101,8 +101,8 @@ The following functions are declared for accessing fields from a `Node` type.
 capacity
 opex_var
 opex_fixed
-inputs
-outputs
+inputs(n::EnergyModelsBase.Node)
+outputs(n::EnergyModelsBase.Node)
 node_data
 charge
 level

--- a/docs/src/manual/optimization-variables.md
+++ b/docs/src/manual/optimization-variables.md
@@ -136,6 +136,19 @@ The following node variable is then declared for all emission resource 𝒫ᵉ�
 
 - ``\texttt{emissions\_node}[n, t, p_\texttt{em}]``:  Emissions of node ``n`` at operational period ``t`` of emission resource ``p_\texttt{em}``.
 
+Similarly, it is not necessary that links have associated emission variables.
+Emission variables are only created for a link ``l`` if the function [`has_emissions(n::Link)`](@ref) returns `true`.
+The following link variable is then declared for all emission resource 𝒫ᵉᵐ:
+
+- ``\texttt{emissions\_link}[n, t, p_\texttt{em}]``:  Emissions of link ``l`` at operational period ``t`` of emission resource ``p_\texttt{em}``.
+
+!!! tip "Links with emissions"
+    All links introduced in `EnergyModelsBase` do not allow for emissions.
+    If you plan to introduce a link with emissions, you have to create a new method for the function `has_emissions` for your introduced link.
+
+    We have not implemented a similar approach as for nodes.
+    It is however planned to allow for transmission emissions in the near future, similar to the concept employed for process emissions for nodes.
+
 In addition, `EnergyModelsBase` declares the following variables for the global emissions:
 
 - ``\texttt{emissions\_total}[t, p_\texttt{em}]``: Total emissions of `ResourceEmit` ``p_\texttt{em}`` in operational period ``t``, and

--- a/docs/src/manual/optimization-variables.md
+++ b/docs/src/manual/optimization-variables.md
@@ -113,7 +113,19 @@ for t_inv ∈ 𝒯ᴵⁿᵛ, n ∈ 𝒩ˢᵘᵇ
 end
 ```
 
-The variables ``\texttt{cap\_inst}``, ``\texttt{stor\_charge\_inst}``, ``\texttt{stor\_level\_inst}``, and ``\texttt{stor\_discharge\_inst}`` are used in `EnergyModelsInvestment` to allow for investments in capacity of individual nodes.
+We also introduce the potential for links with capacities.
+By default, links do not introduce new variables.
+The capacity variable is only created for a link ``l`` if the function [`has_capacity(n::Link)`](@ref) returns `true`.
+The following link variable ise then declared representing the capacity of links:
+
+- ``\texttt{link\_cap\_inst}[l, t]``: Installed capacity of link ``l`` at operational period ``t``.
+
+!!! tip "Links with a capacity"
+    All links introduced in `EnergyModelsBase` do not allow for a capacity limiting the transfer.
+    If you plan to introduce a link with a capacity, you have to create a new method for the function `has_capacity` for your introduced link.
+
+!!! note "Inclusions of investments"
+    The variables ``\texttt{cap\_inst}``, ``\texttt{stor\_charge\_inst}``, ``\texttt{stor\_level\_inst}``, ``\texttt{stor\_discharge\_inst}``, and ``\texttt{link\_cap\_inst}`` are used in `EnergyModelsInvestment` to allow for investments in capacity of individual nodes.
 
 ## [Flow variables](@id man-opt_var-flow)
 

--- a/docs/src/manual/optimization-variables.md
+++ b/docs/src/manual/optimization-variables.md
@@ -47,6 +47,18 @@ Instead, it is only dependent on the installed capacity.
 It is calculated using the function [`constraints_opex_fixed`](@ref).
 It represents fixed costs like labour cost, maintenance, as well as insurances and taxes.
 
+We also introduce the potential for links with operational costs.
+By default, links do not introduce new variables.
+Operational cost variables are only created for a link ``l`` if the function [`has_opex(n::Link)`](@ref) returns `true`.
+The following link variables are then declared representing the operational costs of the links:
+
+- ``\texttt{link\_opex\_var}[l, t_\texttt{inv}]``:  Variable OPEX of link ``l`` in strategic period ``t_\texttt{inv}``.
+- ``\texttt{link\_opex\_foxed}[l, t_\texttt{inv}]``:  Fixed OPEX of link ``l`` in strategic period ``t_\texttt{inv}``.
+
+!!! tip "Links with OPEX"
+    All links introduced in `EnergyModelsBase` do not allow for operational costs.
+    If you plan to introduce a link with operational costs, you have to create a new method for the function `has_opex` for your introduced link.
+
 ## [Capacity variables](@id man-opt_var-cap)
 
 Capacity variables focus on both the capacity usage and installed capacity.

--- a/ext/EMIExt/EMIExt.jl
+++ b/ext/EMIExt/EMIExt.jl
@@ -70,13 +70,15 @@ EMI.investment_data(inv_data::SingleInvData) = inv_data.cap
     EMI.investment_data(n::EMB.Node, field::Symbol)
     EMI.investment_data(l::Link, field::Symbol)
 
-Return the `InvestmentData` of the Node `n` or Link `l`.
+Return the `InvestmentData` of the Node `n` or Link `l`. It will return an error if the
+if the Node `n` or Link `l` does not have investment data.
+
 If `field` is specified, it returns the `InvData` for the corresponding capacity.
 """
 EMI.investment_data(n::EMB.Node) =
     filter(data -> typeof(data) <: InvestmentData, node_data(n))[1]
-    EMI.investment_data(l::Link) =
-        filter(data -> typeof(data) <: InvestmentData, link_data(l))[1]
+EMI.investment_data(l::Link) =
+    filter(data -> typeof(data) <: InvestmentData, link_data(l))[1]
 EMI.investment_data(n::EMB.Node, field::Symbol) = getproperty(investment_data(n), field)
 EMI.investment_data(l::Link, field::Symbol) = getproperty(investment_data(l), field)
 

--- a/ext/EMIExt/EMIExt.jl
+++ b/ext/EMIExt/EMIExt.jl
@@ -31,6 +31,19 @@ function EMI.has_investment(n::EMB.Node)
 end
 
 """
+    EMI.has_investment(l::Link)
+
+For a given Link `l`, checks that it contains the required investment data.
+"""
+function EMI.has_investment(l::Link)
+    (
+        has_capacity(l) &&
+        hasproperty(l, :data) &&
+        !isnothing(findfirst(data -> typeof(data) <: InvestmentData, link_data(l)))
+    )
+end
+
+"""
     EMI.has_investment(n::Storage, field::Symbol)
 
 For a given `Storage` node, checks that it contains investments for the field
@@ -53,19 +66,26 @@ EMI.investment_data(inv_data::SingleInvData) = inv_data.cap
 
 """
     EMI.investment_data(n::EMB.Node)
+    EMI.investment_data(l::Link)
     EMI.investment_data(n::EMB.Node, field::Symbol)
+    EMI.investment_data(l::Link, field::Symbol)
 
-Return the `InvestmentData` of the Node `n` or if `field` is specified, it returns the
-`InvData` for the corresponding capacity.
+Return the `InvestmentData` of the Node `n` or Link `l`.
+If `field` is specified, it returns the `InvData` for the corresponding capacity.
 """
 EMI.investment_data(n::EMB.Node) =
     filter(data -> typeof(data) <: InvestmentData, node_data(n))[1]
+    EMI.investment_data(l::Link) =
+        filter(data -> typeof(data) <: InvestmentData, link_data(l))[1]
 EMI.investment_data(n::EMB.Node, field::Symbol) = getproperty(investment_data(n), field)
+EMI.investment_data(l::Link, field::Symbol) = getproperty(investment_data(l), field)
 
 
 EMI.start_cap(n::EMB.Node, t_inv, inv_data::NoStartInvData, cap) =
     capacity(n, t_inv)
 EMI.start_cap(n::Storage, t_inv, inv_data::NoStartInvData, cap) =
     capacity(getproperty(n, cap), t_inv)
+EMI.start_cap(l::Link, t_inv, inv_data::NoStartInvData, cap) =
+    capacity(l, t_inv)
 
 end

--- a/ext/EMIExt/objective.jl
+++ b/ext/EMIExt/objective.jl
@@ -29,6 +29,7 @@ function EMB.objective(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype::AbstractInvestmentMo
 
     # Filtering through the individual links
     ℒᵒᵖᵉˣ = filter(has_opex, ℒ)
+    ℒᴵⁿᵛ = filter(has_investment, ℒ)
 
     𝒫ᵉᵐ = filter(EMB.is_resource_emit, 𝒫)              # Emissions resources
 
@@ -51,7 +52,7 @@ function EMB.objective(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype::AbstractInvestmentMo
         )
     )
 
-    # Calculation of the capital cost contribution
+    # Calculation of the capital cost contributionof standard nodes
     capex_cap = @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
         sum(m[:cap_capex][n, t_inv] for n ∈ 𝒩ᴵⁿᵛ)
     )
@@ -63,12 +64,18 @@ function EMB.objective(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype::AbstractInvestmentMo
         sum(m[:stor_discharge_capex][n, t_inv] for n ∈ 𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ)
     )
 
+    # Calculation of the capital cost contribution of Links
+    capex_link = @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
+        sum(m[:link_cap_capex][l, t_inv] for l ∈ ℒᴵⁿᵛ)
+    )
+
     # Calculation of the objective function.
     @objective(m, Max,
         -sum(
             (opex[t_inv] + link_opex[t_inv] + emissions[t_inv]) *
             duration_strat(t_inv) * objective_weight(t_inv, disc; type = "avg") +
-            (capex_cap[t_inv] + capex_stor[t_inv]) * objective_weight(t_inv, disc)
-            for t_inv ∈ 𝒯ᴵⁿᵛ)
+            (capex_cap[t_inv] + capex_stor[t_inv] + capex_link[t_inv]) *
+            objective_weight(t_inv, disc)
+        for t_inv ∈ 𝒯ᴵⁿᵛ)
     )
 end

--- a/ext/EMIExt/objective.jl
+++ b/ext/EMIExt/objective.jl
@@ -52,7 +52,7 @@ function EMB.objective(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype::AbstractInvestmentMo
         )
     )
 
-    # Calculation of the capital cost contributionof standard nodes
+    # Calculation of the capital cost contribution of standard nodes
     capex_cap = @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
         sum(m[:cap_capex][n, t_inv] for n ∈ 𝒩ᴵⁿᵛ)
     )

--- a/ext/EMIExt/structures/inv_data.jl
+++ b/ext/EMIExt/structures/inv_data.jl
@@ -28,36 +28,36 @@ struct SingleInvData <: EMB.SingleInvData
 end
 EMB.SingleInvData(args...) = SingleInvData(args...)
 function EMB.SingleInvData(
-    capex_trans::TimeProfile,
-    trans_max_inst::TimeProfile,
+    capex::TimeProfile,
+    max_inst::TimeProfile,
     inv_mode::Investment,
 )
-    return SingleInvData(NoStartInvData(capex_trans, trans_max_inst, inv_mode))
+    return SingleInvData(NoStartInvData(capex, max_inst, inv_mode))
 end
 function EMB.SingleInvData(
-    capex_trans::TimeProfile,
-    trans_max_inst::TimeProfile,
+    capex::TimeProfile,
+    max_inst::TimeProfile,
     inv_mode::Investment,
     life_mode::LifetimeMode,
 )
-    return SingleInvData(NoStartInvData(capex_trans, trans_max_inst, inv_mode, life_mode))
+    return SingleInvData(NoStartInvData(capex, max_inst, inv_mode, life_mode))
 end
 function EMB.SingleInvData(
-    capex_trans::TimeProfile,
-    trans_max_inst::TimeProfile,
+    capex::TimeProfile,
+    max_inst::TimeProfile,
     initial::TimeProfile,
     inv_mode::Investment,
 )
-    return SingleInvData(StartInvData(capex_trans, trans_max_inst, initial, inv_mode))
+    return SingleInvData(StartInvData(capex, max_inst, initial, inv_mode))
 end
 function EMB.SingleInvData(
-    capex_trans::TimeProfile,
-    trans_max_inst::TimeProfile,
+    capex::TimeProfile,
+    max_inst::TimeProfile,
     initial::TimeProfile,
     inv_mode::Investment,
     life_mode::LifetimeMode,
 )
     return SingleInvData(
-        StartInvData(capex_trans, trans_max_inst, initial, inv_mode, life_mode),
+        StartInvData(capex, max_inst, initial, inv_mode, life_mode),
     )
 end

--- a/ext/EMIExt/variables_capex.jl
+++ b/ext/EMIExt/variables_capex.jl
@@ -1,5 +1,5 @@
 """
-    EMB.variables_capex(m, 𝒩, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
+    EMB.variables_capex(m, 𝒩, 𝒯, modeltype::AbstractInvestmentModel)
 
 Create variables for the capital costs for the investments in storage and technology nodes.
 
@@ -27,7 +27,7 @@ Additional variables for investment in storage:
 * `:stor_charge_invest_b` - binary variable whether investments in rate are happening
 * `:stor_charge_remove_b` - binary variable whether investments in rate are removed
 """
-function EMB.variables_capex(m, 𝒩, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
+function EMB.variables_capex(m, 𝒩, 𝒯, modeltype::AbstractInvestmentModel)
     𝒩ᴵⁿᵛ = filter(has_investment, filter(!EMB.is_storage, 𝒩))
     𝒩ˢᵗᵒʳ = filter(EMB.is_storage, 𝒩)
     𝒩ˡᵉᵛᵉˡ = filter(n -> has_investment(n, :level), 𝒩ˢᵗᵒʳ)
@@ -36,40 +36,66 @@ function EMB.variables_capex(m, 𝒩, 𝒯, 𝒫, modeltype::AbstractInvestmentM
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # Add investment variables for reference nodes for each strategic period:
-    @variable(m, cap_capex[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] >= 0)
-    @variable(m, cap_current[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] >= 0)
-    @variable(m, cap_add[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] >= 0)
-    @variable(m, cap_rem[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] >= 0)
-    @variable(m, cap_invest_b[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] >= 0; container = IndexedVarArray)
-    @variable(m, cap_remove_b[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] >= 0; container = IndexedVarArray)
+    @variable(m, cap_capex[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, cap_current[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, cap_add[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, cap_rem[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, cap_invest_b[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
+    @variable(m, cap_remove_b[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
 
     # Add storage specific investment variables for each strategic period:
-    @variable(m, stor_level_capex[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] >= 0)
-    @variable(m, stor_level_current[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] >= 0)
-    @variable(m, stor_level_add[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] >= 0)
-    @variable(m, stor_level_rem[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] >= 0)
-    @variable(m, stor_level_invest_b[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] >= 0; container = IndexedVarArray)
-    @variable(m, stor_level_remove_b[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] >= 0; container = IndexedVarArray)
+    @variable(m, stor_level_capex[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, stor_level_current[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, stor_level_add[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, stor_level_rem[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, stor_level_invest_b[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
+    @variable(m, stor_level_remove_b[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
 
-    @variable(m, stor_charge_capex[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] >= 0)
-    @variable(m, stor_charge_current[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] >= 0)
-    @variable(m, stor_charge_add[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] >= 0)
-    @variable(m, stor_charge_rem[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] >= 0)
-    @variable(m, stor_charge_invest_b[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] >= 0; container = IndexedVarArray)
-    @variable(m, stor_charge_remove_b[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] >= 0; container = IndexedVarArray)
+    @variable(m, stor_charge_capex[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, stor_charge_current[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, stor_charge_add[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, stor_charge_rem[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, stor_charge_invest_b[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
+    @variable(m, stor_charge_remove_b[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
 
-    @variable(m, stor_discharge_capex[𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] >= 0)
-    @variable(m, stor_discharge_current[𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] >= 0)
-    @variable(m, stor_discharge_add[𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] >= 0)
-    @variable(m, stor_discharge_rem[𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] >= 0)
+    @variable(m, stor_discharge_capex[𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, stor_discharge_current[𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, stor_discharge_add[𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, stor_discharge_rem[𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0)
     @variable(
         m,
-        stor_discharge_invest_b[𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] >= 0;
+        stor_discharge_invest_b[𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0;
         container = IndexedVarArray
     )
     @variable(
         m,
-        stor_discharge_remove_b[𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] >= 0;
+        stor_discharge_remove_b[𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0;
         container = IndexedVarArray
     )
+end
+
+"""
+    EMB.variables_links_capex(m, ℒ, 𝒯, modeltype::AbstractInvestmentModel)
+
+Create variables for the capital costs for the investments in [`Link`](@ref)s.
+
+Additional variables for investment in capacity:
+* `:link_cap_capex` - CAPEX costs for a technology
+* `:link_cap_current` - installed capacity for storage in each strategic period
+* `:link_cap_add` - added capacity
+* `:link_cap_rem` - removed capacity
+* `:link_cap_invest_b` - binary variable whether investments in capacity are happening
+* `:link_cap_remove_b` - binary variable whether investments in capacity are removed
+"""
+function EMB.variables_links_capex(m, ℒ, 𝒯, modeltype::AbstractInvestmentModel)
+    ℒᴵⁿᵛ = filter(has_investment, ℒ)
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+
+    # Add investment variables for reference nodes for each strategic period:
+    @variable(m, link_cap_capex[ℒᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, link_cap_current[ℒᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, link_cap_add[ℒᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, link_cap_rem[ℒᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0)
+    @variable(m, link_cap_invest_b[ℒᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
+    @variable(m, link_cap_remove_b[ℒᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
 end

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -103,6 +103,7 @@ export has_charge, has_discharge
 export charge, level, discharge
 
 # Export commonly used functions for extracting fields in `Link`
+export has_opex
 export formulation
 
 # Export commonly used functions for extracting fields in `EnergyModel`

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -105,7 +105,7 @@ export charge, level, discharge
 
 # Export commonly used functions for extracting fields in `Link`
 export has_opex, has_capacity
-export formulation
+export formulation, link_data
 
 # Export commonly used functions for extracting fields in `EnergyModel`
 export emission_limit, emission_price, co2_instance, discount_rate

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -70,6 +70,7 @@ export InvData, InvDataStorage
 export @assert_or_log
 export create_model, run_model
 export variables_node, create_node
+export variables_link
 export constraints_capacity, constraints_capacity_installed
 export constraints_flow_in, constraints_flow_out
 export constraints_level, constraints_level_aux

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -103,7 +103,7 @@ export has_charge, has_discharge
 export charge, level, discharge
 
 # Export commonly used functions for extracting fields in `Link`
-export has_opex
+export has_opex, has_capacity
 export formulation
 
 # Export commonly used functions for extracting fields in `EnergyModel`

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -87,7 +87,7 @@ export co2_capture, process_emissions
 
 # Export commonly used functions for extracting fields in `Node`
 export nodes_input, nodes_output, nodes_emissions
-export has_input, has_output, has_emissions
+export has_input, has_output, has_emissions, is_unidirectional
 export capacity,
     inputs,
     outputs,

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -45,11 +45,12 @@ end
 """
     constraints_capacity_installed(m, n::Node, 𝒯::TimeStructure, modeltype::EnergyModel)
     constraints_capacity_installed(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
+    constraints_capacity_installed(m, l::Link, 𝒯::TimeStructure, modeltype::EnergyModel)
 
 Function for creating the constraint on the installed capacity to the available capacity.
 
 These functions serve as fallback option if no other method is specified for a specific
-`Node`.
+`Node` or `Link`.
 
 !!! danger "Dispatching on this function"
     This function should only be used to dispatch on the modeltype for providing investments.
@@ -87,6 +88,17 @@ function constraints_capacity_installed(
         for t ∈ 𝒯
             fix(m[:stor_discharge_inst][n, t], capacity(discharge(n), t); force = true)
         end
+    end
+end
+function constraints_capacity_installed(
+    m,
+    l::Link,
+    𝒯::TimeStructure,
+    modeltype::EnergyModel,
+)
+    # Fix the installed capacity to the upper bound
+    for t ∈ 𝒯
+        fix(m[:link_cap_inst][l, t], capacity(l, t); force = true)
     end
 end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -143,16 +143,38 @@ end
 
 Declaration of the individual input (`:flow_in`) and output (`:flow_out`) flowrates for
 each technological node `n ∈ 𝒩` and link `l ∈ ℒ` (`:link_in` and `:link_out`).
+
+By default, all nodes `𝒩` and links ℒ only allow for unidirectional flow.
 """
 function variables_flow(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype::EnergyModel)
     𝒩ⁱⁿ = filter(has_input, 𝒩)
     𝒩ᵒᵘᵗ = filter(has_output, 𝒩)
 
-    @variable(m, flow_in[n_in ∈ 𝒩ⁱⁿ, 𝒯, inputs(n_in)] >= 0)
-    @variable(m, flow_out[n_out ∈ 𝒩ᵒᵘᵗ, 𝒯, outputs(n_out)] >= 0)
+    @variable(m, flow_in[n_in ∈ 𝒩ⁱⁿ, 𝒯, inputs(n_in)])
+    @variable(m, flow_out[n_out ∈ 𝒩ᵒᵘᵗ, 𝒯, outputs(n_out)])
 
-    @variable(m, link_in[l ∈ ℒ, 𝒯, inputs(l)] >= 0)
-    @variable(m, link_out[l ∈ ℒ, 𝒯, outputs(l)] >= 0)
+    @variable(m, link_in[l ∈ ℒ, 𝒯, inputs(l)])
+    @variable(m, link_out[l ∈ ℒ, 𝒯, outputs(l)])
+
+    # Set the bounds fo unidirectional nodes and links
+    𝒩ⁱⁿ⁻ᵘⁿⁱ = filter(is_unidirectional, 𝒩ⁱⁿ)
+    𝒩ᵒᵘᵗ⁻ᵘⁿⁱ = filter(is_unidirectional, 𝒩ᵒᵘᵗ)
+    ℒᵘⁿⁱ = filter(is_unidirectional, ℒ)
+
+    for n_in ∈ 𝒩ⁱⁿ⁻ᵘⁿⁱ, t ∈ 𝒯, p ∈ inputs(n_in)
+        set_lower_bound(m[:flow_in][n_in, t, p], 0)
+    end
+    for n_out ∈ 𝒩ᵒᵘᵗ⁻ᵘⁿⁱ, t ∈ 𝒯, p ∈ outputs(n_out)
+        set_lower_bound(m[:flow_out][n_out, t, p], 0)
+    end
+    for l ∈ ℒᵘⁿⁱ, t ∈ 𝒯
+        for p ∈ inputs(l)
+            set_lower_bound(m[:link_in][l, t, p], 0)
+        end
+        for p ∈ outputs(l)
+            set_lower_bound(m[:link_out][l, t, p], 0)
+        end
+    end
 end
 
 """

--- a/src/model.jl
+++ b/src/model.jl
@@ -189,8 +189,9 @@ Declaration of emission variables per technology node with emissions `n ∈ 𝒩
 emissions `l ∈ ℒᵉᵐ` for each emission resource `𝒫ᵉᵐ ∈ 𝒫`.
 
 The inclusion of node and link emissions require that the function `has_emissions` returns
-a value `true` for the given node or link. This is by default achieved for nodes through
-inclusion of `EmissionData`.
+`true` for the given node or link. This is by default achieved for nodes through inclusion
+of `EmissionData` in nodes while links require you to explicitly provide a method for your
+link type.
 
 The emission variables are differentiated in:
 * `:emissions_node` - emissions of a node in an operational period,

--- a/src/model.jl
+++ b/src/model.jl
@@ -149,7 +149,7 @@ end
 Declaration of the individual input (`:flow_in`) and output (`:flow_out`) flowrates for
 each technological node `n ∈ 𝒩` and link `l ∈ ℒ` (`:link_in` and `:link_out`).
 
-By default, all nodes `𝒩` and links ℒ only allow for unidirectional flow.
+By default, all nodes `𝒩` and links `ℒ` only allow for unidirectional flow.
 """
 function variables_flow(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype::EnergyModel)
     𝒩ⁱⁿ = filter(has_input, 𝒩)
@@ -161,7 +161,7 @@ function variables_flow(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype::EnergyModel)
     @variable(m, link_in[l ∈ ℒ, 𝒯, inputs(l)])
     @variable(m, link_out[l ∈ ℒ, 𝒯, outputs(l)])
 
-    # Set the bounds fo unidirectional nodes and links
+    # Set the bounds for unidirectional nodes and links
     𝒩ⁱⁿ⁻ᵘⁿⁱ = filter(is_unidirectional, 𝒩ⁱⁿ)
     𝒩ᵒᵘᵗ⁻ᵘⁿⁱ = filter(is_unidirectional, 𝒩ᵒᵘᵗ)
     ℒᵘⁿⁱ = filter(is_unidirectional, ℒ)
@@ -241,7 +241,7 @@ function variables_capex(m, 𝒩, 𝒯, modeltype::EnergyModel) end
     variables_links_capacity(m, ℒ, 𝒯, modeltype::EnergyModel)
 
 Declaration of the capacity variable for links (`:link_cap_inst`) in each operational period
-t ∈ 𝒯 of the model. The capacity variabke is only created for links, if the function
+t ∈ 𝒯 of the model. The capacity variable is only created for links, if the function
 [`has_capacity`](@ref) has received an additional method for a given link `l` returning the
 value `true`.
 """

--- a/src/model.jl
+++ b/src/model.jl
@@ -151,8 +151,8 @@ function variables_flow(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype::EnergyModel)
     @variable(m, flow_in[n_in ∈ 𝒩ⁱⁿ, 𝒯, inputs(n_in)] >= 0)
     @variable(m, flow_out[n_out ∈ 𝒩ᵒᵘᵗ, 𝒯, outputs(n_out)] >= 0)
 
-    @variable(m, link_in[l ∈ ℒ, 𝒯, link_res(l)] >= 0)
-    @variable(m, link_out[l ∈ ℒ, 𝒯, link_res(l)] >= 0)
+    @variable(m, link_in[l ∈ ℒ, 𝒯, inputs(l)] >= 0)
+    @variable(m, link_out[l ∈ ℒ, 𝒯, outputs(l)] >= 0)
 end
 
 """
@@ -276,14 +276,14 @@ function constraints_node(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype::EnergyModel)
         if has_output(n)
             @constraint(m, [t ∈ 𝒯, p ∈ outputs(n)],
                 m[:flow_out][n, t, p] ==
-                sum(m[:link_in][l, t, p] for l ∈ ℒᶠʳᵒᵐ if p ∈ inputs(l.to))
+                sum(m[:link_in][l, t, p] for l ∈ ℒᶠʳᵒᵐ if p ∈ outputs(l))
             )
         end
         # Constraint for input flowrate and output links.
         if has_input(n)
             @constraint(m, [t ∈ 𝒯, p ∈ inputs(n)],
                 m[:flow_in][n, t, p] ==
-                sum(m[:link_out][l, t, p] for l ∈ ℒᵗᵒ if p ∈ outputs(l.from))
+                sum(m[:link_out][l, t, p] for l ∈ ℒᵗᵒ if p ∈ inputs(l))
             )
         end
         # Call of function for individual node constraints.

--- a/src/model.jl
+++ b/src/model.jl
@@ -57,11 +57,12 @@ function create_model(
     variables_flow(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype)
     variables_emission(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype)
     variables_opex(m, 𝒩, 𝒯, 𝒫, modeltype)
-    variables_capex(m, 𝒩, 𝒯, 𝒫, modeltype)
+    variables_capex(m, 𝒩, 𝒯, modeltype)
     variables_capacity(m, 𝒩, 𝒯, modeltype)
     variables_nodes(m, 𝒩, 𝒯, modeltype)
 
     variables_links_capacity(m, ℒ, 𝒯, modeltype)
+    variables_links_capex(m, ℒ, 𝒯, modeltype)
     variables_links_opex(m, ℒ, 𝒯, 𝒫, modeltype)
     variables_links(m, ℒ, 𝒯, modeltype)
 
@@ -229,12 +230,12 @@ function variables_opex(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
 end
 
 """
-    variables_capex(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
+    variables_capex(m, 𝒩, 𝒯, modeltype::EnergyModel)
 
 Declaration of the CAPEX variables of the model for each investment period `t_inv ∈ 𝒯ᴵⁿᵛ`.
 Empty for operational models but required for multiple dispatch in investment model.
 """
-function variables_capex(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel) end
+function variables_capex(m, 𝒩, 𝒯, modeltype::EnergyModel) end
 
 """
     variables_links_capacity(m, ℒ, 𝒯, modeltype::EnergyModel)
@@ -267,6 +268,15 @@ function variables_links_opex(m, ℒ, 𝒯, 𝒫, modeltype::EnergyModel)
     @variable(m, link_opex_var[ℒᵒᵖᵉˣ, 𝒯ᴵⁿᵛ])
     @variable(m, link_opex_fixed[ℒᵒᵖᵉˣ, 𝒯ᴵⁿᵛ] ≥ 0)
 end
+
+"""
+    variables_links_capex(m, ℒ, 𝒯, modeltype::EnergyModel)
+
+Declaration of the CAPEX variables of the model for links for each investment period
+`t_inv ∈ 𝒯ᴵⁿᵛ`.
+Empty for operational models but required for multiple dispatch in investment model.
+"""
+function variables_links_capex(m, ℒ, 𝒯, modeltype::EnergyModel) end
 
 """
     variables_nodes(m, 𝒩, 𝒯, modeltype::EnergyModel)

--- a/src/structures/link.jl
+++ b/src/structures/link.jl
@@ -52,6 +52,16 @@ Returns logic whether the link `l` can be used bidirectional or only unidirectio
 is_unidirectional(l::Link) = true
 
 """
+    has_emissions(l::Link)
+
+Checks whether link `l` has emissions.
+
+By default, links do not have emissions. You must dispatch on this function if you want to
+introduce links with associated emissions, *e.g.*, through leakage.
+"""
+has_emissions(l::Link) = false
+
+"""
     link_res(l::Link)
 
 Return the resources transported for a given link `l`.

--- a/src/structures/link.jl
+++ b/src/structures/link.jl
@@ -41,8 +41,29 @@ end
     link_res(l::Link)
 
 Return the resources transported for a given link `l`.
+
+The default approach is to use the intersection of the inputs of the `to` node and the
+outputs of the `from` node.
 """
 link_res(l::Link) = intersect(inputs(l.to), outputs(l.from))
+
+"""
+    inputs(n::Link)
+
+Returns the input resources of a link `l`.
+
+The default approach is to use the function [`link_res(l::Link)`](@ref).
+"""
+inputs(l::Link) = link_res(l)
+
+"""
+    outputs(n::Link)
+
+Returns the output resources of a link `l`.
+
+The default approach is to use the function [`link_res(l::Link)`](@ref).
+"""
+outputs(l::Link) = link_res(l)
 
 """
     formulation(l::Link)

--- a/src/structures/link.jl
+++ b/src/structures/link.jl
@@ -62,6 +62,16 @@ introduce links with associated emissions, *e.g.*, through leakage.
 has_emissions(l::Link) = false
 
 """
+    has_capacity(l::Link)
+
+Checks whether link `l` has a capacity.
+
+By default, links do not have a capacity. You must dispatch on this function if you want to
+introduce links with capacities.
+"""
+has_capacity(l::Link) = false
+
+"""
     has_opex(l::Link)
 
 Checks whether link `l` has operational expenses.

--- a/src/structures/link.jl
+++ b/src/structures/link.jl
@@ -62,6 +62,16 @@ introduce links with associated emissions, *e.g.*, through leakage.
 has_emissions(l::Link) = false
 
 """
+    has_opex(l::Link)
+
+Checks whether link `l` has operational expenses.
+
+By default, links do not have operational expenses. You must dispatch on this function if
+you want to introduce links with operational expenses.
+"""
+has_opex(l::Link) = false
+
+"""
     link_res(l::Link)
 
 Return the resources transported for a given link `l`.

--- a/src/structures/link.jl
+++ b/src/structures/link.jl
@@ -38,6 +38,20 @@ function link_sub(ℒ::Vector{<:Link}, n::Node)
 end
 
 """
+    is_unidirectional(l::Link)
+
+Returns logic whether the link `l` can be used bidirectional or only unidirectional.
+
+!!! note "Bidirectional flow in links"
+    In the current stage, `EnergyModelsBase` does not include any links which can be used
+    bidirectional, that is with flow reversal.
+
+    If you plan to use bidirectional flow, you have to declare your own nodes and links which
+    support this. You can then dispatch on this function for the incorporation.
+"""
+is_unidirectional(l::Link) = true
+
+"""
     link_res(l::Link)
 
 Return the resources transported for a given link `l`.

--- a/src/structures/link.jl
+++ b/src/structures/link.jl
@@ -115,3 +115,12 @@ outputs(l::Link) = link_res(l)
 Return the formulation of a Link `l`.
 """
 formulation(l::Link) = l.formulation
+
+"""
+    link_data(l::Link)
+
+Returns the [`Data`](@ref) array of link `l`.
+
+The default options returns nothing.
+"""
+link_data(l::Link) = nothing

--- a/src/structures/node.jl
+++ b/src/structures/node.jl
@@ -475,6 +475,20 @@ has_output(n::Node) = true
 has_output(n::Sink) = false
 
 """
+    is_unidirectional(n::Node)
+
+Returns logic whether the node `n` can be used bidirectional or only unidirectional.
+
+!!! note "Bidirectional flow in nodes"
+    In the current stage, `EnergyModelsBase` does not include any nodes which can be used
+    bidirectional, that is with flow reversal.
+
+    If you plan to use bidirectional flow, you have to declare your own nodes and links that
+    support this. You can then dispatch on this function for the incorporation.
+"""
+is_unidirectional(n::Node) = true
+
+"""
     has_charge(n::Storage)
 
 Returns logic whether the node has a `charge` field allowing for restrictions and/or costs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,10 @@ ENV["EMB_TEST"] = true # Set flag for example scripts to check if they are run a
         include("test_nodes.jl")
     end
 
+    @testset "Base | Link" begin
+        include("test_links.jl")
+    end
+
     @testset "Base | Modeltype" begin
         include("test_modeltype.jl")
     end

--- a/test/test_links.jl
+++ b/test/test_links.jl
@@ -1,4 +1,4 @@
-@testset "Link utilities" begin
+@testset "Link - utilities" begin
 
     # Resources used in the analysis
     NG = ResourceEmit("NG", 0.2)
@@ -61,6 +61,9 @@
 
         # Test that all links do not have emissions
         @test !all(has_emissions(l) for l ∈ ℒ)
+
+        # Test that all links do not have opex variables
+        @test !all(has_opex(l) for l ∈ ℒ)
     end
 
     @testset "Access functions" begin
@@ -98,12 +101,54 @@
             for l ∈ ℒ, t ∈ 𝒯
         )
 
-        # Test that `emissions_link` variable is empty
+        # Test that `emissions_link`, `link_opex_var`, and `link_opex_fixed` are empty
         @test isempty(m[:emissions_link])
+        @test isempty(m[:link_opex_var])
+        @test isempty(m[:link_opex_fixed])
     end
 end
 
-@testset "Link emissions" begin
+
+# Resources used in the analysis
+Power = ResourceCarrier("Power", 0.0)
+CO2 = ResourceEmit("CO2", 1.0)
+
+# Function for setting up the system
+function link_graph(LinkType::Type{<:Link})
+    # Used source, network, and sink
+    source = RefSource(
+        "source",
+        FixedProfile(4),
+        FixedProfile(10),
+        FixedProfile(0),
+        Dict(Power => 1),
+    )
+    sink = RefSink(
+        "sink",
+        FixedProfile(3),
+        Dict(:surplus => FixedProfile(4), :deficit => FixedProfile(100)),
+        Dict(Power => 1),
+    )
+
+    resources = [Power, CO2]
+    ops = SimpleTimes(5, 2)
+    op_per_strat = 10
+    T = TwoLevel(2, 2, ops; op_per_strat)
+
+    nodes = [source, sink]
+    links = [
+        LinkType(12, source, sink, Linear())
+    ]
+    model = OperationalModel(
+        Dict(CO2 => FixedProfile(100)),
+        Dict(CO2 => FixedProfile(0)),
+        CO2,
+    )
+    case = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
+    return run_model(case, model, HiGHS.Optimizer), case, model
+end
+
+@testset "Link - emissions" begin
     # Creation of a new link type with associated emissions in each operational period
     struct EmissionDirect <: Link
         id::Any
@@ -112,7 +157,6 @@ end
         formulation::EMB.Formulation
     end
     function EMB.create_link(m, 𝒯, 𝒫, l::EmissionDirect, formulation::EMB.Formulation)
-
         # Generic link in which each output corresponds to the input
         @constraint(m, [t ∈ 𝒯, p ∈ EMB.link_res(l)],
             m[:link_out][l, t, p] == m[:link_in][l, t, p]
@@ -126,47 +170,8 @@ end
     end
     EMB.has_emissions(l::EmissionDirect) = true
 
-    # Resources used in the analysis
-    Power = ResourceCarrier("Power", 0.0)
-    CO2 = ResourceEmit("CO2", 1.0)
-
-    # Function for setting up the system
-    function simple_graph()
-        # Used source, network, and sink
-        source = RefSource(
-            "source",
-            FixedProfile(4),
-            FixedProfile(10),
-            FixedProfile(0),
-            Dict(Power => 1),
-        )
-        sink = RefSink(
-            "sink",
-            FixedProfile(3),
-            Dict(:surplus => FixedProfile(4), :deficit => FixedProfile(100)),
-            Dict(Power => 1),
-        )
-
-        resources = [Power, CO2]
-        ops = SimpleTimes(5, 2)
-        op_per_strat = 10
-        T = TwoLevel(2, 2, ops; op_per_strat)
-
-        nodes = [source, sink]
-        links = [
-            EmissionDirect(23, source, sink, Linear())
-        ]
-        model = OperationalModel(
-            Dict(CO2 => FixedProfile(100)),
-            Dict(CO2 => FixedProfile(0)),
-            CO2,
-        )
-        case = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
-        return case, model
-    end
-
-    case, model = simple_graph()
-    m = run_model(case, model, HiGHS.Optimizer)
+    # Create and solve the system
+    m, case, model = link_graph(EmissionDirect)
     ℒ = case[:links]
     𝒩 = case[:nodes]
     𝒯 = case[:T]
@@ -180,4 +185,44 @@ end
         value.(m[:emissions_link][ℒ[1], t, CO2])
     for t ∈ 𝒯)
     @test all(value.(m[:emissions_total][t, CO2]) == 0.1 for t ∈ 𝒯)
+end
+
+@testset "Link - OPEX" begin
+    # Creation of a new link type with associated OPEX
+    struct OpexDirect <: Link
+        id::Any
+        from::EMB.Node
+        to::EMB.Node
+        formulation::EMB.Formulation
+    end
+    function EMB.create_link(m, 𝒯, 𝒫, l::OpexDirect, formulation::EMB.Formulation)
+        𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+
+        # Generic link in which each output corresponds to the input
+        @constraint(m, [t ∈ 𝒯, p ∈ EMB.link_res(l)],
+            m[:link_out][l, t, p] == m[:link_in][l, t, p]
+        )
+
+        # Variable OPEX calculation
+        @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ], m[:link_opex_var][l, t_inv] == 0.2)
+        @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ], m[:link_opex_fixed][l, t_inv] == 1)
+    end
+    EMB.has_opex(l::OpexDirect) = true
+
+    # Create and solve the system
+    m, case, model = link_graph(OpexDirect)
+    ℒ = case[:links]
+    𝒩 = case[:nodes]
+    𝒯 = case[:T]
+
+    # Test that `link_opex_var` and `link_opex_fixed` are not empty
+    @test !isempty(m[:link_opex_var])
+    @test !isempty(m[:link_opex_fixed])
+
+    # Test that the values are included in the objective function
+    #   3 * 10 * 10     is the cost of the source Node
+    #   0.2             is the variable OPEX contribution from the link
+    #   1               is the fixed OPEX contribution from the link
+    # The multiplication with 2 * 2 is due to 2 strategic periods with a duration of 2
+    @test objective_value(m) ≈ -((3 * 10 * 10) + 0.2 + 1) * (2 * 2) atol=TEST_ATOL
 end

--- a/test/test_links.jl
+++ b/test/test_links.jl
@@ -60,10 +60,10 @@
         @test all(is_unidirectional(l) for l ∈ ℒ)
 
         # Test that all links do not have emissions
-        @test !all(has_emissions(l) for l ∈ ℒ)
+        @test !any(has_emissions(l) for l ∈ ℒ)
 
         # Test that all links do not have opex variables
-        @test !all(has_opex(l) for l ∈ ℒ)
+        @test !any(has_opex(l) for l ∈ ℒ)
     end
 
     @testset "Access functions" begin

--- a/test/test_links.jl
+++ b/test/test_links.jl
@@ -53,6 +53,13 @@
         return case, model
     end
 
+    @testset "Identification functions" begin
+        case, model = simple_graph()
+
+        # Test that all links are identified as unidirectional
+        @test all(is_unidirectional(l) for l ∈ case[:links])
+    end
+
     @testset "Access functions" begin
         case, model = simple_graph()
         ℒ = case[:links]
@@ -69,5 +76,22 @@
         # Test that the constructor for a direct link is working and that the function
         # formulation is working
         @test isa(formulation(ℒ[1]), Linear)
+    end
+
+    @testset "Variable declaration" begin
+        case, model = simple_graph()
+        m = create_model(case, model)
+        ℒ = case[:links]
+        𝒯 = case[:T]
+
+        # Test that all link variables have a lower bound of 0
+        @test all(
+            all(lower_bound(m[:link_in][l, t, p]) == 0 for p ∈ inputs(l))
+            for l ∈ ℒ, t ∈ 𝒯
+        )
+        @test all(
+            all(lower_bound(m[:link_out][l, t, p]) == 0 for p ∈ outputs(l))
+            for l ∈ ℒ, t ∈ 𝒯
+        )
     end
 end

--- a/test/test_links.jl
+++ b/test/test_links.jl
@@ -1,0 +1,73 @@
+
+@testset "Link utilities" begin
+
+    # Resources used in the analysis
+    NG = ResourceEmit("NG", 0.2)
+    Power = ResourceCarrier("Power", 0.0)
+    CO2 = ResourceEmit("CO2", 1.0)
+
+    # Function for setting up the system
+    function simple_graph()
+        # Used source, network, and sink
+        source = RefSource(
+            "source",
+            FixedProfile(4),
+            FixedProfile(10),
+            FixedProfile(0),
+            Dict(NG => 1),
+        )
+        network = RefNetworkNode(
+            "network",
+            FixedProfile(25),
+            FixedProfile(5.5),
+            FixedProfile(0),
+            Dict(NG => 2),
+            Dict(Power => 1),
+            Data[EmissionsEnergy()],
+        )
+
+        sink = RefSink(
+            "sink",
+            FixedProfile(3),
+            Dict(:surplus => FixedProfile(4), :deficit => FixedProfile(100)),
+            Dict(Power => 1),
+        )
+
+        resources = [NG, Power, CO2]
+        ops = SimpleTimes(5, 2)
+        op_per_strat = 10
+        T = TwoLevel(2, 2, ops; op_per_strat)
+
+        nodes = [source, network, sink]
+        links = [
+            Direct(12, source, network)
+            Direct(23, network, sink)
+            Direct(23, source, sink)
+        ]
+        model = OperationalModel(
+            Dict(CO2 => FixedProfile(100), NG => FixedProfile(100)),
+            Dict(CO2 => FixedProfile(0), NG => FixedProfile(0)),
+            CO2,
+        )
+        case = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
+        return case, model
+    end
+
+    @testset "Access functions" begin
+        case, model = simple_graph()
+        ℒ = case[:links]
+        𝒩 = case[:nodes]
+
+        # Test that the tranported resources are correctly identified
+        @test inputs(ℒ[1]) == outputs(𝒩[1])
+        @test outputs(ℒ[1]) == inputs(𝒩[2])
+
+        # Test that the function `link_res` does not return a transported resources for the
+        # 3ʳᵈ link
+        @test isempty(EMB.link_res(ℒ[3]))
+
+        # Test that the constructor for a direct link is working and that the function
+        # formulation is working
+        @test isa(formulation(ℒ[1]), Linear)
+    end
+end

--- a/test/test_links.jl
+++ b/test/test_links.jl
@@ -1,4 +1,3 @@
-
 @testset "Link utilities" begin
 
     # Resources used in the analysis
@@ -55,9 +54,13 @@
 
     @testset "Identification functions" begin
         case, model = simple_graph()
+        ℒ = case[:links]
 
         # Test that all links are identified as unidirectional
-        @test all(is_unidirectional(l) for l ∈ case[:links])
+        @test all(is_unidirectional(l) for l ∈ ℒ)
+
+        # Test that all links do not have emissions
+        @test !all(has_emissions(l) for l ∈ ℒ)
     end
 
     @testset "Access functions" begin
@@ -71,6 +74,7 @@
 
         # Test that the function `link_res` does not return a transported resources for the
         # 3ʳᵈ link
+        @test isempty(EMB.link_res(ℒ[3]))
         @test isempty(EMB.link_res(ℒ[3]))
 
         # Test that the constructor for a direct link is working and that the function
@@ -93,5 +97,87 @@
             all(lower_bound(m[:link_out][l, t, p]) == 0 for p ∈ outputs(l))
             for l ∈ ℒ, t ∈ 𝒯
         )
+
+        # Test that `emissions_link` variable is empty
+        @test isempty(m[:emissions_link])
     end
+end
+
+@testset "Link emissions" begin
+    # Creation of a new link type with associated emissions in each operational period
+    struct EmissionDirect <: Link
+        id::Any
+        from::EMB.Node
+        to::EMB.Node
+        formulation::EMB.Formulation
+    end
+    function EMB.create_link(m, 𝒯, 𝒫, l::EmissionDirect, formulation::EMB.Formulation)
+
+        # Generic link in which each output corresponds to the input
+        @constraint(m, [t ∈ 𝒯, p ∈ EMB.link_res(l)],
+            m[:link_out][l, t, p] == m[:link_in][l, t, p]
+        )
+
+        # Emissions
+        𝒫ᵉᵐ = filter(EMB.is_resource_emit, 𝒫)
+        @constraint(m, [t ∈ 𝒯, p_em ∈ 𝒫ᵉᵐ],
+            m[:emissions_link][l, t, p_em] == 0.1
+        )
+    end
+    EMB.has_emissions(l::EmissionDirect) = true
+
+    # Resources used in the analysis
+    Power = ResourceCarrier("Power", 0.0)
+    CO2 = ResourceEmit("CO2", 1.0)
+
+    # Function for setting up the system
+    function simple_graph()
+        # Used source, network, and sink
+        source = RefSource(
+            "source",
+            FixedProfile(4),
+            FixedProfile(10),
+            FixedProfile(0),
+            Dict(Power => 1),
+        )
+        sink = RefSink(
+            "sink",
+            FixedProfile(3),
+            Dict(:surplus => FixedProfile(4), :deficit => FixedProfile(100)),
+            Dict(Power => 1),
+        )
+
+        resources = [Power, CO2]
+        ops = SimpleTimes(5, 2)
+        op_per_strat = 10
+        T = TwoLevel(2, 2, ops; op_per_strat)
+
+        nodes = [source, sink]
+        links = [
+            EmissionDirect(23, source, sink, Linear())
+        ]
+        model = OperationalModel(
+            Dict(CO2 => FixedProfile(100)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2,
+        )
+        case = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
+        return case, model
+    end
+
+    case, model = simple_graph()
+    m = run_model(case, model, HiGHS.Optimizer)
+    ℒ = case[:links]
+    𝒩 = case[:nodes]
+    𝒯 = case[:T]
+
+    # Test that `emissions_link` variable is not empty
+    @test !isempty(m[:emissions_link])
+
+    # Test that the value of the emission variable is included in the total emissions
+    @test all(
+        value.(m[:emissions_total][t, CO2]) ==
+        value.(m[:emissions_link][ℒ[1], t, CO2])
+    for t ∈ 𝒯)
+    @test all(value.(m[:emissions_total][t, CO2]) == 0.1 for t ∈ 𝒯)
 end

--- a/test/test_nodes.jl
+++ b/test/test_nodes.jl
@@ -1,4 +1,165 @@
 
+@testset "Node utilities" begin
+
+    # Resources used in the analysis
+    NG = ResourceEmit("NG", 0.2)
+    Coal = ResourceCarrier("Coal", 0.35)
+    Power = ResourceCarrier("Power", 0.0)
+    CO2 = ResourceEmit("CO2", 1.0)
+
+    # Function for setting up the system
+    function simple_graph()
+        # Define the different resources
+        NG = ResourceEmit("NG", 0.2)
+        Coal = ResourceCarrier("Coal", 0.35)
+        Power = ResourceCarrier("Power", 0.0)
+        CO2 = ResourceEmit("CO2", 1.0)
+        products = [NG, Coal, Power, CO2]
+
+        # Creation of the emission data for the individual nodes.
+        capture_data = CaptureEnergyEmissions(0.9)
+        emission_data = EmissionsEnergy()
+
+        # Create the individual test nodes, corresponding to a system with an electricity demand/sink,
+        # coal and nautral gas sources, coal and natural gas (with CCS) power plants and CO2 storage.
+        nodes = [
+            GenAvailability(1, products),
+            RefSource(2, FixedProfile(1e12), FixedProfile(30), FixedProfile(0), Dict(NG => 1)),
+            RefSource(3, FixedProfile(1e12), FixedProfile(9), FixedProfile(0), Dict(Coal => 1)),
+            RefNetworkNode(
+                4,
+                FixedProfile(25),
+                FixedProfile(5.5),
+                FixedProfile(5),
+                Dict(NG => 2),
+                Dict(Power => 1, CO2 => 1),
+                [capture_data],
+            ),
+            RefNetworkNode(
+                5,
+                FixedProfile(25),
+                FixedProfile(6),
+                FixedProfile(10),
+                Dict(Coal => 2.5),
+                Dict(Power => 1),
+                [emission_data],
+            ),
+            RefStorage{AccumulatingEmissions}(
+                6,
+                StorCapOpex(FixedProfile(60), FixedProfile(9.1), FixedProfile(0)),
+                StorCap(FixedProfile(600)),
+                CO2,
+                Dict(CO2 => 1, Power => 0.02),
+                Dict(CO2 => 1),
+            ),
+            RefSink(
+                7,
+                OperationalProfile([20, 30, 40, 30]),
+                Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
+                Dict(Power => 1),
+            ),
+        ]
+
+        # Connect all nodes with the availability node for the overall energy/mass balance
+        links = [
+            Direct(14, nodes[1], nodes[4], Linear())
+            Direct(15, nodes[1], nodes[5], Linear())
+            Direct(16, nodes[1], nodes[6], Linear())
+            Direct(17, nodes[1], nodes[7], Linear())
+            Direct(21, nodes[2], nodes[1], Linear())
+            Direct(31, nodes[3], nodes[1], Linear())
+            Direct(41, nodes[4], nodes[1], Linear())
+            Direct(51, nodes[5], nodes[1], Linear())
+            Direct(61, nodes[6], nodes[1], Linear())
+        ]
+
+        # Creation of the time structure and global data
+        T = TwoLevel(4, 2, SimpleTimes(4, 2), op_per_strat = 8)
+        model = OperationalModel(
+            Dict(CO2 => StrategicProfile([160, 140, 120, 100]), NG => FixedProfile(1e6)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2,
+        )
+
+        # WIP data structure
+        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+        return case, model
+    end
+
+    @testset "Identification functions" begin
+        case, model = simple_graph()
+        𝒩 = case[:nodes]
+        stor = 𝒩[6]
+
+        # Test that all nodal supertypes are identified correctly
+        @test [EMB.is_source(n) for n ∈ 𝒩] ==
+            [false, true, true, false, false, false, false]
+        @test [EMB.is_network_node(n) for n ∈ 𝒩] ==
+            [true, false, false, true, true, true, false]
+        @test [EMB.is_storage(n) for n ∈ 𝒩] ==
+            [false, false, false, false, false, true, false]
+        @test [EMB.is_sink(n) for n ∈ 𝒩] ==
+            [false, false, false, false, false, false, true]
+
+        # Test that the corrects nodes with emissions are identified
+        @test [EMB.has_emissions(n) for n ∈ 𝒩] ==
+            [false, false, false, true, true, true, false]
+
+        # Test that the corrects nodes with input and output are identified
+        @test [has_output(n) for n ∈ 𝒩] ==
+            [true, true, true, true, true, true, false]
+        @test [has_input(n) for n ∈ 𝒩] ==
+            [true, false, false, true, true, true, true]
+
+        # Test that all nodes are identified as unidirectional
+        @test all(is_unidirectional(n) for n ∈ 𝒩)
+
+        # Test that the storage node is correctly identified
+        @test all([
+            has_charge(stor), EMB.has_charge_cap(stor), EMB.has_charge_OPEX_fixed(stor),
+            EMB.has_charge_OPEX_var(stor),
+            !EMB.has_level_OPEX_fixed(stor), !EMB.has_level_OPEX_var(stor),
+            !has_discharge(stor), !EMB.has_discharge_cap(stor),
+            !EMB.has_discharge_OPEX_fixed(stor), !EMB.has_discharge_OPEX_var(stor),
+        ])
+    end
+
+    @testset "Access functions" begin
+        case, model = simple_graph()
+        𝒩 = case[:nodes]
+
+        # Test that the input and output resources are correctly identified
+        @test outputs(𝒩[2]) == [NG]
+        @test outputs(𝒩[2], NG) == 1
+        @test outputs(𝒩[4]) == [CO2, Power] || outputs(𝒩[4]) == [Power, CO2]
+        @test inputs(𝒩[6]) == [CO2, Power] || inputs(𝒩[6]) == [Power, CO2]
+        @test inputs(𝒩[7]) == [Power]
+        @test inputs(𝒩[7], Power) == 1
+    end
+
+    @testset "Variable declaration" begin
+        case, model = simple_graph()
+        m = create_model(case, model)
+
+        𝒩 = case[:nodes]
+        stor = 𝒩[6]
+        𝒩ⁱⁿ = filter(has_input, 𝒩)
+        𝒩ᵒᵘᵗ = setdiff(filter(has_output, 𝒩), [stor]) # The storage has a fixed output variable
+        𝒯 = case[:T]
+
+        # Test that all link variables have a lower bound of 0
+        @test all(
+            all(lower_bound(m[:flow_in][n_in, t, p]) == 0 for p ∈ inputs(n_in))
+            for n_in ∈ 𝒩ⁱⁿ, t ∈ 𝒯
+        )
+        @test all(
+            all(lower_bound(m[:flow_out][n_out, t, p]) == 0 for p ∈ outputs(n_out))
+            for n_out ∈ 𝒩ᵒᵘᵗ, t ∈ 𝒯
+        )
+    end
+end
+
+
 @testset "Test RefSource and RefSink" begin
 
     # Resources used in the analysis

--- a/test/test_nodes.jl
+++ b/test/test_nodes.jl
@@ -83,7 +83,6 @@
     end
 
     @testset "General tests - RefSink" begin
-
         # Test that the deficit values are properly calculated and time is involved
         # in the penalty calculation
         source = RefSource(


### PR DESCRIPTION
This PR focuses on increasing the flexibility of `Link`s. It incorporates several different concepts for links to allow for 

1. differing input and output resources of links as well as specifying these directly (ae10474d7c6f83c30cad1937dd39cf084dad2eda),
2. bidirectional links and nodes (113b8f30d1af94d55162a8540e996d22014e5bb3),
3. emissions of links (8110d8da1a3a81d5928767376fe6959a92f2ff37),
4. OPEX of links (with both fixed and variable OPEX created at the same time) (166fe57c3066b08371095bda59b2f2c3b344bd42),
5. capacity of links (9027a4de46b1cb3d6c2ad09044425e53def9fb38), 
6. inclusion of new variables (f8d959a71bbb7042d1c9c3c4717e4a7349d6b22a), and
7. investments in links (7c18c7ecdfb532723890b09e20d7ea41061e2990).

All introduced changes are only valid if the user specifies explicitly for their abstract or composite type that they should include them.

I did not update the documentation with additional information regarding the extension of `Link`s yet. In practice, it only includes the new variables and the docstrings, but not how one can create new links.