### PR TITLE
Inclusion of default checks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Release notes
 
+## Version 0.8.3 (2024-11-29)
+
+### Reference checks possible to be called
+
+* Created function `check_node_default()`.
+* The function can be called from other `check_node` to include all default checks
+
 ## Version 0.8.2 (2024-11-27)
 
 ### Restructuring of function calls

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsBase"
 uuid = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -49,6 +49,7 @@ check_data
 check_case_data
 check_model
 check_node
+check_node_default
 check_fixed_opex
 check_node_data(n::Node, data::EmissionsData, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 check_time_structure

--- a/docs/src/manual/philosophy.md
+++ b/docs/src/manual/philosophy.md
@@ -9,7 +9,7 @@ One key aim in the development of `EnergyModelsBase` was to create an energy sys
 3. is designed in a way such that the thought process for understanding the model is straight forward.
 
 Julia as a programming language offers the flexibility required in points 1 and 2 through the concept of multiple dispatch.
-The philosophy hence focueses on only creating variables and constraintes that are used, instead of creating all potential constraints and variables and constrain a large fraction of these variables to a value of 0.
+`EnergyModelsBase` hence focuses on only creating variables and constraints that are used, instead of creating all potential constraints and variables and constrain a large fraction of these variables to a value of 0.
 In that respect, `EnergyModelsBase` moves away from a parameter driven flexibility to a type driven flexibility.
 Point 3 is achieved through a one direction flow in function calls, that is that we limit the number of required files and function calls for the individual technology constraint creations, and meaningful names of the individual functions.
 

--- a/docs/src/nodes/storage.md
+++ b/docs/src/nodes/storage.md
@@ -143,9 +143,9 @@ Hence, if you do not have to call additional functions, but only plan to include
 
   ```math
   \begin{aligned}
-  \texttt{stor\_level\_use}[n, t] & = \texttt{stor\_level\_inst}[n, t] \\
-  \texttt{stor\_charge\_use}[n, t] & = \texttt{stor\_charge\_inst}[n, t] \\
-  \texttt{stor\_discharge\_use}[n, t] & = \texttt{stor\_discharge\_inst}[n, t]
+  \texttt{stor\_level\_use}[n, t] & \leq \texttt{stor\_level\_inst}[n, t] \\
+  \texttt{stor\_charge\_use}[n, t] & \leq \texttt{stor\_charge\_inst}[n, t] \\
+  \texttt{stor\_discharge\_use}[n, t] & \leq \texttt{stor\_discharge\_inst}[n, t]
   \end{aligned}
   ```
 

--- a/ext/EMIExt/checks.jl
+++ b/ext/EMIExt/checks.jl
@@ -145,8 +145,7 @@ function check_inv_data(
     if isa(inv_data, StartInvData)
         if bool_sp
             @assert_or_log(
-                sum(inv_data.initial[t_inv] ≤ EMI.max_installed(inv_data, t_inv) for t_inv ∈ 𝒯ᴵⁿᵛ) ==
-                    length(𝒯ᴵⁿᵛ),
+                all(inv_data.initial[t_inv] ≤ EMI.max_installed(inv_data, t_inv) for t_inv ∈ 𝒯ᴵⁿᵛ),
                 "The value for the field `initial` in the investment data " * message *
                 " can not be larger than the maximum installed constraint."
             )
@@ -158,8 +157,7 @@ function check_inv_data(
         bool_sp = EMB.check_strategic_profile(capacity_profile, submessage)
         if bool_sp
             @assert_or_log(
-                sum(capacity_profile[t_inv] ≤ EMI.max_installed(inv_data, t_inv) for t_inv ∈ 𝒯ᴵⁿᵛ) ==
-                    length(𝒯ᴵⁿᵛ),
+                all(capacity_profile[t_inv] ≤ EMI.max_installed(inv_data, t_inv) for t_inv ∈ 𝒯ᴵⁿᵛ),
                 "The existing capacity can not be larger than the maximum installed value in " *
                 "all strategic periods for the capacity coupled to the investment data " *
                 message * "."
@@ -170,7 +168,7 @@ function check_inv_data(
     # Check on the minmimum and maximum added capacities
     if isa(EMI.investment_mode(inv_data), Union{ContinuousInvestment,SemiContiInvestment})
         @assert_or_log(
-            sum(EMI.min_add(inv_data, t) ≤ EMI.max_add(inv_data, t) for t ∈ 𝒯) == length(𝒯),
+            all(EMI.min_add(inv_data, t) ≤ EMI.max_add(inv_data, t) for t ∈ 𝒯),
             "`min_add` has to be less than `max_add` in the investment data " *
             message * "."
         )

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -683,7 +683,7 @@ function check_node_default(n::Storage, 𝒯, modeltype::EnergyModel, check_time
     if isa(par_discharge, UnionCapacity)
         @assert_or_log(
             all(capacity(par_discharge, t) ≥ 0 for t ∈ 𝒯),
-            "The charge capacity must be non-negative."
+            "The discharge capacity must be non-negative."
         )
     end
     if isa(par_discharge, UnionOpexFixed)

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -556,23 +556,37 @@ end
     check_node(n::Node, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
 Check that the fields of a `Node` corresponds to required structure.
+
+The default approach calls the subroutine [`check_node_default`](@ref) which provides the
+user with default checks for [`Source`](@ref), [`NetworkNode`](@ref), [`Availability`](@ref),
+[`Storage`](@ref), and [`Sink`](@ref) nodes.
+
+!!! tip "Creating a new node type"
+    When developing a new node with new checks, it is important to create a new method for
+    `check_node`. You can then call within this function the default tests for the corresponding
+    supertype through calling the function [`check_node_default`](@ref).
 """
-function check_node(n::Node, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool) end
+check_node(n::Node, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool) =
+    check_node_default(n, 𝒯, modeltype, check_timeprofiles)
 """
-    check_node(n::Availability, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_node_default(n::Node, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+
+This method checks that a `Node` node is valid. By default, that does not include
+any checks.
+"""
+function check_node_default(n::Node, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool) end
+"""
+    check_node_default(n::Availability, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
 This method checks that an `Availability` node is valid. By default, that does not include
 any checks.
 """
-function check_node(n::Availability, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool) end
+function check_node_default(n::Availability, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool) end
 """
-    check_node(n::Source, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_node_default(n::Source, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
-This method checks that a `Source` node is valid.
-
-These checks are always performed, if the user is not creating a new method. Hence, it is
-important that a new `Source` type includes at least the same fields as in the [`RefSource`](@ref)
-node or that a new `Source` type receives a new method for `check_node`.
+Subroutine that can be utilized in other packages for incorporating the standard tests for
+a [`Source`](@ref) node.
 
 ## Checks
 - The field `cap` is required to be non-negative.
@@ -581,7 +595,7 @@ node or that a new `Source` type receives a new method for `check_node`.
   accessible through a `StrategicPeriod` as outlined in the function
   [`check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)`](@ref).
 """
-function check_node(n::Source, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+function check_node_default(n::Source, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     @assert_or_log(
@@ -595,13 +609,10 @@ function check_node(n::Source, 𝒯, modeltype::EnergyModel, check_timeprofiles:
     check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)
 end
 """
-    check_node(n::NetworkNode, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_node_default(n::NetworkNode, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
-This method checks that a `NetworkNode` node is valid.
-
-These checks are always performed, if the user is not creating a new method. Hence, it is
-important that a new `NetworkNode` type includes at least the same fields as in the
-[`RefNetworkNode`(@ref) node or that a new `NetworkNode` type receives a new method for `check_node`.
+Subroutine that can be utilized in other packages for incorporating the standard tests for
+a [`NetworkNode`](@ref) node.
 
 ## Checks
 - The field `cap` is required to be non-negative.
@@ -611,7 +622,7 @@ important that a new `NetworkNode` type includes at least the same fields as in 
   accessible through a `StrategicPeriod` as outlined in the function
   [`check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)`](@ref).
 """
-function check_node(n::NetworkNode, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+function check_node_default(n::NetworkNode, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     @assert_or_log(
@@ -629,13 +640,10 @@ function check_node(n::NetworkNode, 𝒯, modeltype::EnergyModel, check_timeprof
     check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)
 end
 """
-    check_node(n::Storage, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_node_default(n::Storage, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
-This method checks that a `Storage` node is valid.
-
-These checks are always performed, if the user is not creating a new method. Hence, it is
-important that a new `Storage` type includes at least the same fields as in the
-[`RefStorage`](@ref) node or that a new `Storage` type receives a new method for `check_node`.
+Subroutine that can be utilized in other packages for incorporating the standard tests for
+a [`Storage`](@ref) node.
 
 ## Checks
 - The `TimeProfile` of the field `capacity` in the type in the field `charge` is required
@@ -650,7 +658,7 @@ important that a new `Storage` type includes at least the same fields as in the
 - The values of the dictionary `input` are required to be non-negative.
 - The values of the dictionary `output` are required to be non-negative.
 """
-function check_node(n::Storage, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+function check_node_default(n::Storage, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
     par_charge = charge(n)
     par_level = level(n)
@@ -690,23 +698,21 @@ function check_node(n::Storage, 𝒯, modeltype::EnergyModel, check_timeprofiles
         "The values for the Dictionary `output` must be non-negative."
     )
 end
+
 """
-    check_node(n::Sink, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_node_default(n::Sink, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
-This method checks that a `Sink` node is valid.
-
-These checks are always performed, if the user is not creating a new method. Hence, it is
-important that a new `Sink` type includes at least the same fields as in the [`RefSink`](@ref)
-node or that a new `Source` type receives a new method for `check_node`.
+Subroutine that can be utilized in other packages for incorporating the standard tests for
+a [`Sink`](@ref) node.
 
 ## Checks
 - The field `cap` is required to be non-negative.
 - The values of the dictionary `input` are required to be non-negative.
 - The dictionary `penalty` is required to have the keys `:deficit` and `:surplus`.
 - The sum of the values `:deficit` and `:surplus` in the dictionary `penalty` has to be
-  non-negative to avoid an infeasible model.
+    non-negative to avoid an infeasible model.
 """
-function check_node(n::Sink, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+function check_node_default(n::Sink, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
     @assert_or_log(
         all(capacity(n, t) ≥ 0 for t ∈ 𝒯),
         "The capacity must be non-negative."
@@ -728,6 +734,8 @@ function check_node(n::Sink, 𝒯, modeltype::EnergyModel, check_timeprofiles::B
         )
     end
 end
+
+
 """
     check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles::Bool)
 

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -585,11 +585,11 @@ function check_node(n::Source, 𝒯, modeltype::EnergyModel, check_timeprofiles:
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     @assert_or_log(
-        sum(capacity(n, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+        all(capacity(n, t) ≥ 0 for t ∈ 𝒯),
         "The capacity must be non-negative."
     )
     @assert_or_log(
-        sum(outputs(n, p) ≥ 0 for p ∈ outputs(n)) == length(outputs(n)),
+        all(outputs(n, p) ≥ 0 for p ∈ outputs(n)),
         "The values for the Dictionary `output` must be non-negative."
     )
     check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)
@@ -615,15 +615,15 @@ function check_node(n::NetworkNode, 𝒯, modeltype::EnergyModel, check_timeprof
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     @assert_or_log(
-        sum(capacity(n, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+        all(capacity(n, t) ≥ 0 for t ∈ 𝒯),
         "The capacity must be non-negative."
     )
     @assert_or_log(
-        sum(inputs(n, p) ≥ 0 for p ∈ inputs(n)) == length(inputs(n)),
+        all(inputs(n, p) ≥ 0 for p ∈ inputs(n)),
         "The values for the Dictionary `input` must be non-negative."
     )
     @assert_or_log(
-        sum(outputs(n, p) ≥ 0 for p ∈ outputs(n)) == length(outputs(n)),
+        all(outputs(n, p) ≥ 0 for p ∈ outputs(n)),
         "The values for the Dictionary `output` must be non-negative."
     )
     check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)
@@ -658,7 +658,7 @@ function check_node(n::Storage, 𝒯, modeltype::EnergyModel, check_timeprofiles
 
     if isa(par_charge, UnionCapacity)
         @assert_or_log(
-            sum(capacity(par_charge, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+            all(capacity(par_charge, t) ≥ 0 for t ∈ 𝒯),
             "The charge capacity must be non-negative."
         )
     end
@@ -666,7 +666,7 @@ function check_node(n::Storage, 𝒯, modeltype::EnergyModel, check_timeprofiles
         check_fixed_opex(par_charge, 𝒯ᴵⁿᵛ, check_timeprofiles)
     end
     @assert_or_log(
-        sum(capacity(par_level, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+        all(capacity(par_level, t) ≥ 0 for t ∈ 𝒯),
         "The level capacity must be non-negative."
     )
     if isa(par_level, UnionOpexFixed)
@@ -674,7 +674,7 @@ function check_node(n::Storage, 𝒯, modeltype::EnergyModel, check_timeprofiles
     end
     if isa(par_discharge, UnionCapacity)
         @assert_or_log(
-            sum(capacity(par_discharge, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+            all(capacity(par_discharge, t) ≥ 0 for t ∈ 𝒯),
             "The charge capacity must be non-negative."
         )
     end
@@ -682,11 +682,11 @@ function check_node(n::Storage, 𝒯, modeltype::EnergyModel, check_timeprofiles
         check_fixed_opex(par_discharge, 𝒯ᴵⁿᵛ, check_timeprofiles)
     end
     @assert_or_log(
-        sum(inputs(n, p) ≥ 0 for p ∈ inputs(n)) == length(inputs(n)),
+        all(inputs(n, p) ≥ 0 for p ∈ inputs(n)),
         "The values for the Dictionary `input` must be non-negative."
     )
-    @assert_or_log(
-        sum(outputs(n, p) ≥ 0 for p ∈ outputs(n)) == length(outputs(n)),
+    has_output(n) && @assert_or_log(
+        all(outputs(n, p) ≥ 0 for p ∈ outputs(n)),
         "The values for the Dictionary `output` must be non-negative."
     )
 end
@@ -708,11 +708,11 @@ node or that a new `Source` type receives a new method for `check_node`.
 """
 function check_node(n::Sink, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
     @assert_or_log(
-        sum(capacity(n, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+        all(capacity(n, t) ≥ 0 for t ∈ 𝒯),
         "The capacity must be non-negative."
     )
     @assert_or_log(
-        sum(inputs(n, p) ≥ 0 for p ∈ inputs(n)) == length(inputs(n)),
+        all(inputs(n, p) ≥ 0 for p ∈ inputs(n)),
         "The values for the Dictionary `input` must be non-negative."
     )
     @assert_or_log(
@@ -723,7 +723,7 @@ function check_node(n::Sink, 𝒯, modeltype::EnergyModel, check_timeprofiles::B
     if :surplus ∈ keys(n.penalty) && :deficit ∈ keys(n.penalty)
         # The if-condition was checked above.
         @assert_or_log(
-            sum(surplus_penalty(n, t) + deficit_penalty(n, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+            all(surplus_penalty(n, t) + deficit_penalty(n, t) ≥ 0 for t ∈ 𝒯),
             "An inconsistent combination of `:surplus` and `:deficit` leads to an infeasible model."
         )
     end
@@ -758,7 +758,7 @@ function check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles::Bool)
     # Check that the value is positive in all cases
     if bool_sp
         @assert_or_log(
-            sum(opex_fixed(n, t_inv) ≥ 0 for t_inv ∈ 𝒯ᴵⁿᵛ) == length(𝒯ᴵⁿᵛ),
+            all(opex_fixed(n, t_inv) ≥ 0 for t_inv ∈ 𝒯ᴵⁿᵛ),
             "The fixed OPEX must be non-negative."
         )
     end

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -689,7 +689,7 @@ function check_node_default(n::Storage, 𝒯, modeltype::EnergyModel, check_time
     if isa(par_discharge, UnionOpexFixed)
         check_fixed_opex(par_discharge, 𝒯ᴵⁿᵛ, check_timeprofiles)
     end
-    @assert_or_log(
+    has_input(n) && @assert_or_log(
         all(inputs(n, p) ≥ 0 for p ∈ inputs(n)),
         "The values for the Dictionary `input` must be non-negative."
     )

--- a/src/structures/resource.jl
+++ b/src/structures/resource.jl
@@ -7,7 +7,7 @@ Base.show(io::IO, r::Resource) = print(io, "$(r.id)")
 """
     ResourceEmit{T<:Real} <: Resource
 
-Resources that can can be emitted (*e.g.*, CO₂, CH₄, NOₓ).
+Resources that can be emitted (*e.g.*, CO₂, CH₄, NOₓ).
 
 These resources can be included as resources that are emitted, *e.g*, in the variable
 [`emissions_strategic`](@ref man-opt_var-emissions).

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,6 @@ const TS = TimeStruct
 const TEST_ATOL = 1e-6
 ENV["EMB_TEST"] = true # Set flag for example scripts to check if they are run as part of the tests
 
-
 @testset "Base" begin
     @testset "Base | General" begin
         include("test_general.jl")

--- a/test/test_general.jl
+++ b/test/test_general.jl
@@ -110,26 +110,26 @@ end
 
     # Check that total emissions of both methane and CO2 are within the constraint
     # - constraints_emissions(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
-    @test sum(
+    @test all(
         value.(m[:emissions_strategic])[t_inv, CO2] <=
         EMB.emission_limit(model, CO2, t_inv) for t_inv ∈ 𝒯ᴵⁿᵛ
-    ) == length(𝒯ᴵⁿᵛ)
-    @test sum(
+    )
+    @test all(
         value.(m[:emissions_strategic])[t_inv, NG] <= EMB.emission_limit(model, NG, t_inv)
         for t_inv ∈ 𝒯ᴵⁿᵛ
-    ) == length(𝒯ᴵⁿᵛ)
+    )
 
     # Check that the total and strategic emissions are correctly calculated
     # - constraints_emissions(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
-    @test sum(
+    @test all(
         value.(m[:emissions_strategic][t_inv, CO2]) ≈
         sum(value.(m[:emissions_total][t, CO2]) * scale_op_sp(t_inv, t) for t ∈ t_inv) for
         t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
-    ) ≈ length(𝒯ᴵⁿᵛ)
-    @test sum(
+    )
+    @test all(
         value.(m[:emissions_total][t, CO2]) ≈
         sum(value.(m[:emissions_node][n, t, CO2]) for n ∈ 𝒩ᵉᵐ) for t ∈ 𝒯, atol ∈ TEST_ATOL
-    ) ≈ length(𝒯)
+    )
 
     # Check that the objective value is properly calculated
     # - objective(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
@@ -145,36 +145,36 @@ end
         ℒᶠʳᵒᵐ, ℒᵗᵒ = EMB.link_sub(ℒ, n)
         # Constraint for output flowrate and input links.
         if has_output(n)
-            @test sum(
+            @test all(
                 value.(m[:flow_out][n, t, p]) ≈
                 sum(value.(m[:link_in][l, t, p]) for l ∈ ℒᶠʳᵒᵐ if p ∈ inputs(l.to)) for
                 t ∈ 𝒯, p ∈ outputs(n), atol ∈ TEST_ATOL
-            ) ≈ length(𝒯) * length(outputs(n))
+            )
         end
         # Constraint for input flowrate and output links.
         if has_input(n)
-            @test sum(
+            @test all(
                 value.(m[:flow_in][n, t, p]) ≈
                 sum(value.(m[:link_out][l, t, p]) for l ∈ ℒᵗᵒ if p ∈ outputs(l.from)) for
                 t ∈ 𝒯, p ∈ inputs(n), atol ∈ TEST_ATOL
-            ) ≈ length(𝒯) * length(inputs(n))
+            )
         end
     end
 
     # Check that the total energy balances are fulfilled in the availability node for
     # each resource
     # - create_node(m, n::Availability, 𝒯, 𝒫, modeltype::EnergyModel)
-    @test sum(
+    @test all(
         value.(m[:flow_in][avail, t, p]) ≈ value.(m[:flow_out][avail, t, p]) for t ∈ 𝒯,
         p ∈ 𝒫, atol ∈ TEST_ATOL
-    ) ≈ length(𝒯) * length(𝒫)
+    )
 
     # Check that the link balance is correct
     # - create_link(m, 𝒯, 𝒫, l, formulation::Formulation)
-    @test sum(
-        sum(
+    @test all(
+        all(
             value.(m[:link_out][l, t, p]) ≈ value.(m[:link_in][l, t, p]) for t ∈ 𝒯,
             p ∈ EMB.link_res(l), atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) * length(EMB.link_res(l)) for l ∈ ℒ, atol ∈ TEST_ATOL
-    ) ≈ length(ℒ)
+        ) for l ∈ ℒ, atol ∈ TEST_ATOL
+    )
 end

--- a/test/test_modeltype.jl
+++ b/test/test_modeltype.jl
@@ -41,9 +41,9 @@
 
         # Test that the system produces
         # Test that the deficit is hence larger than 0 in a strategic period
-        @test sum(
+        @test all(
             sum(value.(m[:cap_use][sink, t]) for t ∈ t_inv) > TEST_ATOL for t_inv ∈ 𝒯ᴵⁿᵛ
-        ) == length(𝒯ᴵⁿᵛ)
+        )
     end
 
     @testset "Emission cap" begin
@@ -65,15 +65,15 @@
 
         # Test that the strategic emission limits hold
         # - constraints_emissions(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel
-        @test sum(
+        @test all(
             value.(m[:emissions_strategic][t_inv, CO2]) ≈ cap for t_inv ∈ 𝒯ᴵⁿᵛ,
             atol ∈ TEST_ATOL
-        ) == length(𝒯ᴵⁿᵛ)
+        )
         # Test that the deficit is hence larger than 0 in a strategic period
-        @test sum(
+        @test all(
             sum(value.(m[:sink_deficit][sink, t]) for t ∈ t_inv) > TEST_ATOL for
             t_inv ∈ 𝒯ᴵⁿᵛ
-        ) == length(𝒯ᴵⁿᵛ)
+        )
     end
 
     @testset "Emission price" begin
@@ -99,6 +99,6 @@
         @test objective_value(m) ≈ -cap * price * 2 * 2 atol = TEST_ATOL
 
         # Check that there is no deficit
-        @test sum(value.(m[:sink_deficit][sink, t]) ≤ TEST_ATOL for t ∈ 𝒯) == length(𝒯)
+        @test all(value.(m[:sink_deficit][sink, t]) ≤ TEST_ATOL for t ∈ 𝒯)
     end
 end

--- a/test/test_nodes.jl
+++ b/test/test_nodes.jl
@@ -1,4 +1,3 @@
-
 @testset "Node utilities" begin
 
     # Resources used in the analysis
@@ -147,15 +146,13 @@
         𝒩ᵒᵘᵗ = setdiff(filter(has_output, 𝒩), [stor]) # The storage has a fixed output variable
         𝒯 = case[:T]
 
-        # Test that all link variables have a lower bound of 0
+        # Test that all node flow variables have a lower bound of 0
         @test all(
             all(lower_bound(m[:flow_in][n_in, t, p]) == 0 for p ∈ inputs(n_in))
-            for n_in ∈ 𝒩ⁱⁿ, t ∈ 𝒯
-        )
+        for n_in ∈ 𝒩ⁱⁿ, t ∈ 𝒯)
         @test all(
             all(lower_bound(m[:flow_out][n_out, t, p]) == 0 for p ∈ outputs(n_out))
-            for n_out ∈ 𝒩ᵒᵘᵗ, t ∈ 𝒯
-        )
+        for n_out ∈ 𝒩ᵒᵘᵗ, t ∈ 𝒯)
     end
 end
 
@@ -205,42 +202,42 @@ end
 
         # Test that the capacity bound is properly set
         # - constraints_capacity_installed(m, n::Node, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:cap_inst][source, t]) ≈ EMB.capacity(source)[t] for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            atol = TEST_ATOL
+        )
 
         # Test that the capacity bound is properly utilized for a `RefSink`
         # - constraints_capacity(m, n::Node, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:cap_use][source, t]) <= value.(m[:cap_inst][source, t]) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            atol = TEST_ATOL
+        )
 
         # Test that the outflow is equal to the specified capacity usage
         # - constraints_flow_out(m, n::Node, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:flow_out][source, t, Power]) ≈
             value.(m[:cap_use][source, t]) * outputs(source, Power) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            atol = TEST_ATOL
+        )
 
         # Test that the variable OPEX values are properly calculated for RefSource
         # - constraints_opex_var(m, n::Node, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:opex_var][source, t_inv]) ≈ sum(
                 value.(m[:cap_use][source, t]) * EMB.opex_var(source, t) * duration(t) for
                 t ∈ t_inv
-            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯ᴵⁿᵛ) atol = TEST_ATOL
+            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol = TEST_ATOL
+        )
 
         # Test that the fixed OPEX values are properly calculated for RefSource
         # - constraints_opex_fixed(m, n::Node, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:opex_fixed][source, t_inv]) ≈
             EMB.opex_fixed(source, t_inv) * value.(m[:cap_inst][source, first(t_inv)]) for
-            t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯ᴵⁿᵛ) atol = TEST_ATOL
+            t_inv ∈ 𝒯ᴵⁿᵛ, atol = TEST_ATOL
+        )
     end
 
     @testset "General tests - RefSink" begin
@@ -266,32 +263,30 @@ end
 
         # Test that the inflow is equal to the specified capacity usage
         # - constraints_flow_in(m, n::Node, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:flow_in][sink, t, Power]) ≈
-            value.(m[:cap_use][sink, t]) * inputs(sink, Power) for t ∈ 𝒯, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            value.(m[:cap_use][sink, t]) * inputs(sink, Power) for t ∈ 𝒯, atol = TEST_ATOL
+        )
 
         # Test that the mass balance is properly calculated
         # - constraints_capacity(m, n::Sink, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(value.(m[:sink_deficit][sink, t] for t ∈ 𝒯)) ≈ length(𝒯) * 4 atol =
-            TEST_ATOL
-        @test sum(
+        @test all(value.(m[:sink_deficit][sink, t]) ≈ 4 for t ∈ 𝒯)
+        @test all(
             value.(m[:sink_deficit][sink, t]) + value.(m[:cap_use][sink, t]) ≈
             value.(m[:sink_surplus][sink, t]) + value.(m[:cap_inst][sink, t]) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            atol = TEST_ATOL
+        )
 
         # Test that the fixed OPEX is set to 0
         # - constraints_opex_fixed(m, n::Sink, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
-        @test sum(value.(m[:opex_fixed][sink, t_inv]) ≈ 0 for t_inv ∈ 𝒯ᴵⁿᵛ) ≈ length(𝒯ᴵⁿᵛ) atol =
-            TEST_ATOL
+        @test all(value.(m[:opex_fixed][sink, t_inv]) ≈ 0 for t_inv ∈ 𝒯ᴵⁿᵛ)
 
         # Test that the opex calculations are correct
         # - constraints_opex_var(m, n::Sink, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
-        @test sum(value.(m[:opex_var][sink, t_inv]) ≈
+        @test all(
+            value.(m[:opex_var][sink, t_inv]) ≈
                 sum(value.(m[:sink_deficit][sink, t]) * duration(t) * 10 for t ∈ t_inv)
-                for t_inv ∈ 𝒯ᴵⁿᵛ)  ≈
-                    length(𝒯ᴵⁿᵛ) atol=TEST_ATOL
+        for t_inv ∈ 𝒯ᴵⁿᵛ)
 
         # Test that the surplus values are properly calculated and time is involved
         # in the penalty calculation
@@ -307,20 +302,19 @@ end
 
         # Test that the mass balance is properly calculated
         # - constraints_capacity(m, n::Sink, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(value.(m[:sink_surplus][sink, t]) for t ∈ 𝒯) ≈ length(𝒯) * 2 atol =
-            TEST_ATOL
-        @test sum(
+        @test all(value.(m[:sink_surplus][sink, t]) ≈ 2 for t ∈ 𝒯)
+        @test all(
             value.(m[:sink_deficit][sink, t]) + value.(m[:cap_use][sink, t]) ≈
             value.(m[:sink_surplus][sink, t]) + value.(m[:cap_inst][sink, t]) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            atol = TEST_ATOL
+        )
 
         # Test that the opex calculations are correct
         # - constraints_opex_var(m, n::Sink, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
-        @test sum(value.(m[:opex_var][sink, t_inv]) ≈
+        @test all(
+            value.(m[:opex_var][sink, t_inv]) ≈
                 sum(value.(m[:sink_surplus][sink, t]) * duration(t) * -100 for t ∈ t_inv)
-                for t_inv ∈ 𝒯ᴵⁿᵛ) ==
-                    length(𝒯ᴵⁿᵛ)
+        for t_inv ∈ 𝒯ᴵⁿᵛ)
 
     end
 
@@ -359,11 +353,10 @@ end
         m, case, model = simple_graph(source, snk_emit)
         𝒯 = case[:T]
         # Test that the emissions are properly calculated
-        @test sum(
+        @test all(
             value.(m[:cap_use][snk_emit, t]) * process_emissions(em_data, CO2, t) ≈
             value.(m[:emissions_node][snk_emit, t, CO2]) for t ∈ 𝒯
-        ) ≈ length(𝒯) atol = TEST_ATOL
-
+        )
         # Test that the emissions from a source node with emissions are properly accounted for
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
         em_data = EmissionsProcess(Dict(CO2 => 10.0))
@@ -380,10 +373,10 @@ end
         # Test that the emissions are properly calculated, although no input is present in
         # a `Source ndoe`
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
-        @test sum(
+        @test all(
             value.(m[:cap_use][src_emit, t]) * process_emissions(em_data, CO2, t) ≈
             value.(m[:emissions_node][src_emit, t, CO2]) for t ∈ 𝒯
-        ) ≈ length(𝒯) atol = TEST_ATOL
+        )
     end
 end
 
@@ -478,7 +471,7 @@ end
         net = 𝒩[2]
 
         # Check that there is production
-        @test sum(value.(m[:cap_use][net, t]) > 0 for t ∈ 𝒯) ≈ length(𝒯) atol = TEST_ATOL
+        @test all(value.(m[:cap_use][net, t]) > 0 for t ∈ 𝒯)
 
         # Check that no emission variables are created without emissions
         # - variables_emission(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
@@ -486,18 +479,16 @@ end
 
         # Check that the total and strategic emissions are 0
         # - constraints_emissions(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:emissions_strategic][t_inv, CO2]) ≈ 0 for t_inv ∈ 𝒯ᴵⁿᵛ,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯ᴵⁿᵛ)
-        @test sum(value.(m[:emissions_total][t, CO2]) ≈ 0 for t ∈ 𝒯, atol ∈ TEST_ATOL) ≈
-              length(𝒯)
-        @test sum(
+            atol = TEST_ATOL
+        )
+        @test all(value.(m[:emissions_total][t, CO2]) ≈ 0 for t ∈ 𝒯, atol = TEST_ATOL)
+        @test all(
             value.(m[:emissions_strategic][t_inv, NG]) ≈ 0 for t_inv ∈ 𝒯ᴵⁿᵛ,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯ᴵⁿᵛ)
-        @test sum(value.(m[:emissions_total][t, NG]) ≈ 0 for t ∈ 𝒯, atol ∈ TEST_ATOL) ≈
-              length(𝒯)
+            atol = TEST_ATOL
+        )
+        @test all(value.(m[:emissions_total][t, NG]) ≈ 0 for t ∈ 𝒯, atol = TEST_ATOL)
     end
 
     @testset "Emissions tests - with energy emissions" begin
@@ -515,7 +506,7 @@ end
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Check that there is production
-        @test sum(value.(m[:cap_use][net, t]) > 0 for t ∈ 𝒯) ≈ length(𝒯) atol = TEST_ATOL
+        @test all(value.(m[:cap_use][net, t]) > 0 for t ∈ 𝒯)
 
         # Check that the # of created variables correspond to the # of nodes with emissions
         # - variables_emission(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
@@ -523,13 +514,12 @@ end
 
         # Check that the total and strategic emissions are correctly calculated
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsEnergy)
-        @test sum(
+        @test all(
             value.(m[:emissions_node][net, t, CO2]) ≈
             sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯)
-        @test sum(value.(m[:emissions_node][net, t, NG]) ≈ 0 for t ∈ 𝒯, atol ∈ TEST_ATOL) ≈
-              length(𝒯)
+            atol = TEST_ATOL
+        )
+        @test all(value.(m[:emissions_node][net, t, NG]) ≈ 0 for t ∈ 𝒯, atol = TEST_ATOL)
     end
 
     @testset "Emissions tests - with energy and process emissions" begin
@@ -550,7 +540,7 @@ end
         𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
         # Check that there is production
-        @test sum(value.(m[:cap_use][net, t]) > 0 for t ∈ 𝒯) ≈ length(𝒯) atol = TEST_ATOL
+        @test all(value.(m[:cap_use][net, t]) > 0 for t ∈ 𝒯)
 
         # Check that the # of created variables correspond to the # of nodes with emissions
         # - variables_emission(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
@@ -558,17 +548,17 @@ end
 
         # Check that the total and strategic emissions are correctly calculated
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
-        @test sum(
+        @test all(
             value.(m[:emissions_node][net, t, CO2]) ≈
             sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) +
             value.(m[:cap_use][net, t]) * process_emissions(em_data, CO2, t) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯)
-        @test sum(
+            atol = TEST_ATOL
+        )
+        @test all(
             value.(m[:emissions_node][net, t, NG]) ≈
             value.(m[:cap_use][net, t]) * process_emissions(em_data, NG, t) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯)
+            atol = TEST_ATOL
+        )
     end
 
     @testset "Emissions tests - with energy and process emissions as TimeProfile" begin
@@ -589,7 +579,7 @@ end
         𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
         # Check that there is production
-        @test sum(value.(m[:cap_use][net, t]) > 0 for t ∈ 𝒯) ≈ length(𝒯) atol = TEST_ATOL
+        @test all(value.(m[:cap_use][net, t]) > 0 for t ∈ 𝒯)
 
         # Check that the # of created variables correspond to the # of nodes with emissions
         # - variables_emission(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
@@ -597,17 +587,17 @@ end
 
         # Check that the total and strategic emissions are correctly calculated
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
-        @test sum(
+        @test all(
             value.(m[:emissions_node][net, t, CO2]) ≈
             sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) +
             value.(m[:cap_use][net, t]) * process_emissions(em_data, CO2, t) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯)
-        @test sum(
+            atol = TEST_ATOL
+        )
+        @test all(
             value.(m[:emissions_node][net, t, NG]) ≈
             value.(m[:cap_use][net, t]) * process_emissions(em_data, NG, t) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯)
+            atol = TEST_ATOL
+        )
     end
 
     @testset "Emissions tests - with capture on energy emissions" begin
@@ -628,7 +618,7 @@ end
         𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
         # Check that there is production
-        @test sum(value.(m[:cap_use][net, t]) > 0 for t ∈ 𝒯) ≈ length(𝒯) atol = TEST_ATOL
+        @test all(value.(m[:cap_use][net, t]) > 0 for t ∈ 𝒯)
 
         # Check that the # of created variables correspond to the # of nodes with emissions
         # - variables_emission(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
@@ -636,26 +626,26 @@ end
 
         # Check that the total and strategic emissions are correctly calculated
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
-        @test sum(
+        @test all(
             value.(m[:emissions_node][net, t, CO2]) ≈
             sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) *
             (1 - co2_capture(em_data)) +
             value.(m[:cap_use][net, t]) * process_emissions(em_data, CO2, t) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
-        @test sum(
+            atol = TEST_ATOL
+        )
+        @test all(
             value.(m[:emissions_node][net, t, NG]) ≈
             value.(m[:cap_use][net, t]) * process_emissions(em_data, NG, t) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            atol = TEST_ATOL
+        )
 
         # Test that the CO2 capture is calculated correctly
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
-        @test sum(
+        @test all(
             value.(m[:flow_out][net, t, CO2]) ≈
             sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) *
-            co2_capture(em_data) for t ∈ 𝒯, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            co2_capture(em_data) for t ∈ 𝒯, atol = TEST_ATOL
+        )
     end
 
     @testset "Emissions tests - with capture on process emissions" begin
@@ -676,7 +666,7 @@ end
         𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
         # Check that there is production
-        @test sum(value.(m[:cap_use][net, t]) > 0 for t ∈ 𝒯) ≈ length(𝒯) atol = TEST_ATOL
+        @test all(value.(m[:cap_use][net, t]) > 0 for t ∈ 𝒯)
 
         # Check that the # of created variables correspond to the # of nodes with emissions
         # - variables_emission(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
@@ -684,27 +674,27 @@ end
 
         # Check that the total and strategic emissions are correctly calculated
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
-        @test sum(
+        @test all(
             value.(m[:emissions_node][net, t, CO2]) ≈
             sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) +
             value.(m[:cap_use][net, t]) *
             process_emissions(em_data, CO2, t) *
-            (1 - co2_capture(em_data)) for t ∈ 𝒯, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
-        @test sum(
+            (1 - co2_capture(em_data)) for t ∈ 𝒯, atol = TEST_ATOL
+        )
+        @test all(
             value.(m[:emissions_node][net, t, NG]) ≈
             value.(m[:cap_use][net, t]) * process_emissions(em_data, NG, t) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            atol = TEST_ATOL
+        )
 
         # Test that the CO2 capture is calculated correctly
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
-        @test sum(
+        @test all(
             value.(m[:flow_out][net, t, CO2]) ≈
             value.(m[:cap_use][net, t]) *
             process_emissions(em_data, CO2, t) *
-            co2_capture(em_data) for t ∈ 𝒯, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            co2_capture(em_data) for t ∈ 𝒯, atol = TEST_ATOL
+        )
     end
 
     @testset "Emissions tests - with capture on process emissions" begin
@@ -725,7 +715,7 @@ end
         𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
         # Check that there is production
-        @test sum(value.(m[:cap_use][net, t]) > 0 for t ∈ 𝒯) ≈ length(𝒯) atol = TEST_ATOL
+        @test all(value.(m[:cap_use][net, t]) > 0 for t ∈ 𝒯)
 
         # Check that the # of created variables correspond to the # of nodes with emissions
         # - variables_emission(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)
@@ -733,28 +723,28 @@ end
 
         # Check that the total and strategic emissions are correctly calculated
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
-        @test sum(
+        @test all(
             value.(m[:emissions_node][net, t, CO2]) ≈
             (
                 sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) +
                 value.(m[:cap_use][net, t]) * process_emissions(em_data, CO2, t)
-            ) * (1 - co2_capture(em_data)) for t ∈ 𝒯, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
-        @test sum(
+            ) * (1 - co2_capture(em_data)) for t ∈ 𝒯, atol = TEST_ATOL
+        )
+        @test all(
             value.(m[:emissions_node][net, t, NG]) ≈
             value.(m[:cap_use][net, t]) * process_emissions(em_data, NG, t) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            atol = TEST_ATOL
+        )
 
         # Test that the CO2 capture is calculated correctly
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
-        @test sum(
+        @test all(
             value.(m[:flow_out][net, t, CO2]) ≈
             (
                 sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) +
                 value.(m[:cap_use][net, t]) * process_emissions(em_data, CO2, t)
-            ) * co2_capture(em_data) for t ∈ 𝒯, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            ) * co2_capture(em_data) for t ∈ 𝒯, atol = TEST_ATOL
+        )
     end
 end
 
@@ -833,26 +823,26 @@ end
 
         # Test that the capacity is correctly limited
         # - constraints_capacity(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:stor_level][stor, t]) - value.(m[:stor_level_inst][stor, t]) ≤
             TEST_ATOL for t ∈ 𝒯
-        ) ≈ length(𝒯) atol = TEST_ATOL
-        @test sum(
+        )
+        @test all(
             value.(m[:stor_charge_use][stor, t]) - value.(m[:stor_charge_inst][stor, t]) ≤
             TEST_ATOL for t ∈ 𝒯
-        ) ≈ length(𝒯) atol = TEST_ATOL
+        )
 
         # Test that the design for rate usage is correct
         # - constraints_flow_in(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:flow_in][stor, t, Power]) ≈ value.(m[:stor_charge_use][stor, t]) for
-            t ∈ 𝒯, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
-        @test sum(
+            t ∈ 𝒯, atol = TEST_ATOL
+        )
+        @test all(
             value.(m[:flow_in][stor, t, aux]) ≈
             value.(m[:stor_charge_use][stor, t]) * inputs(stor, aux) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            atol = TEST_ATOL
+        )
 
         # Test that the inlet flow is equivalent to the total usage of the demand
         @test sum(
@@ -869,11 +859,11 @@ end
 
         # Test that the Δ in the storage level is correctly calculated
         # - constraints_level_aux(m, n::Storage, 𝒯, 𝒫, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:stor_level_Δ_op][stor, t]) ≈
             value.(m[:flow_in][stor, t, Power]) - value.(m[:flow_out][stor, t, Power]) for
-            t ∈ 𝒯, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            t ∈ 𝒯, atol = TEST_ATOL
+        )
     end
 
     @testset "SimpleTimes without storage" begin
@@ -893,40 +883,38 @@ end
 
         # Test that the capacity is correctly limited
         # - constraints_capacity_installed(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:stor_level_inst][stor, t]) ≈ capacity(EMB.level(stor), t) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
-        @test sum(
-            value.(m[:stor_charge_inst][stor, t]) ≈ capacity(EMB.charge(stor), t) for
-            t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            atol = TEST_ATOL
+        )
+        @test all(
+            value.(m[:stor_charge_inst][stor, t]) ≈ capacity(EMB.charge(stor), t) for t ∈ 𝒯,
+            atol = TEST_ATOL
+        )
 
         # Test that the input flow is equal to the output flow in the standard scenario as
         # storage does not pay off
         # - constraints_level_aux(m, n::Storage, 𝒯, 𝒫, modeltype::EnergyModel)
-        @test sum(value.(m[:stor_level_Δ_op][stor, t]) ≈ 0 for t ∈ 𝒯, atol ∈ TEST_ATOL) ≈
-              length(𝒯) atol = TEST_ATOL
+        @test all(value.(m[:stor_level_Δ_op][stor, t]) ≈ 0 for t ∈ 𝒯, atol = TEST_ATOL)
 
         # Test that the fixed OPEX is correctly calculated
         # - constraints_opex_fixed(m, n::Storage, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:opex_fixed][stor, t_inv]) ≈
             EMB.opex_fixed(EMB.level(stor), t_inv) *
             value.(m[:stor_level_inst][stor, first(t_inv)]) for t_inv ∈ 𝒯ᴵⁿᵛ,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯ᴵⁿᵛ) atol = TEST_ATOL
+            atol = TEST_ATOL
+        )
 
         # Test that variable OPEX is correctly calculated
         # - constraints_opex_var(m, n::Storage, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:opex_var][stor, t_inv]) ≈ sum(
                 EMB.opex_var(EMB.charge(stor), t_inv) *
                 value.(m[:flow_in][stor, t, Power]) *
                 duration(t) for t ∈ t_inv
-            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯ᴵⁿᵛ) atol = TEST_ATOL
+            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol = TEST_ATOL
+        )
     end
 
     @testset "SimpleTimes with storage" begin
@@ -959,7 +947,7 @@ end
                 value.(m[:stor_level][stor, t_prev]) +
                 value.(m[:stor_level_Δ_op][stor, t]) * duration(t) for
                 (t_prev, t) ∈ withprev(t_inv) if !isnothing(t_prev)
-            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
+            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol = TEST_ATOL
         ) ≈ length(𝒯) - 2 atol = TEST_ATOL
 
         # Test that the level balance is correct in the first period (2 times)
@@ -969,11 +957,11 @@ end
                 value.(m[:stor_level][stor, last(t_inv)]) +
                 value.(m[:stor_level_Δ_op][stor, t]) * duration(t) for
                 (t_prev, t) ∈ withprev(t_inv) if isnothing(t_prev)
-            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
+            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol = TEST_ATOL
         ) ≈ 2 atol = TEST_ATOL
 
         # Test that the level is 0 exactly 4 times
-        @test sum(value.(m[:stor_level][stor, t]) ≈ 0 for t ∈ 𝒯, atol ∈ TEST_ATOL) == 4
+        @test sum(value.(m[:stor_level][stor, t]) ≈ 0 for t ∈ 𝒯, atol = TEST_ATOL) == 4
     end
 
     @testset "RepresentativePeriods with storage" begin
@@ -1056,7 +1044,7 @@ end
             value.(m[:stor_level][stor, t]) ≈
             value.(m[:stor_level][stor, t_prev]) +
             value.(m[:stor_level_Δ_op][stor, t]) * duration(t) for
-            (t_prev, t) ∈ withprev(𝒯), atol ∈ TEST_ATOL if !isnothing(t_prev)
+            (t_prev, t) ∈ withprev(𝒯), atol = TEST_ATOL if !isnothing(t_prev)
         ) ≈ length(𝒯) - length(𝒯ᴵⁿᵛ) * ops.len atol = TEST_ATOL
 
         # Check that there is no outflow in the first representative period of each
@@ -1144,26 +1132,26 @@ end
 
         # Test that the capacity is correctly limited
         # - constraints_capacity(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:stor_level][stor, t]) - value.(m[:stor_level_inst][stor, t]) ≤
             TEST_ATOL for t ∈ 𝒯
-        ) ≈ length(𝒯) atol = TEST_ATOL
-        @test sum(
+        )
+        @test all(
             value.(m[:stor_charge_use][stor, t]) - value.(m[:stor_charge_inst][stor, t]) ≤
             TEST_ATOL for t ∈ 𝒯
-        ) ≈ length(𝒯) atol = TEST_ATOL
+        )
 
         # Test that the design for rate usage is correct
         # - constraints_flow_in(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:flow_in][stor, t, Power]) ≈ value.(m[:stor_charge_use][stor, t]) for
-            t ∈ 𝒯, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
-        @test sum(
+            t ∈ 𝒯, atol = TEST_ATOL
+        )
+        @test all(
             value.(m[:flow_in][stor, t, aux]) ≈
             value.(m[:stor_charge_use][stor, t]) * inputs(stor, aux) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            atol = TEST_ATOL
+        )
 
         # Test that the inlet flow is equivalent to the total usage of the demand
         @test sum(
@@ -1181,11 +1169,11 @@ end
 
         # Test that the Δ_op in the storage level is correctly calculated
         # - constraints_level_aux(m, n::RefStorage, 𝒯, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:stor_level_Δ_op][stor, t]) ≈
             value.(m[:flow_in][stor, t, Power]) - value.(m[:flow_out][stor, t, Power]) for
-            t ∈ 𝒯, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            t ∈ 𝒯, atol = TEST_ATOL
+        )
     end
 
     @testset "SimpleTimes without storage" begin
@@ -1205,40 +1193,39 @@ end
 
         # Test that the capacity is correctly limited
         # - constraints_capacity_installed(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:stor_level_inst][stor, t]) ≈ capacity(EMB.level(stor), t) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
-        @test sum(
+            atol = TEST_ATOL
+        )
+        @test all(
             value.(m[:stor_charge_inst][stor, t]) ≈ capacity(EMB.charge(stor), t) for
             t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            atol = TEST_ATOL
+        )
 
         # Test that the input flow is equal to the output flow in the standard scenario as
         # storage does not pay off
         # - constraints_level_aux(m, n::RefStorage{T}, 𝒯, 𝒫, modeltype::EnergyModel) where {T<:ResourceCarrier}
-        @test sum(value.(m[:stor_level_Δ_op][stor, t]) ≈ 0 for t ∈ 𝒯, atol ∈ TEST_ATOL) ≈
-              length(𝒯) atol = TEST_ATOL
+        @test all(value.(m[:stor_level_Δ_op][stor, t]) ≈ 0 for t ∈ 𝒯, atol = TEST_ATOL)
 
         # Test that the fixed OPEX is correctly calculated
         # - constraints_opex_fixed(m, n::Storage, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:opex_fixed][stor, t_inv]) ≈
             EMB.opex_fixed(EMB.level(stor), t_inv) *
             value.(m[:stor_level_inst][stor, first(t_inv)]) for t_inv ∈ 𝒯ᴵⁿᵛ,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯ᴵⁿᵛ) atol = TEST_ATOL
+            atol = TEST_ATOL
+        )
 
         # Test that variable OPEX is correctly calculated
         # - constraints_opex_var(m, n::Storage, 𝒯ᴵⁿᵛ, modeltype::EnergyModel
-        @test sum(
+        @test all(
             value.(m[:opex_var][stor, t_inv]) ≈ sum(
                 EMB.opex_var(EMB.charge(stor), t_inv) *
                 value.(m[:flow_in][stor, t, Power]) *
                 duration(t) for t ∈ t_inv
-            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯ᴵⁿᵛ) atol = TEST_ATOL
+            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol = TEST_ATOL
+        )
     end
     @testset "SimpleTimes with storage" begin
 
@@ -1271,7 +1258,7 @@ end
                 value.(m[:stor_level][stor, t_prev]) +
                 value.(m[:stor_level_Δ_op][stor, t]) * duration(t) for
                 (t_prev, t) ∈ withprev(t_inv) if !isnothing(t_prev)
-            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
+            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol = TEST_ATOL
         ) ≈ length(𝒯) - 2 atol = TEST_ATOL
 
         # Test that the level balance is correct in the first period (2 times)
@@ -1281,11 +1268,11 @@ end
                 value.(m[:stor_level][stor, last(t_inv)]) +
                 value.(m[:stor_level_Δ_op][stor, t]) * duration(t) for
                 (t_prev, t) ∈ withprev(t_inv) if isnothing(t_prev)
-            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
+            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol = TEST_ATOL
         ) ≈ 2 atol = TEST_ATOL
 
         # Test that the level is 0 exactly 4 times
-        @test sum(value.(m[:stor_level][stor, t]) ≈ 0 for t ∈ 𝒯, atol ∈ TEST_ATOL) == 4
+        @test sum(value.(m[:stor_level][stor, t]) ≈ 0 for t ∈ 𝒯, atol = TEST_ATOL) == 4
     end
     @testset "OperationalScenarios with storage" begin
 
@@ -1328,7 +1315,7 @@ end
         @test sum(
             value.(m[:stor_level][stor, t]) -
             value.(m[:stor_level_Δ_op][stor, t]) * duration(t) ≈ 40 for t ∈ first_scp,
-            atol ∈ TEST_ATOL
+            atol = TEST_ATOL
         ) ≈ length(first_scp) atol = TEST_ATOL
 
         for t_inv ∈ 𝒯ᴵⁿᵛ
@@ -1348,7 +1335,7 @@ end
             value.(m[:stor_level][stor, t]) ≈
             value.(m[:stor_level][stor, t_prev]) +
             value.(m[:stor_level_Δ_op][stor, t]) * duration(t) for
-            (t_prev, t) ∈ withprev(𝒯), atol ∈ TEST_ATOL if !isnothing(t_prev)
+            (t_prev, t) ∈ withprev(𝒯), atol = TEST_ATOL if !isnothing(t_prev)
         ) ≈ length(𝒯) - length(𝒯ᴵⁿᵛ) * ops.len atol = TEST_ATOL
 
         # Check that the level is 0 exactly 2 times
@@ -1381,7 +1368,7 @@ end
         # - constraints_level_rp(m, n::Storage, per, modeltype::EnergyModel)
         @test sum(
             value.(value.(m[:stor_level_Δ_rp][stor, t_rp])) ≈ 0 for t_rp ∈ 𝒯ʳᵖ,
-            atol ∈ TEST_ATOL
+            atol = TEST_ATOL
         ) ≈ length(𝒯ʳᵖ) atol = TEST_ATOL
 
         # All the tests following are for the function, its individual methods, and the
@@ -1402,13 +1389,13 @@ end
         @test sum(
             value.(m[:stor_level][stor, t]) -
             value.(m[:stor_level_Δ_op][stor, t]) * duration(t) ≈ 10 for t ∈ first_rp,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯ᴵⁿᵛ) atol = TEST_ATOL
+            atol = TEST_ATOL
+        ) == length(𝒯ᴵⁿᵛ)
         @test sum(
             value.(m[:stor_level][stor, t]) -
             value.(m[:stor_level_Δ_op][stor, t]) * duration(t) ≈ 40 for t ∈ first_rp,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯ᴵⁿᵛ) atol = TEST_ATOL
+            atol = TEST_ATOL
+        ) == length(𝒯ᴵⁿᵛ)
 
         for t_inv ∈ 𝒯ᴵⁿᵛ
             𝒯ʳᵖ = repr_periods(t_inv)
@@ -1427,7 +1414,7 @@ end
             value.(m[:stor_level][stor, t]) ≈
             value.(m[:stor_level][stor, t_prev]) +
             value.(m[:stor_level_Δ_op][stor, t]) * duration(t) for
-            (t_prev, t) ∈ withprev(𝒯), atol ∈ TEST_ATOL if !isnothing(t_prev)
+            (t_prev, t) ∈ withprev(𝒯), atol = TEST_ATOL if !isnothing(t_prev)
         ) ≈ length(𝒯) - length(𝒯ᴵⁿᵛ) * ops.len atol = TEST_ATOL
     end
     @testset "OperationalScenarios and RepresentativePeriods with storage" begin
@@ -1485,13 +1472,13 @@ end
         @test sum(
             value.(m[:stor_level][stor, t]) -
             value.(m[:stor_level_Δ_op][stor, t]) * duration(t) ≈ 0
-            for t ∈ first_rp, atol = TEST_ATOL) ≈
-                length(𝒯ᴵⁿᵛ)  atol = TEST_ATOL
+            for t ∈ first_rp, atol = TEST_ATOL
+        ) == length(𝒯ᴵⁿᵛ)
         @test sum(
             value.(m[:stor_level][stor, t]) -
             value.(m[:stor_level_Δ_op][stor, t]) * duration(t) ≈ 40 for t ∈ first_rp,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯ᴵⁿᵛ) atol = TEST_ATOL
+            atol = TEST_ATOL
+        ) == length(𝒯ᴵⁿᵛ)
 
         for t_inv ∈ 𝒯ᴵⁿᵛ
             𝒯ʳᵖ = repr_periods(t_inv)
@@ -1510,7 +1497,7 @@ end
             value.(m[:stor_level][stor, t]) ≈
             value.(m[:stor_level][stor, t_prev]) +
             value.(m[:stor_level_Δ_op][stor, t]) * duration(t) for
-            (t_prev, t) ∈ withprev(𝒯), atol ∈ TEST_ATOL if !isnothing(t_prev)
+            (t_prev, t) ∈ withprev(𝒯), atol = TEST_ATOL if !isnothing(t_prev)
         ) ≈ length(𝒯) - length(𝒯ᴵⁿᵛ) * ops.len * scps.len atol = TEST_ATOL
 
         # Check that the level is 0 exactly 14 times
@@ -1596,41 +1583,39 @@ end
         stor = 𝒩[3]
 
         # Test that there is production
-        @test sum(value.(m[:cap_use][𝒩[2], t]) > 0 for t ∈ 𝒯, atol ∈ TEST_ATOL) ≈ length(𝒯) atol =
-            TEST_ATOL
+        @test all(value.(m[:cap_use][𝒩[2], t]) > 0 for t ∈ 𝒯, atol = TEST_ATOL)
 
         # Test that the capacity is correctly limited
         # - constraints_capacity(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:stor_level][stor, t]) <= value.(m[:stor_level_inst][stor, t]) for
-            t ∈ 𝒯, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
-        @test sum(
+            t ∈ 𝒯, atol = TEST_ATOL
+        )
+        @test all(
             value.(m[:stor_charge_use][stor, t]) <= value.(m[:stor_charge_inst][stor, t])
-            for t ∈ 𝒯, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            for t ∈ 𝒯, atol = TEST_ATOL
+        )
 
         # Test that the design for rate usage is correct
         # - constraints_flow_in(m, n::Storage{AccumulatingEmissions}, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:flow_in][stor, t, CO2]) ≈
             value.(m[:stor_charge_use][stor, t]) + value.(m[:emissions_node][stor, t, CO2])
-            for t ∈ 𝒯, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            for t ∈ 𝒯, atol = TEST_ATOL
+        )
 
         # Test that the Δ in the storage level is correctly calculated
         # - constraints_level_aux(m, n::RefStorage{AccumulatingEmissions}, 𝒯, 𝒫, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:stor_level_Δ_op][stor, t]) ≈
             value.(m[:flow_in][stor, t, CO2]) - value.(m[:emissions_node][stor, t, CO2])
             for
-            t ∈ 𝒯, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            t ∈ 𝒯, atol = TEST_ATOL
+        )
 
         # Test that the Δ in the storage level is larger than 0
         # - constraints_level_aux(m, n::RefStorage{AccumulatingEmissions}, 𝒯, 𝒫, modeltype::EnergyModel)
-        @test sum(value.(m[:stor_level_Δ_op][stor, t]) ≥ -TEST_ATOL for t ∈ 𝒯) ≈ length(𝒯) atol =
-            TEST_ATOL
+        @test all(value.(m[:stor_level_Δ_op][stor, t]) ≥ -TEST_ATOL for t ∈ 𝒯)
     end
 
     @testset "SimpleTimes without storage" begin
@@ -1653,38 +1638,38 @@ end
 
         # Test that the capacity is correctly limited
         # - constraints_capacity_installed(m, n::Storage, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:stor_level_inst][stor, t]) ≈ capacity(EMB.level(stor), t) for t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
-        @test sum(
+            atol = TEST_ATOL
+        )
+        @test all(
             value.(m[:stor_charge_inst][stor, t]) ≈ capacity(EMB.charge(stor), t) for
             t ∈ 𝒯,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            atol = TEST_ATOL
+        )
 
         # Test that the input flow is equal to the emissions as the limit allows it
         # - constraints_level_aux(m, n::RefStorage{AccumulatingEmissions}, 𝒯, 𝒫, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:flow_in][stor, t, CO2]) ≈ value.(m[:emissions_node][stor, t, CO2])
             for
-            t ∈ 𝒯, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) atol = TEST_ATOL
+            t ∈ 𝒯, atol = TEST_ATOL
+        )
 
         # Test that the fixed OPEX is correctly calculated
         # - constraints_opex_fixed(m, n::Storage{AccumulatingEmissions}, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:opex_fixed][stor, t_inv]) ≈
             EMB.opex_fixed(EMB.charge(stor), t_inv) *
             value.(m[:stor_charge_inst][stor, first(t_inv)]) for t_inv ∈ 𝒯ᴵⁿᵛ,
-            atol ∈ TEST_ATOL
-        ) ≈ length(𝒯ᴵⁿᵛ) atol = TEST_ATOL
+            atol = TEST_ATOL
+        )
 
         # Test that variable OPEX is correctly calculated
         # - constraints_opex_var(m, n::Storage{AccumulatingEmissions}, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
-        @test sum(
-            value.(m[:opex_var][stor, t_inv]) ≈ 0 for t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯ᴵⁿᵛ) atol = TEST_ATOL
+        @test all(
+            value.(m[:opex_var][stor, t_inv]) ≈ 0 for t_inv ∈ 𝒯ᴵⁿᵛ, atol = TEST_ATOL
+        )
     end
 
     @testset "SimpleTimes with storage" begin
@@ -1701,7 +1686,7 @@ end
 
         # Test that variable OPEX is correctly calculated
         # - function constraints_opex_var(m, n::Storage, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
-        @test sum(
+        @test all(
             value.(m[:opex_var][stor, t_inv]) ≈ sum(
                 EMB.opex_var(EMB.charge(stor), t_inv) *
                 (
@@ -1709,8 +1694,8 @@ end
                     value.(m[:emissions_node][stor, t, CO2])
                 ) *
                 duration(t) for t ∈ t_inv
-            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯ᴵⁿᵛ) atol = TEST_ATOL
+            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol = TEST_ATOL
+        )
 
         # All the tests following are for the function, its individual methods, and the
         # called functions within the function.
@@ -1724,27 +1709,27 @@ end
         #     modeltype,
         # )
         # Test that the level balance is correct for standard periods (6 times)
-        @test sum(
-            sum(
+        @test all(
+            all(
                 value.(m[:stor_level][stor, t]) ≈
                 value.(m[:stor_level][stor, t_prev]) +
                 (
                     value.(m[:flow_in][stor, t, CO2]) -
                     value.(m[:emissions_node][stor, t, CO2])
                 ) * duration(t) for (t_prev, t) ∈ withprev(t_inv) if !isnothing(t_prev)
-            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
-        ) ≈ length(𝒯) - 2 atol = TEST_ATOL
+            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol = TEST_ATOL
+        )
 
         # Test that the level balance is correct in the first period (2 times)
-        @test sum(
-            sum(
+        @test all(
+            all(
                 value.(m[:stor_level][stor, t]) ≈
                 (
                     value.(m[:flow_in][stor, t, CO2]) -
                     value.(m[:emissions_node][stor, t, CO2])
                 ) * duration(t) for (t_prev, t) ∈ withprev(t_inv) if isnothing(t_prev)
-            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
-        ) ≈ 2 atol = TEST_ATOL
+            ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol = TEST_ATOL
+        )
     end
 
     @testset "RepresentativePeriods with storage" begin
@@ -1808,7 +1793,7 @@ end
             value.(m[:stor_level][stor, t]) ≈
             value.(m[:stor_level][stor, t_prev]) +
             value.(m[:stor_level_Δ_op][stor, t]) * duration(t) for
-            (t_prev, t) ∈ withprev(𝒯), atol ∈ TEST_ATOL if !isnothing(t_prev)
+            (t_prev, t) ∈ withprev(𝒯), atol = TEST_ATOL if !isnothing(t_prev)
         ) ≈ length(𝒯) - length(𝒯ᴵⁿᵛ) * ops.len atol = TEST_ATOL
     end
 end


### PR DESCRIPTION
This PR allows the default nodal checks to be reused by the different other packages. It simplifies the approach as it is not longer necessary to copy paste the standard checks.

In addition, checks and tests were changed from `sum() == length()` to `all()`.