### PR TITLE
Introduced a case type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # Release notes
 
+## Unversioned
+
+### Major rework of input data structure
+
+* Set links and nodes as subtype of a new `AbstractElement` type.
+* Moved from a dictionary to a type called `Case`.
+* The type allows extensions without having to create a new `create_model` function, and hence, run in potential problems with several extensions packages.
+
+### Minor updates
+
+* Allow for checks for links.
+
 ## Version 0.8.3 (2024-11-29)
 
 ### Reference checks possible to be called

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -56,6 +56,7 @@ makedocs(
             "Availability"=>"nodes/availability.md",
         ],
         "How to" => Any[
+            "Create a new element"=>"how-to/create_new_element.md",
             "Create a new node"=>"how-to/create-new-node.md",
             "Utilize TimeStruct"=>"how-to/utilize-timestruct.md",
             "Update models"=>"how-to/update-models.md",
@@ -67,6 +68,7 @@ makedocs(
                 "Modeltype and Data"=>"library/public/model_data.md",
                 "Nodes"=>"library/public/nodes.md",
                 "Links"=>"library/public/links.md",
+                "Case"=>"library/public/case_element.md",
                 "Functions"=>"library/public/functions.md",
                 "Miscellaneous"=>"library/public/misc.md",
                 "EMI extension"=>"library/public/emi_extension.md",

--- a/docs/src/how-to/create_new_element.md
+++ b/docs/src/how-to/create_new_element.md
@@ -1,0 +1,57 @@
+# [Create a new element](@id how_to-create_element)
+
+```@meta
+CurrentModule = EMB
+```
+
+## [Idea behind elements](@id how_to-create_element-idea)
+
+`EnergyModelsBase` allows incorporating new elements.
+These elements can have distinctive variables and constraints that are not inherited from the [`Link`](@ref) or [`Node`](@ref) types.
+It is generally preferred to instead create a new link or node (as outlined on *[how to create a new node](@ref how_to-create_node)*).
+
+## [Requirements](@id how_to-create_element-requirements)
+
+It is necessary to be aware of the following limitations when you create a new subtype for `AbstractElement`.
+
+Consider the case of a new abstract type
+
+```julia
+abstract type NewElement <: AbstractElement
+```
+
+You have to be aware of the following requirements.
+
+1. A vector of the new subtype must be added to the field **`elements`** in addition to `Node` and `Link` vector in order to include new variables and constraints in a case description.
+2. A majority of the included functions return as default nothing, when you do not specify a methods for your new `Vector{<:NewElement}`.
+   The different functions for variable creation are:
+
+   - [`variables_capacity`](@ref) for providing variables for capacity utilization and installed capacity,
+   - [`variables_flow`](@ref) for providing inflow and outflow variables,
+   - [`variables_opex`](@ref) for providing operating expenses variables,
+   - [`variables_capex`](@ref) for providing capital expenditure variables,
+   - [`variables_emission`](@ref) for providing emission variables, and
+   - [`variables_elements`](@ref) and for providing subtype specific variables.
+
+   The different functions for constraint creation are:
+
+   - [`constraints_elements`](@ref) for providing the constraints for `Vector{<:NewElement}`,
+   - [`emissions_operational`](@ref) for providing the contribution to the emissions,
+   - [`objective_operational`](@ref) for providing the contribution to the operational costs, and
+   - [`objective_invest`](@ref) for providing the contribution to the cost function for investments.
+
+   In addition, we provide a check function:
+
+   - [`check_elements`](@ref) to iterate throught the `Vector{<:NewElement}`.
+
+3. If you plan to introduce coupling constraints between the `NewElement` and other `AbstractElement`s, you must create a new method for [`constraints_couple`](@ref) and supply a function for extracting the element from the case instance.
+   The latter can be inspired by [`f_nodes`](@ref) and [`f_links`](@ref).
+
+   !!! danger "Couplings with existing elements"
+       Coupling a new element with existing elements is highly dangereous.
+       A major problem is that you can create additional constraints that result in the problem being unfeasible.
+
+       As an example, consider the function `constraints_couple` for nodes and links.
+       In this function, we incorporate the coupling between the different links and nodes.
+       In practice, a link can only have a single input and output, while a node can be connected to an arbirtrary number of links.
+       If you now want to include a new element coupled to a `Node` *via* the flow variables, it is necessary that you only allow these couplings with a novel introduced node, in which the internal energy balance is adjusted to account for the new coupling.

--- a/docs/src/how-to/create_new_element.md
+++ b/docs/src/how-to/create_new_element.md
@@ -8,7 +8,11 @@ CurrentModule = EMB
 
 `EnergyModelsBase` allows incorporating new elements.
 These elements can have distinctive variables and constraints that are not inherited from the [`Link`](@ref) or [`Node`](@ref) types.
-It is generally preferred to instead create a new link or node (as outlined on *[how to create a new node](@ref how_to-create_node)*).
+
+!!! warning "Introducing new Elements"
+   Creating new elements should only be considered in cases where the functionality of [`Link`](@ref) or [`Node`](@ref) types is not sufficient for representing new concepts.
+   It is generally preferred to instead create a new link or node (as outlined on *[how to create a new node](@ref how_to-create_node)*).
+   This approach is simpler and is less error prone
 
 ## [Requirements](@id how_to-create_element-requirements)
 
@@ -23,7 +27,7 @@ abstract type NewElement <: AbstractElement
 You have to be aware of the following requirements.
 
 1. A vector of the new subtype must be added to the field **`elements`** in addition to `Node` and `Link` vector in order to include new variables and constraints in a case description.
-2. A majority of the included functions return as default nothing, when you do not specify a methods for your new `Vector{<:NewElement}`.
+2. You **must** specify new methods for your new `Vector{<:NewElement}` for a lot of different functions that are called within the core functionality of `EnergyModelsBase`.
    The different functions for variable creation are:
 
    - [`variables_capacity`](@ref) for providing variables for capacity utilization and installed capacity,
@@ -32,6 +36,16 @@ You have to be aware of the following requirements.
    - [`variables_capex`](@ref) for providing capital expenditure variables,
    - [`variables_emission`](@ref) for providing emission variables, and
    - [`variables_elements`](@ref) and for providing subtype specific variables.
+
+   All functions have the following input arguments:
+
+   - `m` is the `JuMP.Model` instance,
+   - `elements::Vector{<:NewElement}` is the vector for your `NewElement`s included in the model,
+   - `𝒳::Vector{Vector}` is a vector of all elements vector, required in certain instances to access other elements,
+   - `𝒯::TimeStructure` is the time structure used in the model run, and
+   - `modeltype` is the [`EneryModel`](@ref EnergyModelsBase.EnergyModel) instance.
+
+   The function [`variables_emission`](@ref) requires as additional input the vector of all resources `𝒫`.
 
    The different functions for constraint creation are:
 
@@ -43,6 +57,9 @@ You have to be aware of the following requirements.
    In addition, we provide a check function:
 
    - [`check_elements`](@ref) to iterate throught the `Vector{<:NewElement}`.
+
+   This function has a fallback solution if you do not specify a new method.
+   It is the only exception as it is not necessary to implement checks.
 
 3. If you plan to introduce coupling constraints between the `NewElement` and other `AbstractElement`s, you must create a new method for [`constraints_couple`](@ref) and supply a function for extracting the element from the case instance.
    The latter can be inspired by [`f_nodes`](@ref) and [`f_links`](@ref).

--- a/docs/src/how-to/create_new_element.md
+++ b/docs/src/how-to/create_new_element.md
@@ -62,7 +62,7 @@ You have to be aware of the following requirements.
    It is the only exception as it is not necessary to implement checks.
 
 3. If you plan to introduce coupling constraints between the `NewElement` and other `AbstractElement`s, you must create a new method for [`constraints_couple`](@ref) and supply a function for extracting the element from the case instance.
-   The latter can be inspired by [`f_nodes`](@ref) and [`f_links`](@ref).
+   The latter can be inspired by [`get_nodes`](@ref) and [`get_links`](@ref).
 
    !!! danger "Couplings with existing elements"
        Coupling a new element with existing elements is highly dangereous.

--- a/docs/src/how-to/create_new_element.md
+++ b/docs/src/how-to/create_new_element.md
@@ -8,6 +8,9 @@ CurrentModule = EMB
 
 `EnergyModelsBase` allows incorporating new elements.
 These elements can have distinctive variables and constraints that are not inherited from the [`Link`](@ref) or [`Node`](@ref) types.
+New  elements can be coupled to the existing elements through the introduction of so-called *coupling constraints*.
+An example for coupling constraints is provided by [`constraints_couple`](@ref) in which we include the coupling between nodes and links.
+In this case, the flow into a [`Node`](@ref) corresponds to the sum of all flows from the connected [`Link`](@ref)s while the flow from a [`Node`](@ref) corresponds to the flow into the connected [`Link`](@ref)s.
 
 !!! warning "Introducing new Elements"
    Creating new elements should only be considered in cases where the functionality of [`Link`](@ref) or [`Node`](@ref) types is not sufficient for representing new concepts.

--- a/docs/src/how-to/create_new_element.md
+++ b/docs/src/how-to/create_new_element.md
@@ -41,7 +41,7 @@ You have to be aware of the following requirements.
 
    - `m` is the `JuMP.Model` instance,
    - `elements::Vector{<:NewElement}` is the vector for your `NewElement`s included in the model,
-   - `𝒳::Vector{Vector}` is a vector of all elements vector, required in certain instances to access other elements,
+   - `𝒳ᵛᵉᶜ::Vector{Vector}` is a vector of all elements vector, required in certain instances to access other elements,
    - `𝒯::TimeStructure` is the time structure used in the model run, and
    - `modeltype` is the [`EneryModel`](@ref EnergyModelsBase.EnergyModel) instance.
 

--- a/docs/src/how-to/update-models.md
+++ b/docs/src/how-to/update-models.md
@@ -21,7 +21,7 @@ case = Dict(
 )
 
 # New structure:
-case = Case(T, products, [nodes, links], [[f_nodes, f_links]]) # or
+case = Case(T, products, [nodes, links], [[get_nodes, get_links]]) # or
 case = Case(T, products, [nodes, links])
 ```
 

--- a/docs/src/how-to/update-models.md
+++ b/docs/src/how-to/update-models.md
@@ -5,7 +5,27 @@ Hence, there are frequently breaking changes occuring, although we plan to keep 
 This document is designed to provide users with information regarding how they have to adjust their models to keep compatibility to the latest changes.
 We will as well implement information regarding the adjustment of extension packages, although this is more difficult due to the vast majority of potential changes.
 
-## [Adjustments from 0.6.x](@id how_to-update-06)
+## [Adjustments from 0.8.x](@id how_to-update-08)
+
+Starting from version 0.9.0, we introduced a new input format to the function `create_model`.
+The original case dictionary is replaced with a new type, [`Case`](@ref).
+We introduced deprecated methods that can be utilized with the original dictionary, but it is advisable to switch to the new type as:
+
+```julia
+# Old structure:
+case = Dict(
+    :nodes => nodes,
+    :links => links,
+    :products => products,
+    :T => T,
+)
+
+# New structure:
+case = Case(T, products, [nodes, links], [[f_nodes, f_links]]) # or
+case = Case(T, products, [nodes, links])
+```
+
+## [Adjustments from 0.6.x to 0.8.x](@id how_to-update-06)
 
 ### [Key changes for nodal descriptions](@id how_to-update-06-nodes)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -59,6 +59,7 @@ Depth = 1
 
 ```@contents
 Pages = [
+    "how-to/create_new_element.md",
     "how-to/create-new-node.md",
     "how-to/utilize-timestruct.md",
     "how-to/update-models.md",
@@ -77,6 +78,7 @@ Pages = [
     "library/public/model_data.md",
     "library/public/nodes.md",
     "library/public/links.md",
+    "library/public/case_element.md",
     "library/public/functions.md",
     "library/public/misc.md",
     "library/public/emi_extension.md",

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -23,8 +23,8 @@ emissions_operational
 
 ```@docs
 constraints_emissions
-constraints_links
-constraints_node
+constraints_elements
+constraints_couple
 constraints_level_iterate
 constraints_level_rp
 constraints_level_scp
@@ -37,7 +37,7 @@ constraints_level_bounds
 variables_capacity
 variables_flow
 variables_opex
-variables_capex(m, 𝒩::Vector{<:Node}, 𝒯, modeltype::EnergyModel)
+variables_capex(m, _, 𝒳, 𝒯, modeltype::EnergyModel)
 variables_emission
 variables_elements
 ```
@@ -48,10 +48,13 @@ variables_elements
 check_data
 check_case_data
 check_model
+check_elements
 check_node
+check_link
 check_node_default
-check_fixed_opex
 check_node_data(n::Node, data::EmissionsData, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+check_link_data(n::Link, data::Data, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+check_fixed_opex
 check_time_structure
 check_profile
 check_strategic_profile

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -14,7 +14,7 @@ CurrentModule = EnergyModelsBase
 
 ```@docs
 create_link
-objective(m, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
+objective(m, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
 objective_operational
 emissions_operational
 ```
@@ -37,7 +37,7 @@ constraints_level_bounds
 variables_capacity
 variables_flow
 variables_opex
-variables_capex(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
+variables_capex(m, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
 variables_emission
 variables_elements
 ```

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -13,7 +13,9 @@ CurrentModule = EnergyModelsBase
 ## [Extension functions](@id lib-int-fun-ext)
 
 ```@docs
+create_element
 create_link
+variables_element
 objective(m, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
 objective_operational
 emissions_operational

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -37,7 +37,7 @@ constraints_level_bounds
 variables_capacity
 variables_flow
 variables_opex
-variables_capex(m, _, 𝒳, 𝒯, modeltype::EnergyModel)
+variables_capex(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
 variables_emission
 variables_elements
 ```

--- a/docs/src/library/internals/reference_EMIExt.md
+++ b/docs/src/library/internals/reference_EMIExt.md
@@ -32,7 +32,7 @@ check_inv_data
 ### [Methods](@id lib-int-EMIext-met)
 
 ```@docs
-EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
+EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::AbstractInvestmentModel)
 EMB.objective_invest(m, 𝒩::Vector{<:EMB.Node}, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, modeltype::AbstractInvestmentModel)
 EMB.constraints_capacity_installed(m, n::EMB.Node, 𝒯::TimeStructure, modeltype::AbstractInvestmentModel)
 EMB.check_node_data(n::EMB.Node, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel, check_timeprofiles::Bool)

--- a/docs/src/library/internals/reference_EMIExt.md
+++ b/docs/src/library/internals/reference_EMIExt.md
@@ -25,7 +25,6 @@ StorageInvData
 
 ```@docs
 check_inv_data
-objective_invest
 ```
 
 ## [EnergyModelsBase](@id lib-int-EMIext-EMB)
@@ -33,10 +32,11 @@ objective_invest
 ### [Methods](@id lib-int-EMIext-met)
 
 ```@docs
-EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒯, modeltype::AbstractInvestmentModel)
-EMB.objective(m, 𝒳, 𝒫, 𝒯, modeltype::AbstractInvestmentModel)
+EMB.variables_capex(m, _::Vector{<:AbstractElement}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
+EMB.objective_invest(m, 𝒩::Vector{<:EMB.Node}, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, modeltype::AbstractInvestmentModel)
 EMB.constraints_capacity_installed(m, n::EMB.Node, 𝒯::TimeStructure, modeltype::AbstractInvestmentModel)
 EMB.check_node_data(n::EMB.Node, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel, check_timeprofiles::Bool)
+EMB.check_link_data(l::Link, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel, check_timeprofiles::Bool)
 ```
 
 ## [EnergyModelsInvestments](@id lib-int-EMIext-EMI)

--- a/docs/src/library/internals/reference_EMIExt.md
+++ b/docs/src/library/internals/reference_EMIExt.md
@@ -32,7 +32,7 @@ check_inv_data
 ### [Methods](@id lib-int-EMIext-met)
 
 ```@docs
-EMB.variables_capex(m, _::Vector{<:AbstractElement}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
+EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
 EMB.objective_invest(m, 𝒩::Vector{<:EMB.Node}, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, modeltype::AbstractInvestmentModel)
 EMB.constraints_capacity_installed(m, n::EMB.Node, 𝒯::TimeStructure, modeltype::AbstractInvestmentModel)
 EMB.check_node_data(n::EMB.Node, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel, check_timeprofiles::Bool)

--- a/docs/src/library/public/case_element.md
+++ b/docs/src/library/public/case_element.md
@@ -49,6 +49,7 @@ The fields of the case dictionary correspond to:
    The couplings include connections between two distinctive `AbstractElement` types.
    Coupling implies in this context that two `AbstractElement` type, *i.e.*, [`Link`](@ref) and [`Node`](@ref EnergyModelsBase.Node) have common constraints.
    `EnergyModelsBase` provides as potential functions [`get_nodes`](@ref) and [`get_links`](@ref) in the coupling.
+   In this case, the Vector would be given as `[[get_nodes, get_links]]`.
 
 ```@docs
 AbstractCase

--- a/docs/src/library/public/case_element.md
+++ b/docs/src/library/public/case_element.md
@@ -48,7 +48,7 @@ The fields of the case dictionary correspond to:
 4. **`couplings::Vector{Vector{Function}}`** is a vector of vector of functions.
    The couplings include connections between two distinctive `AbstractElement` types.
    Coupling implies in this context that two `AbstractElement` type, *i.e.*, [`Link`](@ref) and [`Node`](@ref EnergyModelsBase.Node) have common constraints.
-   `EnergyModelsBase` provides as potential functions [`f_nodes`](@ref) and [`f_links`](@ref) in the coupling.
+   `EnergyModelsBase` provides as potential functions [`get_nodes`](@ref) and [`get_links`](@ref) in the coupling.
 
 ```@docs
 AbstractCase
@@ -58,10 +58,10 @@ Case
 ## [Functions for accessing different information](@id lib-pub-links-fun_field)
 
 ```@docs
-f_time_struct
-f_products
-f_elements_vec
-f_couplings
-f_nodes
-f_links
+get_time_struct
+get_products
+get_elements_vec
+get_couplings
+get_nodes
+get_links
 ```

--- a/docs/src/library/public/case_element.md
+++ b/docs/src/library/public/case_element.md
@@ -36,7 +36,7 @@ The fields of the case dictionary correspond to:
    However, storage balances may violate the upper and lower bound when the time structure includes [`OperationalScenarios](@extref TimeStruct.OperationalScenarios).
    In general, it is preferable to utilize either a [`TwoLevel`](@extref TimeStruct.TwoLevel) or [`TwoLevelTree`](@extref TimeStruct.TwoLevelTree) to properly calculate the operational costs and the emissions.
 2. **`products::Vector{<:Resource}`** is a vector of all considered *[resources](@ref lib-pub-res)* in the analysis.
-   In theory, it is not necessary that this vector includes all resources, although it must include all insatnces of [`ResourceEmit`](@ref).
+   In theory, it is not necessary that this vector includes all resources, although it must include all instances of [`ResourceEmit`](@ref).
 3. **`elements::Vector{Vector}`** is a vector of the vectors of [`AbstractElement`](@ref)s of the analysis, as described above.
    This `Vector{Vector}` can be extended with additional types for which variables and constraints should be introduced.
 
@@ -51,7 +51,8 @@ The fields of the case dictionary correspond to:
    `EnergyModelsBase` provides as potential functions [`f_nodes`](@ref) and [`f_links`](@ref) in the coupling.
 
 ```@docs
-EMXCase
+AbstractCase
+Case
 ```
 
 ## [Functions for accessing different information](@id lib-pub-links-fun_field)

--- a/docs/src/library/public/case_element.md
+++ b/docs/src/library/public/case_element.md
@@ -1,0 +1,66 @@
+# [Case description](@id lib-pub-case)
+
+`EnergyModelsBase` data is included in a case.
+The case was previously declared as a dictionary, but is moved from Version 0.10 to a type for improved flexibility.
+The following page explains the concepts of the case type.
+
+## Index
+
+```@index
+Pages = ["case_element.md"]
+```
+
+## [Elements](@id lib-pub-case-element)
+
+All types in `EnergyModelsBase` that require mathemeatical constraints are considered as elements.
+Elements allow for the incorporations of mathematical constraints.
+`EnergyModelsBase` includes two types of `AbstractElement`s, *[nodes](@ref lib-pub-nodes)* and *[links](@ref lib-pub-links)*.
+`Node`s convert, store, supply or demand resources.
+They do not possess any direct connections.
+The connections are incorporated through `Link`s which transport resources between different nodes.
+
+```@docs
+AbstractElement
+```
+
+## [Case type](@id lib-pub-case-case)
+
+The case type is used as input to `EnergyModelsBase` models.
+It contains all information for building a model using the [`create_model`](@ref) function.
+
+The fields of the case dictionary correspond to:
+
+1. **`T::TimeStructure`** is the time structure for which the model should be constructed.
+   Time structures are created using the the [`TimeStruct`](https://sintefore.github.io/TimeStruct.jl/stable/) package.
+   `EnergyModelsBase` supports all time structures included in `TimeStruct`.
+   However, storage balances may violate the upper and lower bound when the time structure includes [`OperationalScenarios](@extref TimeStruct.OperationalScenarios).
+   In general, it is preferable to utilize either a [`TwoLevel`](@extref TimeStruct.TwoLevel) or [`TwoLevelTree`](@extref TimeStruct.TwoLevelTree) to properly calculate the operational costs and the emissions.
+2. **`products::Vector{<:Resource}`** is a vector of all considered *[resources](@ref lib-pub-res)* in the analysis.
+   In theory, it is not necessary that this vector includes all resources, although it must include all insatnces of [`ResourceEmit`](@ref).
+3. **`elements::Vector{Vector}`** is a vector of the vectors of [`AbstractElement`](@ref)s of the analysis, as described above.
+   This `Vector{Vector}` can be extended with additional types for which variables and constraints should be introduced.
+
+   !!! note "Type requirement"
+       The elements must be provided as `elements::Vector{Vector}`.
+       This implies that if you only want to include a single [`AbstractElement`](@ref), *e.g.*, only a `Vector{<:Node}`, you **must** add an additional empty vector of an `AbstractElement`, *e.g.*, `Link`
+       Otherwise, it is not possible to create a case.
+
+4. **`couplings::Vector{Vector{Function}}`** is a vector of vector of functions.
+   The couplings include connections between two distinctive `AbstractElement` types.
+   Coupling implies in this context that two `AbstractElement` type, *i.e.*, [`Link`](@ref) and [`Node`](@ref EnergyModelsBase.Node) have common constraints.
+   `EnergyModelsBase` provides as potential functions [`f_nodes`](@ref) and [`f_links`](@ref) in the coupling.
+
+```@docs
+EMXCase
+```
+
+## [Functions for accessing different information](@id lib-pub-links-fun_field)
+
+```@docs
+f_time_struct
+f_products
+f_elements_vec
+f_couplings
+f_nodes
+f_links
+```

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -134,7 +134,7 @@ function generate_example_network()
     ]
 
     # Input data structure
-    case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
+    case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
     return case, model
 end
 

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -133,13 +133,8 @@ function generate_example_network()
         Direct("CO2_stor-av", nodes[6], nodes[1], Linear())
     ]
 
-    # WIP data structure
-    case = Dict(
-        :nodes => nodes,
-        :links => links,
-        :products => products,
-        :T => T,
-    )
+    # Input data structure
+    case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
     return case, model
 end
 
@@ -149,7 +144,7 @@ optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
 m = run_model(case, model, optimizer)
 
 # Display some results
-ng_ccs_pp, coal_pp, = case[:nodes][[4, 5]]
+ng_ccs_pp, coal_pp, = f_nodes(case)[[4, 5]]
 @info "Capacity usage of the coal power plant"
 pretty_table(
     JuMP.Containers.rowtable(

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -134,7 +134,7 @@ function generate_example_network()
     ]
 
     # Input data structure
-    case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     return case, model
 end
 
@@ -144,7 +144,7 @@ optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
 m = run_model(case, model, optimizer)
 
 # Display some results
-ng_ccs_pp, coal_pp, = f_nodes(case)[[4, 5]]
+ng_ccs_pp, coal_pp, = get_nodes(case)[[4, 5]]
 @info "Capacity usage of the coal power plant"
 pretty_table(
     JuMP.Containers.rowtable(

--- a/examples/network_invest.jl
+++ b/examples/network_invest.jl
@@ -160,7 +160,7 @@ function generate_example_network_investment()
     ]
 
     # Input data structure
-    case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
+    case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
     return case, model
 end
 

--- a/examples/network_invest.jl
+++ b/examples/network_invest.jl
@@ -159,13 +159,8 @@ function generate_example_network_investment()
         Direct("CO2_stor-av", nodes[6], nodes[1], Linear())
     ]
 
-    # WIP data structure
-    case = Dict(
-        :nodes => nodes,
-        :links => links,
-        :products => products,
-        :T => T,
-    )
+    # Input data structure
+    case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
     return case, model
 end
 
@@ -175,7 +170,7 @@ optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
 m = run_model(case, model, optimizer)
 
 # Display some results
-ng_ccs_pp, CO2_stor, = case[:nodes][[4, 6]]
+ng_ccs_pp, CO2_stor, = f_nodes(case)[[4, 6]]
 @info "Invested capacity for the natural gas plant in the beginning of the \
 individual strategic periods"
 pretty_table(

--- a/examples/network_invest.jl
+++ b/examples/network_invest.jl
@@ -160,7 +160,7 @@ function generate_example_network_investment()
     ]
 
     # Input data structure
-    case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     return case, model
 end
 
@@ -170,7 +170,7 @@ optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
 m = run_model(case, model, optimizer)
 
 # Display some results
-ng_ccs_pp, CO2_stor, = f_nodes(case)[[4, 6]]
+ng_ccs_pp, CO2_stor, = get_nodes(case)[[4, 6]]
 @info "Invested capacity for the natural gas plant in the beginning of the \
 individual strategic periods"
 pretty_table(

--- a/examples/sink_source.jl
+++ b/examples/sink_source.jl
@@ -71,7 +71,7 @@ function generate_example_ss()
     ]
 
     # Input data structure
-    case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     return case, model
 end
 
@@ -81,7 +81,7 @@ optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
 m = run_model(case, model, optimizer)
 
 # Display some results
-source, sink = f_nodes(case)
+source, sink = get_nodes(case)
 @info "Capacity usage of the power source"
 pretty_table(
     JuMP.Containers.rowtable(

--- a/examples/sink_source.jl
+++ b/examples/sink_source.jl
@@ -70,13 +70,8 @@ function generate_example_ss()
         Direct("source-demand", nodes[1], nodes[2], Linear()),
     ]
 
-    # WIP data structure
-    case = Dict(
-        :nodes => nodes,
-        :links => links,
-        :products => products,
-        :T => T,
-    )
+    # Input data structure
+    case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
     return case, model
 end
 
@@ -86,7 +81,7 @@ optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
 m = run_model(case, model, optimizer)
 
 # Display some results
-source, sink = case[:nodes]
+source, sink = f_nodes(case)
 @info "Capacity usage of the power source"
 pretty_table(
     JuMP.Containers.rowtable(

--- a/examples/sink_source.jl
+++ b/examples/sink_source.jl
@@ -71,7 +71,7 @@ function generate_example_ss()
     ]
 
     # Input data structure
-    case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
+    case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
     return case, model
 end
 

--- a/examples/sink_source_invest.jl
+++ b/examples/sink_source_invest.jl
@@ -94,13 +94,8 @@ function generate_example_ss_investment(lifemode = RollingLife; discount_rate = 
         Direct("source-demand", nodes[1], nodes[2], Linear()),
     ]
 
-    # WIP data structure
-    case = Dict(
-        :nodes => nodes,
-        :links => links,
-        :products => products,
-        :T => T,
-    )
+    # Input data structure
+    case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
     return case, model
 end
 
@@ -110,7 +105,7 @@ optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
 m = run_model(case, model, optimizer)
 
 # Display some results
-source, sink = case[:nodes]
+source, sink = f_nodes(case)
 @info "Invested capacity for the source in the beginning of the individual strategic periods"
 pretty_table(
     JuMP.Containers.rowtable(

--- a/examples/sink_source_invest.jl
+++ b/examples/sink_source_invest.jl
@@ -95,7 +95,7 @@ function generate_example_ss_investment(lifemode = RollingLife; discount_rate = 
     ]
 
     # Input data structure
-    case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     return case, model
 end
 
@@ -105,7 +105,7 @@ optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
 m = run_model(case, model, optimizer)
 
 # Display some results
-source, sink = f_nodes(case)
+source, sink = get_nodes(case)
 @info "Invested capacity for the source in the beginning of the individual strategic periods"
 pretty_table(
     JuMP.Containers.rowtable(

--- a/examples/sink_source_invest.jl
+++ b/examples/sink_source_invest.jl
@@ -95,7 +95,7 @@ function generate_example_ss_investment(lifemode = RollingLife; discount_rate = 
     ]
 
     # Input data structure
-    case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
+    case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
     return case, model
 end
 

--- a/ext/EMIExt/checks.jl
+++ b/ext/EMIExt/checks.jl
@@ -174,3 +174,29 @@ function check_inv_data(
         )
     end
 end
+
+"""
+    EMB.check_link_data(l::Link, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel, check_timeprofiles::Bool)
+
+Performs various checks on investment data for [`Link`](@ref)s.
+
+## Checks for standard nodes
+- Each link can only have a single `InvestmentData`.
+- All checks incorporated in the function [`check_inv_data`](@ref).
+"""
+function EMB.check_link_data(
+    l::Link,
+    data::InvestmentData,
+    𝒯,
+    modeltype::AbstractInvestmentModel,
+    check_timeprofiles::Bool,
+)
+    inv_data = filter(data -> typeof(data) <: InvestmentData, link_data(l))
+
+    @assert_or_log(
+        length(inv_data) ≤ 1,
+        "Only one `InvestmentData` can be added to each node."
+    )
+
+    check_inv_data(EMI.investment_data(data), EMB.capacity(l), 𝒯, "", check_timeprofiles)
+end

--- a/ext/EMIExt/objective.jl
+++ b/ext/EMIExt/objective.jl
@@ -1,5 +1,5 @@
 """
-    EMB.objective(m, 𝒳, 𝒫, 𝒯, modeltype::AbstractInvestmentModel)
+    EMB.objective(m, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::AbstractInvestmentModel)
 
 Create objective function overloading the default from EMB for `AbstractInvestmentModel`.
 
@@ -14,7 +14,7 @@ These variables would need to be introduced through the package `SparsVariables`
 Both are not necessary, as it is possible to include them through the OPEX values, but it
 would be beneficial for a better separation and simpler calculations from the results.
 """
-function EMB.objective(m, 𝒳, 𝒫, 𝒯, modeltype::AbstractInvestmentModel)
+function EMB.objective(m, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::AbstractInvestmentModel)
 
     # Extraction of the individual subtypes for investments in nodes
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
@@ -25,9 +25,9 @@ function EMB.objective(m, 𝒳, 𝒫, 𝒯, modeltype::AbstractInvestmentModel)
     # Calculation of the OPEX and CAPEX contributions
     opex = JuMP.Containers.DenseAxisArray[]
     capex = JuMP.Containers.DenseAxisArray[]
-    for elements ∈ 𝒳
-        push!(opex, EMB.objective_operational(m, elements, 𝒯ᴵⁿᵛ, modeltype))
-        push!(capex, EMB.objective_invest(m, elements, 𝒯ᴵⁿᵛ, modeltype))
+    for 𝒳 ∈ 𝒳ᵛᵉᶜ
+        push!(opex, EMB.objective_operational(m, 𝒳, 𝒯ᴵⁿᵛ, modeltype))
+        push!(capex, EMB.objective_invest(m, 𝒳, 𝒯ᴵⁿᵛ, modeltype))
     end
     push!(opex, EMB.objective_operational(m, 𝒫, 𝒯ᴵⁿᵛ,modeltype))
 
@@ -42,23 +42,23 @@ function EMB.objective(m, 𝒳, 𝒫, 𝒯, modeltype::AbstractInvestmentModel)
     )
 end
 """
-    EMB.objective_invest(m, elements, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, modeltype::EnergyModel)
+    EMB.objective_invest(m, 𝒳, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, modeltype::EnergyModel)
 
 Create JuMP expressions indexed over the investment periods `𝒯ᴵⁿᵛ` for different elements.
 The expressions correspond to the investments into the different elements. They are not
 discounted and do not take the duration of the investment periods into account.
 
 By default, objective expressions are included for:
-- `elements = 𝒩::Vector{<:Node}`. In the case of a vector of nodes, the function returns the
+- `𝒳 = 𝒩::Vector{<:Node}`. In the case of a vector of nodes, the function returns the
   sum of the capital expenditures for all nodes whose method of the function
   [`has_investment`](@ref) returns true. In the case of [`Storage`](@ref) nodes, all capacity
   investments are considired
-- `elements = 𝒩::Vector{<:Link}`. In the case of a vector of links, the function returns the
+- `𝒳 = 𝒩::Vector{<:Link}`. In the case of a vector of links, the function returns the
   sum of the capital expenditures for all links whose method of the function
   [`has_investment`](@ref) returns true.
 
 !!! note "Default function"
-    It is also possible to provide a tuple `𝒳` for only operational or only investment
+    It is also possible to provide a tuple `𝒳ᵛᵉᶜ` for only operational or only investment
     objective contributions. In this situation, the expression returns a value of 0 for all
     investment periods.
 """

--- a/ext/EMIExt/objective.jl
+++ b/ext/EMIExt/objective.jl
@@ -27,7 +27,7 @@ function EMB.objective(m, 𝒳, 𝒫, 𝒯, modeltype::AbstractInvestmentModel)
     capex = JuMP.Containers.DenseAxisArray[]
     for elements ∈ 𝒳
         push!(opex, EMB.objective_operational(m, elements, 𝒯ᴵⁿᵛ, modeltype))
-        push!(capex, objective_invest(m, elements, 𝒯ᴵⁿᵛ, modeltype))
+        push!(capex, EMB.objective_invest(m, elements, 𝒯ᴵⁿᵛ, modeltype))
     end
     push!(opex, EMB.objective_operational(m, 𝒫, 𝒯ᴵⁿᵛ,modeltype))
 
@@ -42,7 +42,7 @@ function EMB.objective(m, 𝒳, 𝒫, 𝒯, modeltype::AbstractInvestmentModel)
     )
 end
 """
-    objective_invest(m, elements, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, modeltype::EnergyModel)
+    EMB.objective_invest(m, elements, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, modeltype::EnergyModel)
 
 Create JuMP expressions indexed over the investment periods `𝒯ᴵⁿᵛ` for different elements.
 The expressions correspond to the investments into the different elements. They are not
@@ -62,7 +62,7 @@ By default, objective expressions are included for:
     objective contributions. In this situation, the expression returns a value of 0 for all
     investment periods.
 """
-function objective_invest(
+function EMB.objective_invest(
     m,
     𝒩::Vector{<:EMB.Node},
     𝒯ᴵⁿᵛ::TS.AbstractStratPers,
@@ -82,7 +82,7 @@ function objective_invest(
         sum(m[:stor_discharge_capex][n, t_inv] for n ∈ 𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ)
     )
 end
-function objective_invest(
+function EMB.objective_invest(
     m,
     ℒ::Vector{<:Link},
     𝒯ᴵⁿᵛ::TS.AbstractStratPers,
@@ -95,5 +95,3 @@ function objective_invest(
         sum(m[:link_cap_capex][l, t_inv] for l ∈ ℒᴵⁿᵛ)
     )
 end
-objective_invest(m, _, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, _::AbstractInvestmentModel) =
-    @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ], 0)

--- a/ext/EMIExt/variables_capex.jl
+++ b/ext/EMIExt/variables_capex.jl
@@ -1,7 +1,7 @@
 """
-    EMB.variables_capex(m, _::Vector{<:AbstractElement}, 𝒯, modeltype::AbstractInvestmentModel)
-    EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒯, modeltype::AbstractInvestmentModel)
-    EMB.variables_capex(m, ℒ::Vector{<:Link}, 𝒯, modeltype::AbstractInvestmentModel)
+    EMB.variables_capex(m, _::Vector{<:AbstractElement}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
+    EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
+    EMB.variables_capex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
 
 Declaration of different capital expenditures (CAPEX) variables for the element types
 introduced in `EnergyModelsBase`. CAPEX variables are only introduced for elements that have
@@ -38,8 +38,8 @@ user with two individual methods for both `𝒩::Vector{<:EMB.Node}` and 𝒩::V
     - `**prefix**_remove_b` is an auxiliary variable used in some investment modes for the
       reduction of capacities.
 """
-function EMB.variables_capex(m, _::Vector{<:AbstractElement}, 𝒯, modeltype::AbstractInvestmentModel) end
-function EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒯, modeltype::AbstractInvestmentModel)
+function EMB.variables_capex(m, _::Vector{<:AbstractElement}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel) end
+function EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
     𝒩ᴵⁿᵛ = filter(has_investment, filter(!EMB.is_storage, 𝒩))
     𝒩ˢᵗᵒʳ = filter(EMB.is_storage, 𝒩)
     𝒩ˡᵉᵛᵉˡ = filter(n -> has_investment(n, :level), 𝒩ˢᵗᵒʳ)
@@ -85,7 +85,7 @@ function EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒯, modeltype::Abstr
         container = IndexedVarArray
     )
 end
-function EMB.variables_capex(m, ℒ::Vector{<:Link}, 𝒯, modeltype::AbstractInvestmentModel)
+function EMB.variables_capex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
     ℒᴵⁿᵛ = filter(has_investment, ℒ)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 

--- a/ext/EMIExt/variables_capex.jl
+++ b/ext/EMIExt/variables_capex.jl
@@ -1,5 +1,4 @@
 """
-    EMB.variables_capex(m, _::Vector{<:AbstractElement}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
     EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
     EMB.variables_capex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
 
@@ -38,7 +37,6 @@ user with two individual methods for both `𝒩::Vector{<:EMB.Node}` and 𝒩::V
     - `**prefix**_remove_b` is an auxiliary variable used in some investment modes for the
       reduction of capacities.
 """
-function EMB.variables_capex(m, _::Vector{<:AbstractElement}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel) end
 function EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
     𝒩ᴵⁿᵛ = filter(has_investment, filter(!EMB.is_storage, 𝒩))
     𝒩ˢᵗᵒʳ = filter(EMB.is_storage, 𝒩)

--- a/ext/EMIExt/variables_capex.jl
+++ b/ext/EMIExt/variables_capex.jl
@@ -1,4 +1,5 @@
 """
+    EMB.variables_capex(m, _::Vector{<:AbstractElement}, 𝒯, modeltype::AbstractInvestmentModel)
     EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒯, modeltype::AbstractInvestmentModel)
     EMB.variables_capex(m, ℒ::Vector{<:Link}, 𝒯, modeltype::AbstractInvestmentModel)
 
@@ -37,6 +38,7 @@ user with two individual methods for both `𝒩::Vector{<:EMB.Node}` and 𝒩::V
     - `**prefix**_remove_b` is an auxiliary variable used in some investment modes for the
       reduction of capacities.
 """
+function EMB.variables_capex(m, _::Vector{<:AbstractElement}, 𝒯, modeltype::AbstractInvestmentModel) end
 function EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒯, modeltype::AbstractInvestmentModel)
     𝒩ᴵⁿᵛ = filter(has_investment, filter(!EMB.is_storage, 𝒩))
     𝒩ˢᵗᵒʳ = filter(EMB.is_storage, 𝒩)

--- a/ext/EMIExt/variables_capex.jl
+++ b/ext/EMIExt/variables_capex.jl
@@ -1,6 +1,6 @@
 """
-    EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
-    EMB.variables_capex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
+    EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::AbstractInvestmentModel)
+    EMB.variables_capex(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::AbstractInvestmentModel)
 
 Declaration of different capital expenditures (CAPEX) variables for the element types
 introduced in `EnergyModelsBase`. CAPEX variables are only introduced for elements that have
@@ -37,7 +37,7 @@ user with two individual methods for both `𝒩::Vector{<:EMB.Node}` and 𝒩::V
     - `**prefix**_remove_b` is an auxiliary variable used in some investment modes for the
       reduction of capacities.
 """
-function EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
+function EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::AbstractInvestmentModel)
     𝒩ᴵⁿᵛ = filter(has_investment, filter(!EMB.is_storage, 𝒩))
     𝒩ˢᵗᵒʳ = filter(EMB.is_storage, 𝒩)
     𝒩ˡᵉᵛᵉˡ = filter(n -> has_investment(n, :level), 𝒩ˢᵗᵒʳ)
@@ -83,7 +83,7 @@ function EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳, 𝒯, modeltype:
         container = IndexedVarArray
     )
 end
-function EMB.variables_capex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
+function EMB.variables_capex(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::AbstractInvestmentModel)
     ℒᴵⁿᵛ = filter(has_investment, ℒ)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -23,6 +23,7 @@ include(joinpath("structures", "node.jl"))
 include(joinpath("structures", "link.jl"))
 include(joinpath("structures", "model.jl"))
 include(joinpath("structures", "misc.jl"))
+include(joinpath("structures", "case.jl"))
 
 include("utils.jl")
 include("model.jl")
@@ -33,9 +34,14 @@ include("data_functions.jl")
 # Legacy constructors for node types
 include("legacy_constructor.jl")
 
+# Export the case type and its functions
+export EMXCase
+export f_time_struct, f_products, f_elements_vec, f_nodes, f_links
+
 # Export the general classes
 export EnergyModel, OperationalModel
 export Resource, ResourceCarrier, ResourceEmit
+export AbstractElement
 
 # Export the different node types
 export Source, NetworkNode, Sink, Storage, Availability

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -35,7 +35,7 @@ include("data_functions.jl")
 include("legacy_constructor.jl")
 
 # Export the case type and its functions
-export EMXCase
+export AbstractCase, Case
 export f_time_struct, f_products, f_elements_vec, f_nodes, f_links, f_couplings
 
 # Export the general classes

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -36,7 +36,7 @@ include("legacy_constructor.jl")
 
 # Export the case type and its functions
 export AbstractCase, Case
-export f_time_struct, f_products, f_elements_vec, f_nodes, f_links, f_couplings
+export get_time_struct, get_products, get_elements_vec, get_nodes, get_links, get_couplings
 
 # Export the general classes
 export EnergyModel, OperationalModel

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -36,7 +36,7 @@ include("legacy_constructor.jl")
 
 # Export the case type and its functions
 export EMXCase
-export f_time_struct, f_products, f_elements_vec, f_nodes, f_links
+export f_time_struct, f_products, f_elements_vec, f_nodes, f_links, f_couplings
 
 # Export the general classes
 export EnergyModel, OperationalModel

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -4,8 +4,8 @@ Main module for `EnergyModelsBase` a framework for building flexible energy syst
 It exports several types and associated functions for accessing fields.
 In addition, all required functions for creaeting and running the model are exported.
 
-You can find the exported types and functions below or on the pages \
-*[Constraint functions](@ref man-con)* and \
+You can find the exported types and functions below or on the pages
+*[Constraint functions](@ref man-con)* and
 *[Data functions](@ref man-data_fun)*.
 """
 module EnergyModelsBase
@@ -16,6 +16,7 @@ using TimeStruct
 const TS = TimeStruct
 
 # Different introduced types
+include(joinpath("structures", "element.jl"))
 include(joinpath("structures", "resource.jl"))
 include(joinpath("structures", "data.jl"))
 include(joinpath("structures", "node.jl"))

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -68,8 +68,8 @@ function check_data(case, modeltype::EnergyModel, check_timeprofiles::Bool)
     end
 
     # Check the individual elements vector
-    𝒳ᵛᵉᶜ = f_elements_vec(case)
-    𝒯 = f_time_struct(case)
+    𝒳ᵛᵉᶜ = get_elements_vec(case)
+    𝒯 = get_time_struct(case)
     for elements ∈ 𝒳ᵛᵉᶜ
         check_elements(log_by_element, elements, case, 𝒯, modeltype, check_timeprofiles)
     end
@@ -131,7 +131,7 @@ Checks the `case` dictionary is in the correct format.
 - Check that the coupling functions do return elements and not only an empty vector
 """
 function check_case_data(case)
-    𝒳ᵛᵉᶜ = f_elements_vec(case)
+    𝒳ᵛᵉᶜ = get_elements_vec(case)
     get_vect_type(vec::Vector{T}) where {T} = T
     vec_types = [get_vect_type(x) for x ∈ 𝒳ᵛᵉᶜ]
 
@@ -146,7 +146,7 @@ function check_case_data(case)
         end
     end
 
-    𝒳ᵛᵉᶜ_𝒳ᵛᵉᶜ = f_couplings(case)
+    𝒳ᵛᵉᶜ_𝒳ᵛᵉᶜ = get_couplings(case)
     for couple ∈ 𝒳ᵛᵉᶜ_𝒳ᵛᵉᶜ
         for cpl ∈ couple
             @assert_or_log(
@@ -184,7 +184,7 @@ and Vector{<:Link}.
       are not equivalent to the provided timestructure.
 
     In addition, all links are directly checked to have in the fields `:from` and `:to` nodes
-    that are present in the Node vector as extracted through the function [`f_nodes`](@ref)
+    that are present in the Node vector as extracted through the function [`get_nodes`](@ref)
     and that these nodes have input (`:to`) or output (`:from`).
 """
 function check_elements(
@@ -232,7 +232,7 @@ function check_elements(
         global logs = []
 
         # Check the connections of the link
-        𝒩  = f_nodes(case)
+        𝒩  = get_nodes(case)
         @assert_or_log(
             l.from ∈ 𝒩,
             "The node in the field `:from` is not included in the Node vector. As a consequence," *
@@ -282,10 +282,10 @@ Checks the `modeltype` .
   periods.
 """
 function check_model(case, modeltype::EnergyModel, check_timeprofiles::Bool)
-    𝒯ᴵⁿᵛ = strategic_periods(f_time_struct(case))
+    𝒯ᴵⁿᵛ = strategic_periods(get_time_struct(case))
 
     # Check for inclusion of all emission resources
-    for p ∈ f_products(case)
+    for p ∈ get_products(case)
         if isa(p, ResourceEmit)
             @assert_or_log(
                 haskey(emission_limit(modeltype::EnergyModel), p),

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -159,9 +159,9 @@ function check_case_data(case)
 end
 
 """
-    check_elements(log_by_element, _::Vector{<:AbstractElement}, case::EMXCase, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
-    check_elements(log_by_element, 𝒩::Vector{<:Node}, case::EMXCase, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
-    check_elements(log_by_element, ℒ::Vector{<:Link}}, case::EMXCase, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_elements(log_by_element, _::Vector{<:AbstractElement}, case::Case, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_elements(log_by_element, 𝒩::Vector{<:Node}, case::Case, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_elements(log_by_element, ℒ::Vector{<:Link}}, case::Case, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
 Checks the individual elements vector. It has implemented methods for both `Vector{<:Node}`
 and Vector{<:Link}.
@@ -190,7 +190,7 @@ and Vector{<:Link}.
 function check_elements(
     log_by_element,
     _::Vector{<:AbstractElement},
-    case::EMXCase,
+    case::Case,
     𝒯,
     modeltype::EnergyModel,
     check_timeprofiles::Bool
@@ -199,7 +199,7 @@ end
 function check_elements(
     log_by_element,
     𝒩::Vector{<:Node},
-    case::EMXCase,
+    case::Case,
     𝒯,
     modeltype::EnergyModel,
     check_timeprofiles::Bool
@@ -222,7 +222,7 @@ end
 function check_elements(
     log_by_element,
     ℒ::Vector{<:Link},
-    case::EMXCase,
+    case::Case,
     𝒯,
     modeltype::EnergyModel,
     check_timeprofiles::Bool

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -166,10 +166,11 @@ end
 Checks the individual elements vector. It has implemented methods for both `Vector{<:Node}`
 and Vector{<:Link}.
 
+
 !!! note "Node methods"
     All nodes are checked through the functions
     - [`check_node`](@ref) to identify problematic input,
-    - [`check_node_data-Tuple{Node, Data, Any, EnergyModel, Bool}`](@ref) to identify
+    - [`check_node_data`](@ref EnergyModelsBase.check_node_data(n::Node, data::Data, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool))
       issues in the provided additional data, and
     - [`check_time_structure`](@ref) to identify time profiles at the highest level that
       are not equivalent to the provided timestructure.
@@ -177,8 +178,8 @@ and Vector{<:Link}.
 !!! note "Links methods"
     All links are checked through the functions
     - [`check_link`](@ref) to identify problematic input,
-    - [`check_link_data-Tuple{Link, Data, Any, EnergyModel, Bool}`](@ref) to identify
-      issues in the provided additional data, and
+    - [`check_link_data`](@ref EnergyModelsBase.check_link_data(l::Link, data::Data, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool))
+      to identify issues in the provided additional data, and
     - [`check_time_structure`](@ref) to identify time profiles at the highest level that
       are not equivalent to the provided timestructure.
 
@@ -943,9 +944,9 @@ functionality does not check anthing, aside from the checks performed in [`check
 check_link(n::Link, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool) = nothing
 
 """
-    check_link_data(n::Link, data::Data, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_link_data(l::Link, data::Data, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
 Check that the included `Data` types of a `Link` correspond to required structure.
 """
-check_link_data(n::Link, data::Data, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool) =
+check_link_data(l::Link, data::Data, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool) =
     nothing

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -71,7 +71,7 @@ function check_data(case, modeltype::EnergyModel, check_timeprofiles::Bool)
     𝒳ᵛᵉᶜ = get_elements_vec(case)
     𝒯 = get_time_struct(case)
     for elements ∈ 𝒳ᵛᵉᶜ
-        check_elements(log_by_element, elements, case, 𝒯, modeltype, check_timeprofiles)
+        check_elements(log_by_element, elements, 𝒳ᵛᵉᶜ, 𝒯, modeltype, check_timeprofiles)
     end
 
     logs = []
@@ -159,9 +159,9 @@ function check_case_data(case)
 end
 
 """
-    check_elements(log_by_element, _::Vector{<:AbstractElement}, case::Case, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
-    check_elements(log_by_element, 𝒩::Vector{<:Node}, case::Case, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
-    check_elements(log_by_element, ℒ::Vector{<:Link}}, case::Case, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_elements(log_by_element, _::Vector{<:AbstractElement}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_elements(log_by_element, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_elements(log_by_element, ℒ::Vector{<:Link}}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
 Checks the individual elements vector. It has implemented methods for both `Vector{<:Node}`
 and Vector{<:Link}.
@@ -190,7 +190,7 @@ and Vector{<:Link}.
 function check_elements(
     log_by_element,
     _::Vector{<:AbstractElement},
-    case::Case,
+    𝒳ᵛᵉᶜ,
     𝒯,
     modeltype::EnergyModel,
     check_timeprofiles::Bool
@@ -199,7 +199,7 @@ end
 function check_elements(
     log_by_element,
     𝒩::Vector{<:Node},
-    case::Case,
+    𝒳ᵛᵉᶜ,
     𝒯,
     modeltype::EnergyModel,
     check_timeprofiles::Bool
@@ -222,7 +222,7 @@ end
 function check_elements(
     log_by_element,
     ℒ::Vector{<:Link},
-    case::Case,
+    𝒳ᵛᵉᶜ,
     𝒯,
     modeltype::EnergyModel,
     check_timeprofiles::Bool
@@ -232,7 +232,7 @@ function check_elements(
         global logs = []
 
         # Check the connections of the link
-        𝒩  = get_nodes(case)
+        𝒩  = get_nodes(𝒳ᵛᵉᶜ)
         @assert_or_log(
             l.from ∈ 𝒩,
             "The node in the field `:from` is not included in the Node vector. As a consequence," *

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -68,9 +68,9 @@ function check_data(case, modeltype::EnergyModel, check_timeprofiles::Bool)
     end
 
     # Check the individual elements vector
-    𝒳 = f_elements_vec(case)
+    𝒳ᵛᵉᶜ = f_elements_vec(case)
     𝒯 = f_time_struct(case)
-    for elements ∈ 𝒳
+    for elements ∈ 𝒳ᵛᵉᶜ
         check_elements(log_by_element, elements, case, 𝒯, modeltype, check_timeprofiles)
     end
 
@@ -131,9 +131,9 @@ Checks the `case` dictionary is in the correct format.
 - Check that the coupling functions do return elements and not only an empty vector
 """
 function check_case_data(case)
-    𝒳 = f_elements_vec(case)
+    𝒳ᵛᵉᶜ = f_elements_vec(case)
     get_vect_type(vec::Vector{T}) where {T} = T
-    vec_types = [get_vect_type(x) for x ∈ 𝒳]
+    vec_types = [get_vect_type(x) for x ∈ 𝒳ᵛᵉᶜ]
 
     for type_1 ∈ vec_types
         for type_2 ∈ vec_types
@@ -146,8 +146,8 @@ function check_case_data(case)
         end
     end
 
-    𝒳_𝒳 = f_couplings(case)
-    for couple ∈ 𝒳_𝒳
+    𝒳ᵛᵉᶜ_𝒳ᵛᵉᶜ = f_couplings(case)
+    for couple ∈ 𝒳ᵛᵉᶜ_𝒳ᵛᵉᶜ
         for cpl ∈ couple
             @assert_or_log(
                 !isempty(cpl(case)),

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -67,9 +67,9 @@ function check_data(case, modeltype::EnergyModel, check_timeprofiles::Bool)
         compile_logs(case, log_by_element)
     end
 
-    𝒯 = case[:T]
+    𝒯 = f_time_struct(case)
 
-    for n ∈ case[:nodes]
+    for n ∈ f_nodes(case)
 
         # Empty the logs list before each check.
         global logs = []
@@ -145,31 +145,31 @@ Checks the `case` dictionary is in the correct format.
   - `:products::Vector{<:Resource}`.
 """
 function check_case_data(case)
-    case_keys = [:T, :nodes, :links, :products]
-    key_map = Dict(
-        :T => TimeStructure,
-        :nodes => Vector{<:Node},
-        :links => Vector{<:Link},
-        :products => Vector{<:Resource},
-    )
-    for key ∈ case_keys
-        @assert_or_log(
-            haskey(case, key),
-            "The `case` dictionary requires the key `:" *
-            string(key) *
-            "` which is " *
-            "not included."
-        )
-        if haskey(case, key)
-            @assert_or_log(
-                isa(case[key], key_map[key]),
-                "The key `" *
-                string(key) *
-                "` in the `case` dictionary contains " *
-                "other types than the allowed."
-            )
-        end
-    end
+    # case_keys = [:T, :nodes, :links, :products]
+    # key_map = Dict(
+    #     :T => TimeStructure,
+    #     :nodes => Vector{<:Node},
+    #     :links => Vector{<:Link},
+    #     :products => Vector{<:Resource},
+    # )
+    # for key ∈ case_keys
+    #     @assert_or_log(
+    #         haskey(case, key),
+    #         "The `case` dictionary requires the key `:" *
+    #         string(key) *
+    #         "` which is " *
+    #         "not included."
+    #     )
+    #     if haskey(case, key)
+    #         @assert_or_log(
+    #             isa(case[key], key_map[key]),
+    #             "The key `" *
+    #             string(key) *
+    #             "` in the `case` dictionary contains " *
+    #             "other types than the allowed."
+    #         )
+    #     end
+    # end
 end
 
 """
@@ -189,10 +189,10 @@ Checks the `modeltype` .
   periods.
 """
 function check_model(case, modeltype::EnergyModel, check_timeprofiles::Bool)
-    𝒯ᴵⁿᵛ = strategic_periods(case[:T])
+    𝒯ᴵⁿᵛ = strategic_periods(f_time_struct(case))
 
     # Check for inclusion of all emission resources
-    for p ∈ case[:products]
+    for p ∈ f_products(case)
         if isa(p, ResourceEmit)
             @assert_or_log(
                 haskey(emission_limit(modeltype::EnergyModel), p),

--- a/src/model.jl
+++ b/src/model.jl
@@ -55,7 +55,7 @@ function create_model(
     𝒯 = get_time_struct(case)
     𝒫 = get_products(case)
     𝒳ᵛᵉᶜ = get_elements_vec(case)
-    𝒳ᵛᵉᶜ_𝒳ᵛᵉᶜ = get_couplings(case)
+    𝒳_𝒳 = get_couplings(case)
 
     # Declaration of element variables and constraints of the problem
     for 𝒳 ∈ 𝒳ᵛᵉᶜ
@@ -70,7 +70,7 @@ function create_model(
     end
 
     # Declaration of coupling constraints of the problem
-    for couple ∈ 𝒳ᵛᵉᶜ_𝒳ᵛᵉᶜ
+    for couple ∈ 𝒳_𝒳
         elements_vec = [cpl(case) for cpl ∈ couple]
         constraints_couple(m, elements_vec..., 𝒫, 𝒯, modeltype)
     end

--- a/src/model.jl
+++ b/src/model.jl
@@ -114,9 +114,8 @@ function create_model(
 end
 
 """
-    variables_capacity(m, 𝒩::Vector{<:AbstractElement}, 𝒯, modeltype::EnergyModel)
-    variables_capacity(m, 𝒩::Vector{<:Node}, 𝒯, 𝒳, modeltype::EnergyModel)
-    variables_capacity(m, ℒ::Vector{<:Link}, 𝒯, 𝒳, modeltype::EnergyModel)
+    variables_capacity(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
+    variables_capacity(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
 
 Declaration of different capacity variables for the element types introduced in
 `EnergyModelsBase`. `EnergyModelsBase` introduces two elements for an energy system, and
@@ -173,7 +172,6 @@ hence, provides the user with two individual methods:
 
     - `link_cap_inst[l, t]` is the installed capacity of link `l` in operational period `t`.
 """
-function variables_capacity(m, 𝒩::Vector{<:AbstractElement}, 𝒳, 𝒯, modeltype::EnergyModel) end
 function variables_capacity(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
     𝒩ⁿᵒᵗ = nodes_not_sub(𝒩, Union{Storage,Availability})
     𝒩ˢᵗᵒʳ = filter(is_storage, 𝒩)
@@ -204,7 +202,6 @@ function variables_capacity(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::Energ
 end
 
 """
-    variables_flow(m, _, 𝒳, 𝒯, modeltype::EnergyModel)
     variables_flow(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
     variables_flow(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
 
@@ -232,7 +229,6 @@ By default, all nodes `𝒩` and links `ℒ` only allow for unidirectional flow.
 bidirectional flow through providing a method to the function [`is_unidirectional`](@ref)
 for new link/node types.
 """
-function variables_flow(m, _, 𝒳, 𝒯, modeltype::EnergyModel) end
 function variables_flow(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
     # Extract the nodes with inputs and outputs
     𝒩ⁱⁿ = filter(has_input, 𝒩)
@@ -272,7 +268,6 @@ function variables_flow(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyMod
 end
 
 """
-    variables_opex(m, _, 𝒳, 𝒯, modeltype::EnergyModel)
     variables_opex(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
     variables_opex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
 
@@ -295,7 +290,6 @@ hence, provides the user with two individual methods:
     - `link_opex_fixed[n, t_inv]` are the fixed operating expenses of node `n` in investment
       period `t_inv`.
 """
-function variables_opex(m, _, 𝒳, 𝒯, modeltype::EnergyModel) end
 function variables_opex(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
     𝒩ⁿᵒᵗ = nodes_not_av(𝒩)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
@@ -312,7 +306,6 @@ function variables_opex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyMod
 end
 
 """
-    variables_capex(m, _, 𝒳, 𝒯, modeltype::EnergyModel)
     variables_capex(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
     variables_capex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
 
@@ -322,12 +315,10 @@ hence, provides the user with two individual methods:
 
 The default method is empty but it is required for multiple dispatch in investment models.
 """
-function variables_capex(m, _, 𝒳, 𝒯, modeltype::EnergyModel) end
 function variables_capex(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel) end
-function variables_capex(m, 𝒩::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel) end
+function variables_capex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel) end
 
 """
-    variables_emission(m, _, 𝒫, 𝒯, modeltype::EnergyModel)
     variables_emission(m, ℒ::Vector{<:Node}, 𝒫, 𝒯, modeltype::EnergyModel)
     variables_emission(m, ℒ::Vector{<:Link}, 𝒫, 𝒯, modeltype::EnergyModel)
     variables_emission(m, 𝒯, 𝒫, modeltype::EnergyModel)
@@ -363,7 +354,6 @@ The inclusion of node and link emissions require that the function `has_emission
 of `EmissionData` in nodes while links require you to explicitly provide a method for your
 link type.
 """
-function variables_emission(m, _, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel) end
 function variables_emission(m, 𝒩::Vector{<:Node}, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
     𝒩ᵉᵐ = filter(has_emissions, 𝒩)
     𝒫ᵉᵐ = filter(is_resource_emit, 𝒫)
@@ -387,7 +377,6 @@ function variables_emission(m, 𝒫, 𝒯, modeltype::EnergyModel)
 end
 
 """
-    variables_elements(m, _, 𝒳, 𝒯, modeltype::EnergyModel)
     variables_elements(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
     variables_elements(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
 
@@ -402,7 +391,6 @@ node nodes, [`variables_node`](@ref) will be called on a
 - `Node` - the subfunction is [`variables_node`](@ref).
 - `Link` - the subfunction is [`variables_link`](@ref).
 """
-function variables_elements(m, _, 𝒳, 𝒯, modeltype::EnergyModel) end
 function variables_elements(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
     # Vector of the unique node types in 𝒩.
     node_composite_types = unique(map(n -> typeof(n), 𝒩))
@@ -494,7 +482,6 @@ Default fallback method when no method is defined for a [`Link`](@ref) type.
 function variables_link(m, ℒˢᵘᵇ::Vector{<:Link}, 𝒯, modeltype::EnergyModel) end
 
 """
-    constraints_elements(m, _, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
     constraints_elements(m, 𝒩::Vector{<:Node}, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
     constraints_elements(m, ℒ::Vector{<:Link}, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
 
@@ -507,7 +494,6 @@ internal constraints of the entries of the elements vector.
 - `Node` - the subfunction is [`create_node`](@ref).
 - `Link` - the subfunction is [`create_link`](@ref).
 """
-function constraints_elements(m, _, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel) end
 function constraints_elements(m, 𝒩::Vector{<:Node}, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
     for n ∈ 𝒩
         create_node(m, n, 𝒯, 𝒫, modeltype)
@@ -520,7 +506,6 @@ function constraints_elements(m, ℒ::Vector{<:Link}, 𝒳, 𝒫, 𝒯, modeltyp
 end
 
 """
-    constraints_couple(m, _::Vector{<:AbstractElement}, _::Vector{<:AbstractElement}, 𝒫, 𝒯, modeltype::EnergyModel)
     constraints_couple(m, 𝒩::Vector{<:Node}, ℒ::Vector{<:Link}, 𝒫, 𝒯, modeltype::EnergyModel)
     constraints_couple(m, ℒ::Vector{<:Link}, 𝒩::Vector{<:Node}, 𝒫, 𝒯, modeltype::EnergyModel)
 
@@ -530,7 +515,6 @@ Only couplings between two types are introducded in energy models base. A fallba
 is available for the coupling between [`AbstractElement`](@ref)s while a method is implemented
 for the coupling between a [`Link`](@ref) and a [`Node`](@ref EnergyModelsBase.Node).
 """
-function constraints_couple(m, _::Vector{<:AbstractElement}, _::Vector{<:AbstractElement}, 𝒫, 𝒯, modeltype::EnergyModel) end
 function constraints_couple(m, 𝒩::Vector{<:Node}, ℒ::Vector{<:Link}, 𝒫, 𝒯, modeltype::EnergyModel)
     for n ∈ 𝒩
         ℒᶠʳᵒᵐ, ℒᵗᵒ = link_sub(ℒ, n)
@@ -609,9 +593,6 @@ function emissions_operational(m, ℒ::Vector{<:Link}, 𝒫ᵉᵐ, 𝒯, modelty
         sum(m[:emissions_link][l, t, p] for l ∈ ℒᵉᵐ)
     )
 end
-emissions_operational(m, _, 𝒫ᵉᵐ, 𝒯, modeltype::EnergyModel)  =
-    @expression(m, [t ∈ 𝒯, p ∈ 𝒫ᵉᵐ], 0)
-
 
 """
     objective(m, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
@@ -710,8 +691,6 @@ function objective_operational(
         )
     )
 end
-objective_operational(m, _, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, _::EnergyModel) =
-    @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ], 0)
 
 objective_invest(m, _, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, _::AbstractInvestmentModel) =
     @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ], 0)

--- a/src/model.jl
+++ b/src/model.jl
@@ -52,10 +52,10 @@ function create_model(
     end
 
     # WIP Data structure
-    𝒯 = f_time_struct(case)
-    𝒫 = f_products(case)
-    𝒳ᵛᵉᶜ = f_elements_vec(case)
-    𝒳ᵛᵉᶜ_𝒳ᵛᵉᶜ = f_couplings(case)
+    𝒯 = get_time_struct(case)
+    𝒫 = get_products(case)
+    𝒳ᵛᵉᶜ = get_elements_vec(case)
+    𝒳ᵛᵉᶜ_𝒳ᵛᵉᶜ = get_couplings(case)
 
     # Declaration of element variables and constraints of the problem
     for 𝒳 ∈ 𝒳ᵛᵉᶜ

--- a/src/model.jl
+++ b/src/model.jl
@@ -11,7 +11,7 @@ Create the model and call all required functions.
 
 ## Arguments
 - `case::Case` - The case type represents the chosen time structure, the included
-  [`Resource`](@ref)s and the elements and potential coupling between the elements.
+  [`Resource`](@ref)s and the 𝒳 and potential coupling between the 𝒳.
   It is explained in more detail in its *[docstring](@ref Case)*.
 - `modeltype` - Used modeltype, that is a subtype of the type `EnergyModel`.
 - `m` - the empty `JuMP.Model` instance. If it is not provided, then it is assumed that the
@@ -54,33 +54,33 @@ function create_model(
     # WIP Data structure
     𝒯 = f_time_struct(case)
     𝒫 = f_products(case)
-    𝒳 = f_elements_vec(case)
-    𝒳_𝒳 = f_couplings(case)
+    𝒳ᵛᵉᶜ = f_elements_vec(case)
+    𝒳ᵛᵉᶜ_𝒳ᵛᵉᶜ = f_couplings(case)
 
     # Declaration of element variables and constraints of the problem
-    for elements ∈ 𝒳
-        variables_capacity(m, elements, 𝒳, 𝒯, modeltype)
-        variables_flow(m, elements, 𝒳, 𝒯, modeltype)
-        variables_opex(m, elements, 𝒳, 𝒯, modeltype)
-        variables_capex(m, elements, 𝒳, 𝒯, modeltype)
-        variables_emission(m, elements, 𝒳, 𝒫, 𝒯, modeltype)
-        variables_elements(m, elements, 𝒳, 𝒯, modeltype)
+    for 𝒳 ∈ 𝒳ᵛᵉᶜ
+        variables_capacity(m, 𝒳, 𝒳ᵛᵉᶜ, 𝒯, modeltype)
+        variables_flow(m, 𝒳, 𝒳ᵛᵉᶜ, 𝒯, modeltype)
+        variables_opex(m, 𝒳, 𝒳ᵛᵉᶜ, 𝒯, modeltype)
+        variables_capex(m, 𝒳, 𝒳ᵛᵉᶜ, 𝒯, modeltype)
+        variables_emission(m, 𝒳, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype)
+        variables_elements(m, 𝒳, 𝒳ᵛᵉᶜ, 𝒯, modeltype)
 
-        constraints_elements(m, elements, 𝒳, 𝒫, 𝒯, modeltype)
+        constraints_elements(m, 𝒳, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype)
     end
 
     # Declaration of coupling constraints of the problem
-    for couple ∈ 𝒳_𝒳
+    for couple ∈ 𝒳ᵛᵉᶜ_𝒳ᵛᵉᶜ
         elements_vec = [cpl(case) for cpl ∈ couple]
         constraints_couple(m, elements_vec..., 𝒫, 𝒯, modeltype)
     end
 
     # Declaration of global vairables and constraints
     variables_emission(m, 𝒫, 𝒯, modeltype)
-    constraints_emissions(m, 𝒳, 𝒫, 𝒯, modeltype)
+    constraints_emissions(m, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype)
 
     # Construction of the objective function
-    objective(m, 𝒳, 𝒫, 𝒯, modeltype)
+    objective(m, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype)
 
     return m
 end
@@ -114,8 +114,8 @@ function create_model(
 end
 
 """
-    variables_capacity(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
-    variables_capacity(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
+    variables_capacity(m, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
+    variables_capacity(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
 
 Declaration of different capacity variables for the element types introduced in
 `EnergyModelsBase`. `EnergyModelsBase` introduces two elements for an energy system, and
@@ -172,7 +172,7 @@ hence, provides the user with two individual methods:
 
     - `link_cap_inst[l, t]` is the installed capacity of link `l` in operational period `t`.
 """
-function variables_capacity(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
+function variables_capacity(m, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
     𝒩ⁿᵒᵗ = nodes_not_sub(𝒩, Union{Storage,Availability})
     𝒩ˢᵗᵒʳ = filter(is_storage, 𝒩)
     𝒩ˢᵗᵒʳ⁻ᶜ = filter(has_charge, 𝒩ˢᵗᵒʳ)
@@ -195,15 +195,15 @@ function variables_capacity(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::Ener
     @variable(m, stor_discharge_use[𝒩ˢᵗᵒʳ, 𝒯] >= 0)
     @variable(m, stor_discharge_inst[𝒩ˢᵗᵒʳ⁻ᵈᶜ, 𝒯] >= 0)
 end
-function variables_capacity(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
+function variables_capacity(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
     ℒᶜᵃᵖ = filter(has_capacity, ℒ)
 
     @variable(m, link_cap_inst[ℒᶜᵃᵖ, 𝒯])
 end
 
 """
-    variables_flow(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
-    variables_flow(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
+    variables_flow(m, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
+    variables_flow(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
 
 Declaration of flow OPEX variables for the element types introduced in
 `EnergyModelsBase`. `EnergyModelsBase` introduces two elements for an energy system, and
@@ -229,7 +229,7 @@ By default, all nodes `𝒩` and links `ℒ` only allow for unidirectional flow.
 bidirectional flow through providing a method to the function [`is_unidirectional`](@ref)
 for new link/node types.
 """
-function variables_flow(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
+function variables_flow(m, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
     # Extract the nodes with inputs and outputs
     𝒩ⁱⁿ = filter(has_input, 𝒩)
     𝒩ᵒᵘᵗ = filter(has_output, 𝒩)
@@ -249,7 +249,7 @@ function variables_flow(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyMo
         set_lower_bound(m[:flow_out][n_out, t, p], 0)
     end
 end
-function variables_flow(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
+function variables_flow(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
     # Create the link flow variables
     @variable(m, link_in[l ∈ ℒ, 𝒯, inputs(l)])
     @variable(m, link_out[l ∈ ℒ, 𝒯, outputs(l)])
@@ -268,8 +268,8 @@ function variables_flow(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyMod
 end
 
 """
-    variables_opex(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
-    variables_opex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
+    variables_opex(m, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
+    variables_opex(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
 
 Declaration of different OPEX variables for the element types introduced in
 `EnergyModelsBase`. `EnergyModelsBase` introduces two elements for an energy system, and
@@ -290,14 +290,14 @@ hence, provides the user with two individual methods:
     - `link_opex_fixed[n, t_inv]` are the fixed operating expenses of node `n` in investment
       period `t_inv`.
 """
-function variables_opex(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
+function variables_opex(m, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
     𝒩ⁿᵒᵗ = nodes_not_av(𝒩)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     @variable(m, opex_var[𝒩ⁿᵒᵗ, 𝒯ᴵⁿᵛ])
     @variable(m, opex_fixed[𝒩ⁿᵒᵗ, 𝒯ᴵⁿᵛ] >= 0)
 end
-function variables_opex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
+function variables_opex(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
     ℒᵒᵖᵉˣ = filter(has_opex, ℒ)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
@@ -306,8 +306,8 @@ function variables_opex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyMod
 end
 
 """
-    variables_capex(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
-    variables_capex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
+    variables_capex(m, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
+    variables_capex(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
 
 Declaration of different capital expenditures variables for the element types introduced in
 `EnergyModelsBase`. `EnergyModelsBase` introduces two elements for an energy system, and
@@ -315,8 +315,8 @@ hence, provides the user with two individual methods:
 
 The default method is empty but it is required for multiple dispatch in investment models.
 """
-function variables_capex(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel) end
-function variables_capex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel) end
+function variables_capex(m, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel) end
+function variables_capex(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel) end
 
 """
     variables_emission(m, ℒ::Vector{<:Node}, 𝒫, 𝒯, modeltype::EnergyModel)
@@ -354,13 +354,13 @@ The inclusion of node and link emissions require that the function `has_emission
 of `EmissionData` in nodes while links require you to explicitly provide a method for your
 link type.
 """
-function variables_emission(m, 𝒩::Vector{<:Node}, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
+function variables_emission(m, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
     𝒩ᵉᵐ = filter(has_emissions, 𝒩)
     𝒫ᵉᵐ = filter(is_resource_emit, 𝒫)
 
     @variable(m, emissions_node[𝒩ᵉᵐ, 𝒯, 𝒫ᵉᵐ])
 end
-function variables_emission(m, ℒ::Vector{<:Link}, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
+function variables_emission(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
     ℒᵉᵐ = filter(has_emissions, ℒ)
     𝒫ᵉᵐ = filter(is_resource_emit, 𝒫)
 
@@ -377,8 +377,8 @@ function variables_emission(m, 𝒫, 𝒯, modeltype::EnergyModel)
 end
 
 """
-    variables_elements(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
-    variables_elements(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
+    variables_elements(m, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
+    variables_elements(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
 
 Loop through all element types and create variables specific to each type. It starts at the
 top level and subsequently move through the branches until it reaches a leave. That is,
@@ -391,7 +391,7 @@ node nodes, [`variables_node`](@ref) will be called on a
 - `Node` - the subfunction is [`variables_node`](@ref).
 - `Link` - the subfunction is [`variables_link`](@ref).
 """
-function variables_elements(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
+function variables_elements(m, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
     # Vector of the unique node types in 𝒩.
     node_composite_types = unique(map(n -> typeof(n), 𝒩))
     # Get all `Node`-types in the type-hierarchy that the nodes 𝒩 represents.
@@ -422,7 +422,7 @@ function variables_elements(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::Ener
         end
     end
 end
-function variables_elements(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
+function variables_elements(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
     # Vector of the unique link types in ℒ.
     link_composite_types = unique(map(l -> typeof(l), ℒ))
     # Get all `link`-types in the type-hierarchy that the links ℒ represents.
@@ -482,8 +482,8 @@ Default fallback method when no method is defined for a [`Link`](@ref) type.
 function variables_link(m, ℒˢᵘᵇ::Vector{<:Link}, 𝒯, modeltype::EnergyModel) end
 
 """
-    constraints_elements(m, 𝒩::Vector{<:Node}, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
-    constraints_elements(m, ℒ::Vector{<:Link}, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
+    constraints_elements(m, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
+    constraints_elements(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
 
 Loop through all entries of the elements vector and call a subfunction for creating the
 internal constraints of the entries of the elements vector.
@@ -494,12 +494,12 @@ internal constraints of the entries of the elements vector.
 - `Node` - the subfunction is [`create_node`](@ref).
 - `Link` - the subfunction is [`create_link`](@ref).
 """
-function constraints_elements(m, 𝒩::Vector{<:Node}, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
+function constraints_elements(m, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
     for n ∈ 𝒩
         create_node(m, n, 𝒯, 𝒫, modeltype)
     end
 end
-function constraints_elements(m, ℒ::Vector{<:Link}, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
+function constraints_elements(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
     for l ∈ ℒ
         create_link(m, 𝒯, 𝒫, l, modeltype, formulation(l))
     end
@@ -539,18 +539,18 @@ function constraints_couple(m, ℒ::Vector{<:Link}, 𝒩::Vector{<:Node}, 𝒫, 
 end
 
 """
-    constraints_emissions(m, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
+    constraints_emissions(m, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
 
 Create constraints for the emissions accounting for both operational and strategic periods.
 """
-function constraints_emissions(m, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
+function constraints_emissions(m, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
     # Declaration of the required subsets
     𝒫ᵉᵐ = filter(is_resource_emit, 𝒫)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     emissions = JuMP.Containers.DenseAxisArray[]
-    for elements ∈ 𝒳
-        push!(emissions, emissions_operational(m, elements, 𝒫ᵉᵐ, 𝒯, modeltype))
+    for 𝒳 ∈ 𝒳ᵛᵉᶜ
+        push!(emissions, emissions_operational(m, 𝒳, 𝒫ᵉᵐ, 𝒯, modeltype))
     end
 
     # Creation of the individual constraints.
@@ -564,16 +564,16 @@ function constraints_emissions(m, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
     )
 end
 """
-    emissions_operational(m, elements, 𝒫ᵉᵐ, 𝒯, modeltype::EnergyModel)
+    emissions_operational(m, 𝒳, 𝒫ᵉᵐ, 𝒯, modeltype::EnergyModel)
 
-Create JuMP expressions indexed over the operational periods `𝒯` for different elements.
-The expressions correspond to the total emissions of a given type.
+Create JuMP expressions indexed over the operational periods `𝒯` for different elements 𝒳.
+The expressions correspond to the total emissions of a given element type.
 
 By default, objective expressions are included for:
-- `elements = 𝒩::Vector{<:Node}`. In the case of a vector of nodes, the function returns the
+- `𝒳 = 𝒩::Vector{<:Node}`. In the case of a vector of nodes, the function returns the
   sum of the emissions of all nodes whose method of the function [`has_emissions`](@ref)
   returns true. These nodes should be automatically identified without user intervention.
-- `elements = 𝒩::Vector{<:Link}`. In the case of a vector of links, the function returns the
+- `𝒳 = 𝒩::Vector{<:Link}`. In the case of a vector of links, the function returns the
   sum of the emissions of all links whose method of the function [`has_emissions`](@ref)
   returns true.
 """
@@ -595,7 +595,7 @@ function emissions_operational(m, ℒ::Vector{<:Link}, 𝒫ᵉᵐ, 𝒯, modelty
 end
 
 """
-    objective(m, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
+    objective(m, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
 
 Create the objective for the optimization problem for a given modeltype.
 
@@ -609,43 +609,43 @@ The values are not discounted.
 This function serve as fallback option if no other method is specified for a specific
 `modeltype`.
 """
-function objective(m, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
+function objective(m, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
     # Declaration of the required subsets
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     opex = JuMP.Containers.DenseAxisArray[]
-    for elements ∈ 𝒳
-        push!(opex, objective_operational(m, elements, 𝒯ᴵⁿᵛ, modeltype))
+    for 𝒳 ∈ 𝒳ᵛᵉᶜ
+        push!(opex, objective_operational(m, 𝒳, 𝒯ᴵⁿᵛ, modeltype))
     end
     push!(opex, objective_operational(m, 𝒫, 𝒯ᴵⁿᵛ, modeltype))
 
     # Calculation of the objective function.
     @objective(m, Max,
         -sum(
-            sum(elements[t_inv] for elements ∈ opex) * duration_strat(t_inv)
+            sum(𝒳[t_inv] for 𝒳 ∈ opex) * duration_strat(t_inv)
         for t_inv ∈ 𝒯ᴵⁿᵛ)
     )
 end
 """
-    objective_operational(m, elements, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, modeltype::EnergyModel)
+    objective_operational(m, 𝒳, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, modeltype::EnergyModel)
 
-Create JuMP expressions indexed over the investment periods `𝒯ᴵⁿᵛ` for different elements.
+Create JuMP expressions indexed over the investment periods `𝒯ᴵⁿᵛ` for different elements 𝒳.
 The expressions correspond to the operational expenses of the different elements.
 The expressions are not discounted and do not take the duration of the investment periods
 into account.
 
 By default, objective expressions are included for:
-- `elements = 𝒩::Vector{<:Node}`. In the case of a vector of nodes, the function returns the
+- `𝒳 = 𝒩::Vector{<:Node}`. In the case of a vector of nodes, the function returns the
   sum of the variable and fixed OPEX for all nodes whose method of the function [`has_opex`](@ref)
   returns true.
-- `elements = 𝒩::Vector{<:Link}`. In the case of a vector of links, the function returns the
+- `𝒳 = 𝒩::Vector{<:Link}`. In the case of a vector of links, the function returns the
   sum of the variable and fixed OPEX for all links whose method of the function [`has_opex`](@ref)
   returns true.
-- `elements = 𝒩::Vector{<:Resource}`. In the case of a vector of resources, the function
+- `𝒳 = 𝒩::Vector{<:Resource}`. In the case of a vector of resources, the function
   returns the costs associated to the emissions using the function [`emission_price`](@ref).
 
 !!! note "Default function"
-    It is also possible to provide a tuple `𝒳` for only operational or only investment
+    It is also possible to provide a tuple `𝒳ᵛᵉᶜ` for only operational or only investment
     objective contributions. In this situation, the expression returns a value of 0 for all
     investment periods.
 """

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,6 +1,6 @@
 """
     create_model(
-        case::EMXCase,
+        case::Case,
         modeltype::EnergyModel,
         m::JuMP.Model;
         check_timeprofiles::Bool = true,
@@ -10,9 +10,9 @@
 Create the model and call all required functions.
 
 ## Arguments
-- `case::EMXCase` - The case type represents the chosen time structure, the included
+- `case::Case` - The case type represents the chosen time structure, the included
   [`Resource`](@ref)s and the elements and potential coupling between the elements.
-  It is explained in more detail in its *[docstring](@ref EMXCase)*.
+  It is explained in more detail in its *[docstring](@ref Case)*.
 - `modeltype` - Used modeltype, that is a subtype of the type `EnergyModel`.
 - `m` - the empty `JuMP.Model` instance. If it is not provided, then it is assumed that the
   input is a standard `JuMP.Model`.
@@ -30,7 +30,7 @@ Create the model and call all required functions.
     We provide additional methods for translating the old dictionary to the new case types.
 """
 function create_model(
-    case::EMXCase,
+    case::Case,
     modeltype::EnergyModel,
     m::JuMP.Model;
     check_timeprofiles::Bool = true,
@@ -85,7 +85,7 @@ function create_model(
     return m
 end
 function create_model(
-    case::EMXCase,
+    case::Case,
     modeltype::EnergyModel;
     check_timeprofiles::Bool = true,
     check_any_data::Bool = true,
@@ -100,7 +100,7 @@ function create_model(
     check_timeprofiles::Bool = true,
     check_any_data::Bool = true,
 )
-    case_new = EMXCase(case[:T], case[:products], [case[:nodes], case[:links]])
+    case_new = Case(case[:T], case[:products], [case[:nodes], case[:links]])
     create_model(case_new, modeltype, m; check_timeprofiles, check_any_data)
 end
 function create_model(

--- a/src/model.jl
+++ b/src/model.jl
@@ -59,14 +59,14 @@ function create_model(
 
     # Declaration of element variables and constraints of the problem
     for elements ∈ 𝒳
-        variables_capacity(m, elements, 𝒯, modeltype)
-        variables_flow(m, elements, 𝒯, modeltype)
-        variables_opex(m, elements, 𝒯, modeltype)
-        variables_capex(m, elements, 𝒯, modeltype)
-        variables_emission(m, elements, 𝒫, 𝒯, modeltype)
-        variables_elements(m, elements, 𝒯, modeltype)
+        variables_capacity(m, elements, 𝒳, 𝒯, modeltype)
+        variables_flow(m, elements, 𝒳, 𝒯, modeltype)
+        variables_opex(m, elements, 𝒳, 𝒯, modeltype)
+        variables_capex(m, elements, 𝒳, 𝒯, modeltype)
+        variables_emission(m, elements, 𝒳, 𝒫, 𝒯, modeltype)
+        variables_elements(m, elements, 𝒳, 𝒯, modeltype)
 
-        constraints_elements(m, elements, 𝒫, 𝒯, modeltype)
+        constraints_elements(m, elements, 𝒳, 𝒫, 𝒯, modeltype)
     end
 
     # Declaration of coupling constraints of the problem
@@ -115,8 +115,8 @@ end
 
 """
     variables_capacity(m, 𝒩::Vector{<:AbstractElement}, 𝒯, modeltype::EnergyModel)
-    variables_capacity(m, 𝒩::Vector{<:Node}, 𝒯, modeltype::EnergyModel)
-    variables_capacity(m, ℒ::Vector{<:Link}, 𝒯, modeltype::EnergyModel)
+    variables_capacity(m, 𝒩::Vector{<:Node}, 𝒯, 𝒳, modeltype::EnergyModel)
+    variables_capacity(m, ℒ::Vector{<:Link}, 𝒯, 𝒳, modeltype::EnergyModel)
 
 Declaration of different capacity variables for the element types introduced in
 `EnergyModelsBase`. `EnergyModelsBase` introduces two elements for an energy system, and
@@ -173,8 +173,8 @@ hence, provides the user with two individual methods:
 
     - `link_cap_inst[l, t]` is the installed capacity of link `l` in operational period `t`.
 """
-function variables_capacity(m, 𝒩::Vector{<:AbstractElement}, 𝒯, modeltype::EnergyModel) end
-function variables_capacity(m, 𝒩::Vector{<:Node}, 𝒯, modeltype::EnergyModel)
+function variables_capacity(m, 𝒩::Vector{<:AbstractElement}, 𝒳, 𝒯, modeltype::EnergyModel) end
+function variables_capacity(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
     𝒩ⁿᵒᵗ = nodes_not_sub(𝒩, Union{Storage,Availability})
     𝒩ˢᵗᵒʳ = filter(is_storage, 𝒩)
     𝒩ˢᵗᵒʳ⁻ᶜ = filter(has_charge, 𝒩ˢᵗᵒʳ)
@@ -197,16 +197,16 @@ function variables_capacity(m, 𝒩::Vector{<:Node}, 𝒯, modeltype::EnergyMode
     @variable(m, stor_discharge_use[𝒩ˢᵗᵒʳ, 𝒯] >= 0)
     @variable(m, stor_discharge_inst[𝒩ˢᵗᵒʳ⁻ᵈᶜ, 𝒯] >= 0)
 end
-function variables_capacity(m, ℒ::Vector{<:Link}, 𝒯, modeltype::EnergyModel)
+function variables_capacity(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
     ℒᶜᵃᵖ = filter(has_capacity, ℒ)
 
     @variable(m, link_cap_inst[ℒᶜᵃᵖ, 𝒯])
 end
 
 """
-    variables_flow(m, _, 𝒯, modeltype::EnergyModel)
-    variables_flow(m, 𝒩::Vector{<:Node}, 𝒯, modeltype::EnergyModel)
-    variables_flow(m, ℒ::Vector{<:Link}, 𝒯, modeltype::EnergyModel)
+    variables_flow(m, _, 𝒳, 𝒯, modeltype::EnergyModel)
+    variables_flow(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
+    variables_flow(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
 
 Declaration of flow OPEX variables for the element types introduced in
 `EnergyModelsBase`. `EnergyModelsBase` introduces two elements for an energy system, and
@@ -221,24 +221,24 @@ hence, provides the user with two individual methods:
       function [`outputs`](@ref).
 
 !!! tip "Link variables"
-    - `link_in[n, t]` is the flow _**into**_ link `l` in operational period `t` for
+    - `link_in[l, t, p]` is the flow _**into**_ link `l` in operational period `t` for
       resource `p`. The inflow resources of link `l` are extracted using the function
       [`inputs`](@ref).
-    - `link_out[n, t, p]` is the flow _**from**_ link `l` in operational period `t`
+    - `link_out[l, t, p]` is the flow _**from**_ link `l` in operational period `t`
       for resource `p`. The outflow resources of link `l` are extracted using the
       function [`outputs`](@ref).
 
 By default, all nodes `𝒩` and links `ℒ` only allow for unidirectional flow. You can specify
-bidirection flow through providing a method to the function [`is_unidirectional`](@ref) for
-new link/node types.
+bidirectional flow through providing a method to the function [`is_unidirectional`](@ref)
+for new link/node types.
 """
-function variables_flow(m, _, 𝒯, modeltype::EnergyModel) end
-function variables_flow(m, 𝒩::Vector{<:Node}, 𝒯, modeltype::EnergyModel)
+function variables_flow(m, _, 𝒳, 𝒯, modeltype::EnergyModel) end
+function variables_flow(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
     # Extract the nodes with inputs and outputs
     𝒩ⁱⁿ = filter(has_input, 𝒩)
     𝒩ᵒᵘᵗ = filter(has_output, 𝒩)
 
-    # Create the nod flow variables
+    # Create the node flow variables
     @variable(m, flow_in[n_in ∈ 𝒩ⁱⁿ, 𝒯, inputs(n_in)])
     @variable(m, flow_out[n_out ∈ 𝒩ᵒᵘᵗ, 𝒯, outputs(n_out)])
 
@@ -253,7 +253,7 @@ function variables_flow(m, 𝒩::Vector{<:Node}, 𝒯, modeltype::EnergyModel)
         set_lower_bound(m[:flow_out][n_out, t, p], 0)
     end
 end
-function variables_flow(m, ℒ::Vector{<:Link}, 𝒯, modeltype::EnergyModel)
+function variables_flow(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
     # Create the link flow variables
     @variable(m, link_in[l ∈ ℒ, 𝒯, inputs(l)])
     @variable(m, link_out[l ∈ ℒ, 𝒯, outputs(l)])
@@ -272,9 +272,9 @@ function variables_flow(m, ℒ::Vector{<:Link}, 𝒯, modeltype::EnergyModel)
 end
 
 """
-    variables_opex(m, _, 𝒯, modeltype::EnergyModel)
-    variables_opex(m, 𝒩::Vector{<:Node}, 𝒯, modeltype::EnergyModel)
-    variables_opex(m, ℒ::Vector{<:Link}, 𝒯, modeltype::EnergyModel)
+    variables_opex(m, _, 𝒳, 𝒯, modeltype::EnergyModel)
+    variables_opex(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
+    variables_opex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
 
 Declaration of different OPEX variables for the element types introduced in
 `EnergyModelsBase`. `EnergyModelsBase` introduces two elements for an energy system, and
@@ -295,15 +295,15 @@ hence, provides the user with two individual methods:
     - `link_opex_fixed[n, t_inv]` are the fixed operating expenses of node `n` in investment
       period `t_inv`.
 """
-function variables_opex(m, _, 𝒯, modeltype::EnergyModel) end
-function variables_opex(m, 𝒩::Vector{<:Node}, 𝒯, modeltype::EnergyModel)
+function variables_opex(m, _, 𝒳, 𝒯, modeltype::EnergyModel) end
+function variables_opex(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
     𝒩ⁿᵒᵗ = nodes_not_av(𝒩)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     @variable(m, opex_var[𝒩ⁿᵒᵗ, 𝒯ᴵⁿᵛ])
     @variable(m, opex_fixed[𝒩ⁿᵒᵗ, 𝒯ᴵⁿᵛ] >= 0)
 end
-function variables_opex(m, ℒ::Vector{<:Link}, 𝒯, modeltype::EnergyModel)
+function variables_opex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
     ℒᵒᵖᵉˣ = filter(has_opex, ℒ)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
@@ -312,9 +312,9 @@ function variables_opex(m, ℒ::Vector{<:Link}, 𝒯, modeltype::EnergyModel)
 end
 
 """
-    variables_capex(m, _, 𝒯, modeltype::EnergyModel)
-    variables_capex(m, 𝒩::Vector{<:Node}, 𝒯, modeltype::EnergyModel)
-    variables_capex(m, ℒ::Vector{<:Link}, 𝒯, modeltype::EnergyModel)
+    variables_capex(m, _, 𝒳, 𝒯, modeltype::EnergyModel)
+    variables_capex(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
+    variables_capex(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
 
 Declaration of different capital expenditures variables for the element types introduced in
 `EnergyModelsBase`. `EnergyModelsBase` introduces two elements for an energy system, and
@@ -322,9 +322,9 @@ hence, provides the user with two individual methods:
 
 The default method is empty but it is required for multiple dispatch in investment models.
 """
-function variables_capex(m, _, 𝒯, modeltype::EnergyModel) end
-function variables_capex(m, 𝒩::Vector{<:Node}, 𝒯, modeltype::EnergyModel) end
-function variables_capex(m, 𝒩::Vector{<:Link}, 𝒯, modeltype::EnergyModel) end
+function variables_capex(m, _, 𝒳, 𝒯, modeltype::EnergyModel) end
+function variables_capex(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel) end
+function variables_capex(m, 𝒩::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel) end
 
 """
     variables_emission(m, _, 𝒫, 𝒯, modeltype::EnergyModel)
@@ -363,14 +363,14 @@ The inclusion of node and link emissions require that the function `has_emission
 of `EmissionData` in nodes while links require you to explicitly provide a method for your
 link type.
 """
-function variables_emission(m, _, 𝒫, 𝒯, modeltype::EnergyModel) end
-function variables_emission(m, 𝒩::Vector{<:Node}, 𝒫, 𝒯, modeltype::EnergyModel)
+function variables_emission(m, _, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel) end
+function variables_emission(m, 𝒩::Vector{<:Node}, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
     𝒩ᵉᵐ = filter(has_emissions, 𝒩)
     𝒫ᵉᵐ = filter(is_resource_emit, 𝒫)
 
     @variable(m, emissions_node[𝒩ᵉᵐ, 𝒯, 𝒫ᵉᵐ])
 end
-function variables_emission(m, ℒ::Vector{<:Link}, 𝒫, 𝒯, modeltype::EnergyModel)
+function variables_emission(m, ℒ::Vector{<:Link}, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
     ℒᵉᵐ = filter(has_emissions, ℒ)
     𝒫ᵉᵐ = filter(is_resource_emit, 𝒫)
 
@@ -387,9 +387,9 @@ function variables_emission(m, 𝒫, 𝒯, modeltype::EnergyModel)
 end
 
 """
-    variables_elements(m, _, 𝒯, modeltype::EnergyModel)
-    variables_elements(m, 𝒩::Vector{<:Node}, 𝒯, modeltype::EnergyModel)
-    variables_elements(m, ℒ::Vector{<:Link}, 𝒯, modeltype::EnergyModel)
+    variables_elements(m, _, 𝒳, 𝒯, modeltype::EnergyModel)
+    variables_elements(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
+    variables_elements(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
 
 Loop through all element types and create variables specific to each type. It starts at the
 top level and subsequently move through the branches until it reaches a leave. That is,
@@ -402,8 +402,8 @@ node nodes, [`variables_node`](@ref) will be called on a
 - `Node` - the subfunction is [`variables_node`](@ref).
 - `Link` - the subfunction is [`variables_link`](@ref).
 """
-function variables_elements(m, _, 𝒯, modeltype::EnergyModel) end
-function variables_elements(m, 𝒩::Vector{<:Node}, 𝒯, modeltype::EnergyModel)
+function variables_elements(m, _, 𝒳, 𝒯, modeltype::EnergyModel) end
+function variables_elements(m, 𝒩::Vector{<:Node}, 𝒳, 𝒯, modeltype::EnergyModel)
     # Vector of the unique node types in 𝒩.
     node_composite_types = unique(map(n -> typeof(n), 𝒩))
     # Get all `Node`-types in the type-hierarchy that the nodes 𝒩 represents.
@@ -434,7 +434,7 @@ function variables_elements(m, 𝒩::Vector{<:Node}, 𝒯, modeltype::EnergyMode
         end
     end
 end
-function variables_elements(m, ℒ::Vector{<:Link}, 𝒯, modeltype::EnergyModel)
+function variables_elements(m, ℒ::Vector{<:Link}, 𝒳, 𝒯, modeltype::EnergyModel)
     # Vector of the unique link types in ℒ.
     link_composite_types = unique(map(l -> typeof(l), ℒ))
     # Get all `link`-types in the type-hierarchy that the links ℒ represents.
@@ -494,9 +494,9 @@ Default fallback method when no method is defined for a [`Link`](@ref) type.
 function variables_link(m, ℒˢᵘᵇ::Vector{<:Link}, 𝒯, modeltype::EnergyModel) end
 
 """
-    constraints_elements(m, _, 𝒫, 𝒯, modeltype::EnergyModel)
-    constraints_elements(m, 𝒩::Vector{<:Node}, 𝒫, 𝒯, modeltype::EnergyModel)
-    constraints_elements(m, ℒ::Vector{<:Link}, 𝒫, 𝒯, modeltype::EnergyModel)
+    constraints_elements(m, _, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
+    constraints_elements(m, 𝒩::Vector{<:Node}, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
+    constraints_elements(m, ℒ::Vector{<:Link}, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
 
 Loop through all entries of the elements vector and call a subfunction for creating the
 internal constraints of the entries of the elements vector.
@@ -507,13 +507,13 @@ internal constraints of the entries of the elements vector.
 - `Node` - the subfunction is [`create_node`](@ref).
 - `Link` - the subfunction is [`create_link`](@ref).
 """
-function constraints_elements(m, _, 𝒫, 𝒯, modeltype::EnergyModel) end
-function constraints_elements(m, 𝒩::Vector{<:Node}, 𝒫, 𝒯, modeltype::EnergyModel)
+function constraints_elements(m, _, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel) end
+function constraints_elements(m, 𝒩::Vector{<:Node}, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
     for n ∈ 𝒩
         create_node(m, n, 𝒯, 𝒫, modeltype)
     end
 end
-function constraints_elements(m, ℒ::Vector{<:Link}, 𝒫, 𝒯, modeltype::EnergyModel)
+function constraints_elements(m, ℒ::Vector{<:Link}, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)
     for l ∈ ℒ
         create_link(m, 𝒯, 𝒫, l, modeltype, formulation(l))
     end
@@ -609,7 +609,9 @@ function emissions_operational(m, ℒ::Vector{<:Link}, 𝒫ᵉᵐ, 𝒯, modelty
         sum(m[:emissions_link][l, t, p] for l ∈ ℒᵉᵐ)
     )
 end
-function emissions_operational(m, _, 𝒫ᵉᵐ, 𝒯, modeltype::EnergyModel) end
+emissions_operational(m, _, 𝒫ᵉᵐ, 𝒯, modeltype::EnergyModel)  =
+    @expression(m, [t ∈ 𝒯, p ∈ 𝒫ᵉᵐ], 0)
+
 
 """
     objective(m, 𝒳, 𝒫, 𝒯, modeltype::EnergyModel)

--- a/src/model.jl
+++ b/src/model.jl
@@ -713,6 +713,9 @@ end
 objective_operational(m, _, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, _::EnergyModel) =
     @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ], 0)
 
+objective_invest(m, _, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, _::AbstractInvestmentModel) =
+    @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ], 0)
+
 """
     create_node(m, n::Source, 𝒯, 𝒫, modeltype::EnergyModel)
 

--- a/src/structures/case.jl
+++ b/src/structures/case.jl
@@ -12,7 +12,7 @@ for providing the input to a model.
       It must containt all [`ResourceEmit`](@ref) in `EnergyModelsBase`, but it is not
       necessary that the [`ResourceCarrier`](@ref) are included. It is however advisable to
       include all resources.
-- **`elements::Vector{Vector{<:AbstractElement}}`** are the vectors of [`AbstractElement`](@ref)
+- **`elements::Vector{Vector}`** are the vectors of [`AbstractElement`](@ref)
   that should be included in the analysis. It must contain at least vectors of nodes and
   links for an analysis to be useful.
 - **`couplings::Vector{Vector{Function}}`** are the couplings between the individual function

--- a/src/structures/case.jl
+++ b/src/structures/case.jl
@@ -26,7 +26,7 @@ for providing the input to a model.
   links for an analysis to be useful.
 - **`couplings::Vector{Vector{Function}}`** are the couplings between the individual function
   element types. These elements are represented through a corresponding function, *e.g.*,
-  [`get_nodes`](@ref) or [`get_links`](@ref)
+  [`get_nodes`](@ref) or [`get_links`](@ref).
 - **`misc::Dict`** is a dictionary that can be utilized for providing additional high level
   data in the existing format in the case of a new function for case creation. It is
   conditional through the application of a constructor.

--- a/src/structures/case.jl
+++ b/src/structures/case.jl
@@ -15,9 +15,9 @@ for providing the input to a model.
 - **`elements::Vector{Vector{<:AbstractElement}}`** are the vectors of [`AbstractElement`](@ref)
   that should be included in the analysis. It must contain at least vectors of nodes and
   links for an analysis to be useful.
-- **`couplings::Vector{Vector}`** are the couplings between the individual function element
-  types. These elements are represented through a corresponding function, *e.g.*, [`f_nodes`](@ref)
-  or [`f_links`](@ref)
+- **`couplings::Vector{Vector{Function}}`** are the couplings between the individual function
+  element types. These elements are represented through a corresponding function, *e.g.*,
+  [`f_nodes`](@ref) or [`f_links`](@ref)
 - **`misc::Dict`** is a dictionary that can be utilized for providing additional high level
   data in the existing format in the case of a new function for case creation. It is
   conditional through the application of a constructor.
@@ -100,6 +100,13 @@ f_nodes(case::EMXCase) = filter(el -> isa(el, Vector{<:Node}), f_elements_vec(ca
 Returns the vector of links of the EMXCase `case`.
 """
 f_links(case::EMXCase) = filter(el -> isa(el, Vector{<:Link}), f_elements_vec(case))[1]
+
+"""
+    f_couplings(case::EMXCase)
+
+Returns the vector of coupling vectors of the EMXCase `case`.
+"""
+f_couplings(case::EMXCase) = case.couplings
 
 function EMXCase(
     T::TimeStructure,

--- a/src/structures/case.jl
+++ b/src/structures/case.jl
@@ -1,5 +1,14 @@
 """
-    EMXCase
+    abstract type AbstractCase
+
+An `AbstractCase` is a description of a case to be used within `EnergyModelsBase`. It is
+only required to create a new subtype if you plan to incorporate a new [`create_model`](@ref)
+function.
+"""
+abstract type AbstractCase end
+
+"""
+    struct Case <: AbstractCase
 
 Type representing a case in `EnergyModelsBase`. It replaces the previously used dictionary
 for providing the input to a model.
@@ -32,13 +41,13 @@ for providing the input to a model.
 
     in an external constructor if the couplings are not specified.
 """
-struct EMXCase
+struct Case <: AbstractCase
     T::TimeStructure
     products::Vector{<:Resource}
     elements::Vector{Vector}
     couplings::Vector{Vector{Function}}
     misc::Dict
-    function EMXCase(
+    function Case(
         T::TimeStructure,
         products::Vector{<:Resource},
         elements::Vector{Vector},
@@ -57,71 +66,71 @@ struct EMXCase
         end
     end
 end
-function EMXCase(
+function Case(
     T::TimeStructure,
     products::Vector{<:Resource},
     elements::Vector{Vector},
     couplings::Vector{Vector{Function}},
     )
-    return EMXCase(T, products, elements, couplings, Dict())
+    return Case(T, products, elements, couplings, Dict())
 end
 
 """
-    f_time_struct(case::EMXCase)
+    f_time_struct(case::Case)
 
-Returns the time structure of the EMXCase `case`.
+Returns the time structure of the Case `case`.
 """
-f_time_struct(case::EMXCase) = case.T
-
-"""
-    f_products(case::EMXCase)
-
-Returns the vector of products of the EMXCase `case`.
-"""
-f_products(case::EMXCase) = case.products
+f_time_struct(case::Case) = case.T
 
 """
-    f_elements_vec(case::EMXCase)
+    f_products(case::Case)
 
-Returns the vector of element vectors of the EMXCase `case`.
+Returns the vector of products of the Case `case`.
 """
-f_elements_vec(case::EMXCase) = case.elements
-
-"""
-    f_nodes(case::EMXCase)
-
-Returns the vector of nodes of the EMXCase `case`.
-"""
-f_nodes(case::EMXCase) = filter(el -> isa(el, Vector{<:Node}), f_elements_vec(case))[1]
+f_products(case::Case) = case.products
 
 """
-    f_links(case::EMXCase)
+    f_elements_vec(case::Case)
 
-Returns the vector of links of the EMXCase `case`.
+Returns the vector of element vectors of the Case `case`.
 """
-f_links(case::EMXCase) = filter(el -> isa(el, Vector{<:Link}), f_elements_vec(case))[1]
+f_elements_vec(case::Case) = case.elements
 
 """
-    f_couplings(case::EMXCase)
+    f_nodes(case::Case)
 
-Returns the vector of coupling vectors of the EMXCase `case`.
+Returns the vector of nodes of the Case `case`.
 """
-f_couplings(case::EMXCase) = case.couplings
+f_nodes(case::Case) = filter(el -> isa(el, Vector{<:Node}), f_elements_vec(case))[1]
 
-function EMXCase(
+"""
+    f_links(case::Case)
+
+Returns the vector of links of the Case `case`.
+"""
+f_links(case::Case) = filter(el -> isa(el, Vector{<:Link}), f_elements_vec(case))[1]
+
+"""
+    f_couplings(case::Case)
+
+Returns the vector of coupling vectors of the Case `case`.
+"""
+f_couplings(case::Case) = case.couplings
+
+function Case(
     T::TimeStructure,
     products::Vector{<:Resource},
     elements::Vector{Vector},
     )
     couplings = [[f_nodes, f_links]]
-    return EMXCase(T, products, elements, couplings, Dict())
+    return Case(T, products, elements, couplings, Dict())
 end
-function EMXCase(
+function Case(
     T::TimeStructure,
     products::Vector{<:Resource},
     elements::Vector{Vector},
     misc::Dict,
     )
     couplings = [[f_nodes, f_links]]
-    return EMXCase(T, products, elements, couplings, misc)
+    return Case(T, products, elements, couplings, misc)
 end

--- a/src/structures/case.jl
+++ b/src/structures/case.jl
@@ -1,0 +1,120 @@
+"""
+    EMXCase
+
+Type representing a case in `EnergyModelsBase`. It replaces the previously used dictionary
+for providing the input to a model.
+
+# Fields
+- **`T::TimeStructure`** is the time structure of the model.
+- **`products::Vector{<:Resource}`** are the resources that should be incorporated into the
+  model.
+  !!! tip
+      It must containt all [`ResourceEmit`](@ref) in `EnergyModelsBase`, but it is not
+      necessary that the [`ResourceCarrier`](@ref) are included. It is however advisable to
+      include all resources.
+- **`elements::Vector{Vector{<:AbstractElement}}`** are the vectors of [`AbstractElement`](@ref)
+  that should be included in the analysis. It must contain at least vectors of nodes and
+  links for an analysis to be useful.
+- **`couplings::Vector{Vector}`** are the couplings between the individual function element
+  types. These elements are represented through a corresponding function, *e.g.*, [`f_nodes`](@ref)
+  or [`f_links`](@ref)
+- **`misc::Dict`** is a dictionary that can be utilized for providing additional high level
+  data in the existing format in the case of a new function for case creation. It is
+  conditional through the application of a constructor.
+
+!!! tip "Couplings"
+    `EnergyModelsBase` requires the coupling of links and nodes. Hence, as a default
+    approach, it adds the coupling
+
+    ```julia
+    couplings = [[f_nodes, f_links]]
+    ```
+
+    in an external constructor if the couplings are not specified.
+"""
+struct EMXCase
+    T::TimeStructure
+    products::Vector{<:Resource}
+    elements::Vector{Vector}
+    couplings::Vector{Vector{Function}}
+    misc::Dict
+    function EMXCase(
+        T::TimeStructure,
+        products::Vector{<:Resource},
+        elements::Vector{Vector},
+        couplings::Vector{Vector{Function}},
+        misc::Dict,
+    )
+        if all(isa(els, Vector{<:AbstractElement}) for els ∈ elements)
+            new(T, products, elements, couplings, misc)
+        else
+            throw(
+                ArgumentError(
+                    "It is not possible to provide a vector to the field elements that " *
+                    "is not a `Vector{<:AbstractElement}`.",
+                ),
+            )
+        end
+    end
+end
+function EMXCase(
+    T::TimeStructure,
+    products::Vector{<:Resource},
+    elements::Vector{Vector},
+    couplings::Vector{Vector{Function}},
+    )
+    return EMXCase(T, products, elements, couplings, Dict())
+end
+
+"""
+    f_time_struct(case::EMXCase)
+
+Returns the time structure of the EMXCase `case`.
+"""
+f_time_struct(case::EMXCase) = case.T
+
+"""
+    f_products(case::EMXCase)
+
+Returns the vector of products of the EMXCase `case`.
+"""
+f_products(case::EMXCase) = case.products
+
+"""
+    f_elements_vec(case::EMXCase)
+
+Returns the vector of element vectors of the EMXCase `case`.
+"""
+f_elements_vec(case::EMXCase) = case.elements
+
+"""
+    f_nodes(case::EMXCase)
+
+Returns the vector of nodes of the EMXCase `case`.
+"""
+f_nodes(case::EMXCase) = filter(el -> isa(el, Vector{<:Node}), f_elements_vec(case))[1]
+
+"""
+    f_links(case::EMXCase)
+
+Returns the vector of links of the EMXCase `case`.
+"""
+f_links(case::EMXCase) = filter(el -> isa(el, Vector{<:Link}), f_elements_vec(case))[1]
+
+function EMXCase(
+    T::TimeStructure,
+    products::Vector{<:Resource},
+    elements::Vector{Vector},
+    )
+    couplings = [[f_nodes, f_links]]
+    return EMXCase(T, products, elements, couplings, Dict())
+end
+function EMXCase(
+    T::TimeStructure,
+    products::Vector{<:Resource},
+    elements::Vector{Vector},
+    misc::Dict,
+    )
+    couplings = [[f_nodes, f_links]]
+    return EMXCase(T, products, elements, couplings, misc)
+end

--- a/src/structures/case.jl
+++ b/src/structures/case.jl
@@ -26,7 +26,7 @@ for providing the input to a model.
   links for an analysis to be useful.
 - **`couplings::Vector{Vector{Function}}`** are the couplings between the individual function
   element types. These elements are represented through a corresponding function, *e.g.*,
-  [`f_nodes`](@ref) or [`f_links`](@ref)
+  [`get_nodes`](@ref) or [`get_links`](@ref)
 - **`misc::Dict`** is a dictionary that can be utilized for providing additional high level
   data in the existing format in the case of a new function for case creation. It is
   conditional through the application of a constructor.
@@ -36,7 +36,7 @@ for providing the input to a model.
     approach, it adds the coupling
 
     ```julia
-    couplings = [[f_nodes, f_links]]
+    couplings = [[get_nodes, get_links]]
     ```
 
     in an external constructor if the couplings are not specified.
@@ -76,53 +76,53 @@ function Case(
 end
 
 """
-    f_time_struct(case::Case)
+    get_time_struct(case::Case)
 
 Returns the time structure of the Case `case`.
 """
-f_time_struct(case::Case) = case.T
+get_time_struct(case::Case) = case.T
 
 """
-    f_products(case::Case)
+    get_products(case::Case)
 
 Returns the vector of products of the Case `case`.
 """
-f_products(case::Case) = case.products
+get_products(case::Case) = case.products
 
 """
-    f_elements_vec(case::Case)
+    get_elements_vec(case::Case)
 
 Returns the vector of element vectors of the Case `case`.
 """
-f_elements_vec(case::Case) = case.elements
+get_elements_vec(case::Case) = case.elements
 
 """
-    f_nodes(case::Case)
+    get_nodes(case::Case)
 
 Returns the vector of nodes of the Case `case`.
 """
-f_nodes(case::Case) = filter(el -> isa(el, Vector{<:Node}), f_elements_vec(case))[1]
+get_nodes(case::Case) = filter(el -> isa(el, Vector{<:Node}), get_elements_vec(case))[1]
 
 """
-    f_links(case::Case)
+    get_links(case::Case)
 
 Returns the vector of links of the Case `case`.
 """
-f_links(case::Case) = filter(el -> isa(el, Vector{<:Link}), f_elements_vec(case))[1]
+get_links(case::Case) = filter(el -> isa(el, Vector{<:Link}), get_elements_vec(case))[1]
 
 """
-    f_couplings(case::Case)
+    get_couplings(case::Case)
 
 Returns the vector of coupling vectors of the Case `case`.
 """
-f_couplings(case::Case) = case.couplings
+get_couplings(case::Case) = case.couplings
 
 function Case(
     T::TimeStructure,
     products::Vector{<:Resource},
     elements::Vector{Vector},
     )
-    couplings = [[f_nodes, f_links]]
+    couplings = [[get_nodes, get_links]]
     return Case(T, products, elements, couplings, Dict())
 end
 function Case(
@@ -131,6 +131,6 @@ function Case(
     elements::Vector{Vector},
     misc::Dict,
     )
-    couplings = [[f_nodes, f_links]]
+    couplings = [[get_nodes, get_links]]
     return Case(T, products, elements, couplings, misc)
 end

--- a/src/structures/case.jl
+++ b/src/structures/case.jl
@@ -98,17 +98,21 @@ get_elements_vec(case::Case) = case.elements
 
 """
     get_nodes(case::Case)
+    get_nodes(𝒳ᵛᵉᶜ::Vector{Vector})
 
-Returns the vector of nodes of the Case `case`.
+Returns the vector of nodes of the Case `case` or the vector of elements vectors 𝒳ᵛᵉᶜ.
 """
 get_nodes(case::Case) = filter(el -> isa(el, Vector{<:Node}), get_elements_vec(case))[1]
+get_nodes(𝒳ᵛᵉᶜ::Vector{Vector}) = filter(el -> isa(el, Vector{<:Node}), 𝒳ᵛᵉᶜ)[1]
 
 """
     get_links(case::Case)
+    get_links(𝒳ᵛᵉᶜ::Vector{Vector})
 
-Returns the vector of links of the Case `case`.
+Returns the vector of links of the Case `case` or the vector of elements vectors 𝒳ᵛᵉᶜ.
 """
 get_links(case::Case) = filter(el -> isa(el, Vector{<:Link}), get_elements_vec(case))[1]
+get_links(𝒳ᵛᵉᶜ::Vector{Vector}) = filter(el -> isa(el, Vector{<:Link}), 𝒳ᵛᵉᶜ)[1]
 
 """
     get_couplings(case::Case)

--- a/src/structures/element.jl
+++ b/src/structures/element.jl
@@ -7,7 +7,7 @@ an energy system.
 # Introduced elements
 - **[`Node`](@ref)s** correspond to technologies that convert energy or mass as defined
   through the introduced [`Resource`](@ref)s.
-- **[`Links`](@ref)s** transport the [`Resource`](@ref)s between different nodes.
+- **[`Link`](@ref)s** transport the [`Resource`](@ref)s between different nodes.
 
 !!! tip "Additional AbstractElement"
     It is possible to introduce new elements. These elements can introduce also new variables

--- a/src/structures/element.jl
+++ b/src/structures/element.jl
@@ -1,0 +1,16 @@
+"""
+    abstract type AbstractElement
+
+Abstract elements correspond to the core types of `EnergyModelsBase` that form components of
+an energy system.
+
+# Introduced elements
+- **[`Node`](@ref)s** correspond to technologies that convert energy or mass as defined
+  through the introduced [`Resource`](@ref)s.
+- **[`Links`](@ref)s** transport the [`Resource`](@ref)s between different nodes.
+
+!!! tip "Additional AbstractElement"
+    It is possible to introduce new elements. These elements can introduce also new variables
+    and constraints.
+"""
+abstract type AbstractElement end

--- a/src/structures/link.jl
+++ b/src/structures/link.jl
@@ -4,11 +4,16 @@ abstract type Formulation end
 """ Linear `Formulation`, that is input equals output."""
 struct Linear <: Formulation end
 
-""" Declaration of the general type for links connecting nodes."""
-abstract type Link end
+"""
+    abstract type Link <: AbstractElement
+
+Declaration of the general type for links connecting nodes.
+"""
+abstract type Link <: AbstractElement end
 Base.show(io::IO, l::Link) = print(io, "l_$(l.from)-$(l.to)")
 
-""" `Direct <: Link`
+"""
+    struct Direct <: Link
 
 A direct link between two nodes.
 

--- a/src/structures/link.jl
+++ b/src/structures/link.jl
@@ -126,6 +126,6 @@ formulation(l::Link) = l.formulation
 
 Returns the [`Data`](@ref) array of link `l`.
 
-The default options returns nothing.
+The default options returns an empty `Data` vector.
 """
-link_data(l::Link) = nothing
+link_data(l::Link) = Data[]

--- a/src/structures/node.jl
+++ b/src/structures/node.jl
@@ -1,8 +1,10 @@
 """ `Node` as supertype for all technologies."""
-abstract type Node end
+abstract type Node <: AbstractElement end
 Base.show(io::IO, n::Node) = print(io, "n_$(n.id)")
 
 """
+    abstract type StorageBehavior
+
 `StorageBehavior` as supertype for individual storage behaviours.
 
 Storage behaviour is used to identify how a storage node should behave within the individual
@@ -11,7 +13,7 @@ Storage behaviour is used to identify how a storage node should behave within th
 abstract type StorageBehavior end
 
 """
-    Accumulating <: StorageBehavior
+    abstract type Accumulating <: StorageBehavior
 
 `Accumulating` as supertype for an accumulating storage level.
 
@@ -24,7 +26,7 @@ permanently stored or multi year hydropower magazines.
 abstract type Accumulating <: StorageBehavior end
 
 """
-    Cyclic <: StorageBehavior
+    abstract type Cyclic <: StorageBehavior
 
 `Cyclic` as supertype for a cyclic storage level.
 
@@ -34,7 +36,7 @@ period behaves cyclic.
 abstract type Cyclic <: StorageBehavior end
 
 """
-    AccumulatingEmissions <: Accumulating
+    struct AccumulatingEmissions <: Accumulating
 
 `StorageBehavior` which accumulates all inflow witin a strategic period.
 `AccumulatingEmissions` allows as well to serve as a [`ResourceEmit`](@ref) emission point to
@@ -43,7 +45,7 @@ represent a soft constraint on storing the captured emissions.
 struct AccumulatingEmissions <: Accumulating end
 
 """
-    CyclicRepresentative <: Cyclic
+    struct CyclicRepresentative <: Cyclic
 
 `StorageBehavior` in which cyclic behaviour is achieved within the lowest time structure
 excluding operational times.
@@ -55,7 +57,7 @@ In the case of `TwoLevel{RepresentativePeriods{SimpleTimes}}`, this approach dif
 struct CyclicRepresentative <: Cyclic end
 
 """
-    CyclicStrategic <: Cyclic
+    struct CyclicStrategic <: Cyclic
 
 `StorageBehavior` in which the the cyclic behaviour is achieved within a strategic period.
 This implies that the initial level in individual representative periods can be different
@@ -73,7 +75,7 @@ discharging.
 abstract type AbstractStorageParameters end
 
 """
-    StorCapOpex <: AbstractStorageParameters
+    struct StorCapOpex <: AbstractStorageParameters
 
 A storage parameter type for including a capacity as well as variable and fixed operational
 expenditures.
@@ -92,7 +94,7 @@ struct StorCapOpex <: AbstractStorageParameters
 end
 
 """
-    StorCap <: AbstractStorageParameters
+    struct StorCap <: AbstractStorageParameters
 
 A storage parameter type for including only a capacity. This implies that neither the usage
 of the [`Storage`](@ref), nor the installed capacity have a direct impact on the objective function.
@@ -105,7 +107,7 @@ struct StorCap <: AbstractStorageParameters
 end
 
 """
-    StorCap <: AbstractStorageParameters
+    struct StorCapOpexVar <: AbstractStorageParameters
 
 A storage parameter type for including a capacity and variable operational expenditures.
 This implies that the installed capacity has no direct impact on the objective function.
@@ -121,7 +123,7 @@ struct StorCapOpexVar <: AbstractStorageParameters
 end
 
 """
-    StorCapOpexFixed <: AbstractStorageParameters
+    struct StorCapOpexFixed <: AbstractStorageParameters
 
 A storage parameter type for including a capacity and fixed operational expenditures.
 This implies that the installed capacity has no direct impact on the objective function.
@@ -137,7 +139,7 @@ struct StorCapOpexFixed <: AbstractStorageParameters
 end
 
 """
-    StorCap <: AbstractStorageParameters
+    struct StorOpexVar <: AbstractStorageParameters
 
 A storage parameter type for including variable operational expenditures.
 This implies that the charge or discharge rate do not have a capacity and the [`Storage`](@ref)
@@ -174,19 +176,39 @@ Union for simpler dispatching for storage parameters that include a capacity.
 """
 UnionCapacity = Union{StorCapOpex,StorCap,StorCapOpexVar,StorCapOpexFixed}
 
-""" `Source` node with only output."""
+"""
+    abstract type Source <: Node
+
+A `Node` with only output.
+"""
 abstract type Source <: Node end
-""" `NetworkNode` node with both input and output."""
+"""
+    abstract type NetworkNode <: Node
+
+A `Node` with both input and output.
+"""
 abstract type NetworkNode <: Node end
-""" `Sink` node with only input."""
+"""
+    abstract type Sink <: Node
+
+A `Node` with only input.
+"""
 abstract type Sink <: Node end
-""" `Storage` node with level."""
+"""
+    abstract type Storage{T<:StorageBehavior} <: NetworkNode
+
+A `NetworkNode` with a storage level.
+"""
 abstract type Storage{T<:StorageBehavior} <: NetworkNode end
-""" `Availability` node as routing node."""
+"""
+    abstract type Availability <: NetworkNode
+
+A `NetworkNode` as routing node.
+"""
 abstract type Availability <: NetworkNode end
 
 """
-    RefSource <: Source
+    struct RefSource <: Source
 
 A reference [`Source`](@ref) node.
 The reference [`Source`](@ref) node allows for a time varying capacity which is normalized to a
@@ -225,7 +247,7 @@ function RefSource(
 end
 
 """
-    RefNetworkNode <: NetworkNode
+    struct RefNetworkNode <: NetworkNode
 
 A reference [`NetworkNode`](@ref) node.
 The `RefNetworkNode` utilizes a linear, time independent conversion rate of the `input`
@@ -268,7 +290,7 @@ function RefNetworkNode(
 end
 
 """
-    GenAvailability <: Availability
+    struct GenAvailability <: Availability
 
 A reference `Availability` node.
 The reference `Availability` node solves the energy balance for all connected flows.
@@ -290,7 +312,7 @@ end
 GenAvailability(id, 𝒫::Vector{<:Resource}) = GenAvailability(id, 𝒫, 𝒫)
 
 """
-    RefStorage{T} <: Storage{T}
+    struct RefStorage{T} <: Storage{T}
 
 A reference [`Storage`](@ref) node.
 
@@ -341,7 +363,7 @@ function RefStorage{T}(
 end
 
 """
-    RefSink <: Sink
+    struct RefSink <: Sink
 
 A reference [`Sink`](@ref) node. This node corresponds to a demand given by the field `cap`.
 The penalties introduced in the field `penalty` affect the variable OPEX for both a surplus

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,16 +1,11 @@
 """
-    run_model(case::Dict, model::EnergyModel, optimizer)
+    run_model(case::EMXCase, model::EnergyModel, optimizer; check_timeprofiles = true)
 
-Take the `case` data as a dictionary and the `model` and build and optimize the model.
+Take the `case` data, the `model` description, and an `optimizer` to build and optimize the
+model.
 Returns the solved JuMP model.
-
-The dictionary requires the keys:
- - `:nodes::Vector{Node}`
- - `:links::Vector{Link}`
- - `:products::Vector{Resource}`
- - `:T::TimeStructure`
 """
-function run_model(case::Dict, model, optimizer; check_timeprofiles = true)
+function run_model(case::EMXCase, model, optimizer; check_timeprofiles = true)
     @debug "Run model" optimizer
 
     m = create_model(case, model; check_timeprofiles)
@@ -24,6 +19,14 @@ function run_model(case::Dict, model, optimizer; check_timeprofiles = true)
     else
         @warn "No optimizer given"
     end
+    return m
+end
+function run_model(case::Dict, model, optimizer; check_timeprofiles = true)
+    @debug "Run model" optimizer
+
+    case_new = EMXCase(case[:T], case[:products], [case[:nodes], case[:links]])
+    m = run_model(case_new, model, optimizer; check_timeprofiles)
+
     return m
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,11 +1,11 @@
 """
-    run_model(case::EMXCase, model::EnergyModel, optimizer; check_timeprofiles = true)
+    run_model(case::Case, model::EnergyModel, optimizer; check_timeprofiles = true)
 
 Take the `case` data, the `model` description, and an `optimizer` to build and optimize the
 model.
 Returns the solved JuMP model.
 """
-function run_model(case::EMXCase, model, optimizer; check_timeprofiles = true)
+function run_model(case::Case, model, optimizer; check_timeprofiles = true)
     @debug "Run model" optimizer
 
     m = create_model(case, model; check_timeprofiles)
@@ -24,7 +24,7 @@ end
 function run_model(case::Dict, model, optimizer; check_timeprofiles = true)
     @debug "Run model" optimizer
 
-    case_new = EMXCase(case[:T], case[:products], [case[:nodes], case[:links]])
+    case_new = Case(case[:T], case[:products], [case[:nodes], case[:links]])
     m = run_model(case_new, model, optimizer; check_timeprofiles)
 
     return m

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -46,7 +46,7 @@ function collect_types(types_list)
         types[n] = 1
 
         parent = supertype(n)
-        if parent == Any
+        if parent == Any || parent == AbstractElement
             continue
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,10 @@ ENV["EMB_TEST"] = true # Set flag for example scripts to check if they are run a
         include("test_checks.jl")
     end
 
+    @testset "Base | Deprecation" begin
+        include("test_deprecation.jl")
+    end
+
     @testset "Base | Investments" begin
         include("test_investments.jl")
     end

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -766,7 +766,7 @@ end
     end
 
     # Test that the from and to fields are correctly checked
-    # - check_elements(log_by_element, ℒ::Vector{<:Link}}, 𝒳, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    # - check_elements(log_by_element, ℒ::Vector{<:Link}}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
     case, model = simple_graph()
     av, source, sink = f_nodes(case)
     case.elements[2] = [Direct(12, GenAvailability("test", f_products(case)), sink)]

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -1,69 +1,69 @@
 # Set the global to true to suppress the error message
 EMB.TEST_ENV = true
 
-@testset "Test checks - case dictionary" begin
-    # Resources used in the analysis
-    Power = ResourceCarrier("Power", 0.0)
-    CO2 = ResourceEmit("CO2", 1.0)
+# @testset "Test checks - case dictionary" begin
+#     # Resources used in the analysis
+#     Power = ResourceCarrier("Power", 0.0)
+#     CO2 = ResourceEmit("CO2", 1.0)
 
-    # Function for setting up the system
-    function simple_graph()
-        resources = [Power, CO2]
-        ops = SimpleTimes(5, 2)
-        T = TwoLevel(2, 2, ops; op_per_strat = 10)
+#     # Function for setting up the system
+#     function simple_graph()
+#         resources = [Power, CO2]
+#         ops = SimpleTimes(5, 2)
+#         T = TwoLevel(2, 2, ops; op_per_strat = 10)
 
-        source = RefSource(
-            "source_emit",
-            FixedProfile(4),
-            FixedProfile(0),
-            FixedProfile(10),
-            Dict(Power => 1),
-        )
-        sink = RefSink(
-            "sink",
-            FixedProfile(3),
-            Dict(:surplus => FixedProfile(-4), :deficit => FixedProfile(4)),
-            Dict(Power => 1),
-        )
+#         source = RefSource(
+#             "source_emit",
+#             FixedProfile(4),
+#             FixedProfile(0),
+#             FixedProfile(10),
+#             Dict(Power => 1),
+#         )
+#         sink = RefSink(
+#             "sink",
+#             FixedProfile(3),
+#             Dict(:surplus => FixedProfile(-4), :deficit => FixedProfile(4)),
+#             Dict(Power => 1),
+#         )
 
-        ops = SimpleTimes(5, 2)
-        T = TwoLevel(2, 2, ops; op_per_strat = 10)
+#         ops = SimpleTimes(5, 2)
+#         T = TwoLevel(2, 2, ops; op_per_strat = 10)
 
-        nodes = [source, sink]
-        links = [Direct(12, source, sink)]
-        model = OperationalModel(
-            Dict(CO2 => FixedProfile(100)),
-            Dict(CO2 => FixedProfile(0)),
-            CO2,
-        )
-        case = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
-        return case, model
-    end
+#         nodes = [source, sink]
+#         links = [Direct(12, source, sink)]
+#         model = OperationalModel(
+#             Dict(CO2 => FixedProfile(100)),
+#             Dict(CO2 => FixedProfile(0)),
+#             CO2,
+#         )
+#         case = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
+#         return case, model
+#     end
 
-    # Check that the keys are present
-    # - EMB.check_case_data(case)
-    case, model = simple_graph()
-    for key ∈ keys(case)
-        case_test = deepcopy(case)
-        pop!(case_test, key)
-        @test_throws AssertionError run_model(case_test, model, HiGHS.Optimizer)
-    end
+#     # Check that the keys are present
+#     # - EMB.check_case_data(case)
+#     case, model = simple_graph()
+#     for key ∈ keys(case)
+#         case_test = deepcopy(case)
+#         pop!(case_test, key)
+#         @test_throws AssertionError run_model(case_test, model, HiGHS.Optimizer)
+#     end
 
-    # Check that the keys are of the correct format and do not include any unwanted types
-    # - EMB.check_case_data(case)
-    case_test = deepcopy(case)
-    case_test[:T] = 10
-    @test_throws AssertionError run_model(case_test, model, HiGHS.Optimizer)
-    case_test = deepcopy(case)
-    case_test[:nodes] = [case[:nodes], case[:nodes], 10]
-    @test_throws AssertionError run_model(case_test, model, HiGHS.Optimizer)
-    case_test = deepcopy(case)
-    case_test[:links] = [case[:links], 10]
-    @test_throws AssertionError run_model(case_test, model, HiGHS.Optimizer)
-    case_test = deepcopy(case)
-    case_test[:products] = [case[:products], case[:products], 10]
-    @test_throws AssertionError run_model(case_test, model, HiGHS.Optimizer)
-end
+#     # Check that the keys are of the correct format and do not include any unwanted types
+#     # - EMB.check_case_data(case)
+#     case_test = deepcopy(case)
+#     case_test[:T] = 10
+#     @test_throws AssertionError run_model(case_test, model, HiGHS.Optimizer)
+#     case_test = deepcopy(case)
+#     case_test[:nodes] = [case[:nodes], case[:nodes], 10]
+#     @test_throws AssertionError run_model(case_test, model, HiGHS.Optimizer)
+#     case_test = deepcopy(case)
+#     case_test[:links] = [case[:links], 10]
+#     @test_throws AssertionError run_model(case_test, model, HiGHS.Optimizer)
+#     case_test = deepcopy(case)
+#     case_test[:products] = [case[:products], case[:products], 10]
+#     @test_throws AssertionError run_model(case_test, model, HiGHS.Optimizer)
+# end
 
 @testset "Test checks - modeltype" begin
     # Resources used in the analysis

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -38,16 +38,16 @@ EMB.TEST_ENV = true
 
     # Check that the individual elements vector are unique
     # - EMB.check_case_data(case)
-    case_test = EMXCase(T, resources, [nodes, [nodes[1]], links])
+    case_test = Case(T, resources, [nodes, [nodes[1]], links])
     @test_throws AssertionError create_model(case_test, model)
-    case_test = EMXCase(T, resources, [nodes, [nodes[2]], links])
+    case_test = Case(T, resources, [nodes, [nodes[2]], links])
     @test_throws AssertionError create_model(case_test, model)
-    case_test = EMXCase(T, resources, [nodes, [links[1]], links])
+    case_test = Case(T, resources, [nodes, [links[1]], links])
     @test_throws AssertionError create_model(case_test, model)
 
     # Check that the couplings return non_empty vectors
     # - EMB.check_case_data(case)
-    case_test = EMXCase(T, resources, [nodes, Link[]], [[f_nodes, f_links]])
+    case_test = Case(T, resources, [nodes, Link[]], [[f_nodes, f_links]])
     @test_throws AssertionError create_model(case_test, model)
 end
 
@@ -81,7 +81,7 @@ end
 
         nodes = [source, sink]
         links = [Direct(12, source, sink)]
-        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
         return case
     end
 
@@ -177,7 +177,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
         return case, model
     end
 
@@ -250,7 +250,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
         return case, model
     end
 
@@ -379,7 +379,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
         return create_model(case, model), case, model
     end
 
@@ -534,7 +534,7 @@ end
             Dict(CO2 => FixedProfile(0), NG => FixedProfile(0)),
             CO2,
         )
-        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
         return create_model(case, model), case, model
     end
 
@@ -641,7 +641,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
         return create_model(case, model), case, model
     end
 
@@ -761,7 +761,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
         return case, model
     end
 

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -47,7 +47,7 @@ EMB.TEST_ENV = true
 
     # Check that the couplings return non_empty vectors
     # - EMB.check_case_data(case)
-    case_test = Case(T, resources, [nodes, Link[]], [[f_nodes, f_links]])
+    case_test = Case(T, resources, [nodes, Link[]], [[get_nodes, get_links]])
     @test_throws AssertionError create_model(case_test, model)
 end
 
@@ -81,7 +81,7 @@ end
 
         nodes = [source, sink]
         links = [Direct(12, source, sink)]
-        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
         return case
     end
 
@@ -177,7 +177,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
         return case, model
     end
 
@@ -250,7 +250,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
         return case, model
     end
 
@@ -379,7 +379,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
         return create_model(case, model), case, model
     end
 
@@ -534,7 +534,7 @@ end
             Dict(CO2 => FixedProfile(0), NG => FixedProfile(0)),
             CO2,
         )
-        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
         return create_model(case, model), case, model
     end
 
@@ -641,7 +641,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
         return create_model(case, model), case, model
     end
 
@@ -761,17 +761,17 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
         return case, model
     end
 
     # Test that the from and to fields are correctly checked
     # - check_elements(log_by_element, ℒ::Vector{<:Link}}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
     case, model = simple_graph()
-    av, source, sink = f_nodes(case)
-    case.elements[2] = [Direct(12, GenAvailability("test", f_products(case)), sink)]
+    av, source, sink = get_nodes(case)
+    case.elements[2] = [Direct(12, GenAvailability("test", get_products(case)), sink)]
     @test_throws AssertionError create_model(case, model)
-    case.elements[2] = [Direct(12, source, GenAvailability("test", f_products(case)))]
+    case.elements[2] = [Direct(12, source, GenAvailability("test", get_products(case)))]
     @test_throws AssertionError create_model(case, model)
     case.elements[2] = [Direct(12, av, source)]
     @test_throws AssertionError create_model(case, model)

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -1,69 +1,55 @@
 # Set the global to true to suppress the error message
 EMB.TEST_ENV = true
 
-# @testset "Test checks - case dictionary" begin
-#     # Resources used in the analysis
-#     Power = ResourceCarrier("Power", 0.0)
-#     CO2 = ResourceEmit("CO2", 1.0)
+@testset "Test checks - case type" begin
+    # Resources used in the analysis
+    Power = ResourceCarrier("Power", 0.0)
+    CO2 = ResourceEmit("CO2", 1.0)
 
-#     # Function for setting up the system
-#     function simple_graph()
-#         resources = [Power, CO2]
-#         ops = SimpleTimes(5, 2)
-#         T = TwoLevel(2, 2, ops; op_per_strat = 10)
+    # Setting up the system
+    resources = [Power, CO2]
+    ops = SimpleTimes(5, 2)
+    T = TwoLevel(2, 2, ops; op_per_strat = 10)
 
-#         source = RefSource(
-#             "source_emit",
-#             FixedProfile(4),
-#             FixedProfile(0),
-#             FixedProfile(10),
-#             Dict(Power => 1),
-#         )
-#         sink = RefSink(
-#             "sink",
-#             FixedProfile(3),
-#             Dict(:surplus => FixedProfile(-4), :deficit => FixedProfile(4)),
-#             Dict(Power => 1),
-#         )
+    source = RefSource(
+        "source_emit",
+        FixedProfile(4),
+        FixedProfile(0),
+        FixedProfile(10),
+        Dict(Power => 1),
+    )
+    sink = RefSink(
+        "sink",
+        FixedProfile(3),
+        Dict(:surplus => FixedProfile(-4), :deficit => FixedProfile(4)),
+        Dict(Power => 1),
+    )
 
-#         ops = SimpleTimes(5, 2)
-#         T = TwoLevel(2, 2, ops; op_per_strat = 10)
+    ops = SimpleTimes(5, 2)
+    T = TwoLevel(2, 2, ops; op_per_strat = 10)
 
-#         nodes = [source, sink]
-#         links = [Direct(12, source, sink)]
-#         model = OperationalModel(
-#             Dict(CO2 => FixedProfile(100)),
-#             Dict(CO2 => FixedProfile(0)),
-#             CO2,
-#         )
-#         case = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
-#         return case, model
-#     end
+    nodes = [source, sink]
+    links = Link[Direct(12, source, sink)]
+    model = OperationalModel(
+        Dict(CO2 => FixedProfile(100)),
+        Dict(CO2 => FixedProfile(0)),
+        CO2,
+    )
 
-#     # Check that the keys are present
-#     # - EMB.check_case_data(case)
-#     case, model = simple_graph()
-#     for key ∈ keys(case)
-#         case_test = deepcopy(case)
-#         pop!(case_test, key)
-#         @test_throws AssertionError run_model(case_test, model, HiGHS.Optimizer)
-#     end
+    # Check that the individual elements vector are unique
+    # - EMB.check_case_data(case)
+    case_test = EMXCase(T, resources, [nodes, [nodes[1]], links])
+    @test_throws AssertionError create_model(case_test, model)
+    case_test = EMXCase(T, resources, [nodes, [nodes[2]], links])
+    @test_throws AssertionError create_model(case_test, model)
+    case_test = EMXCase(T, resources, [nodes, [links[1]], links])
+    @test_throws AssertionError create_model(case_test, model)
 
-#     # Check that the keys are of the correct format and do not include any unwanted types
-#     # - EMB.check_case_data(case)
-#     case_test = deepcopy(case)
-#     case_test[:T] = 10
-#     @test_throws AssertionError run_model(case_test, model, HiGHS.Optimizer)
-#     case_test = deepcopy(case)
-#     case_test[:nodes] = [case[:nodes], case[:nodes], 10]
-#     @test_throws AssertionError run_model(case_test, model, HiGHS.Optimizer)
-#     case_test = deepcopy(case)
-#     case_test[:links] = [case[:links], 10]
-#     @test_throws AssertionError run_model(case_test, model, HiGHS.Optimizer)
-#     case_test = deepcopy(case)
-#     case_test[:products] = [case[:products], case[:products], 10]
-#     @test_throws AssertionError run_model(case_test, model, HiGHS.Optimizer)
-# end
+    # Check that the couplings return non_empty vectors
+    # - EMB.check_case_data(case)
+    case_test = EMXCase(T, resources, [nodes, Link[]], [[f_nodes, f_links]])
+    @test_throws AssertionError create_model(case_test, model)
+end
 
 @testset "Test checks - modeltype" begin
     # Resources used in the analysis

--- a/test/test_deprecation.jl
+++ b/test/test_deprecation.jl
@@ -1,0 +1,61 @@
+
+@testset "create_model" begin
+    """
+        simple_graph()
+
+    Creates a simple test case for testing that the deprecation is working correctly.
+    """
+    function simple_graph()
+        source = RefSource(
+            "source",
+            FixedProfile(4),
+            FixedProfile(2),
+            FixedProfile(10),
+            Dict(Power => 1.5),
+        )
+        sink = RefSink(
+            "sink",
+            OperationalProfile([6, 8, 10, 6, 8]),
+            Dict(:surplus => FixedProfile(4), :deficit => FixedProfile(10)),
+            Dict(Power => 1),
+        )
+        resources = [Power, CO2]
+        ops = SimpleTimes(5, 2)
+        op_per_strat = 10
+        T = TwoLevel(2, 2, ops; op_per_strat)
+
+        nodes = [source, sink]
+        links = [Direct(12, source, sink)]
+        model = OperationalModel(
+            Dict(CO2 => FixedProfile(100)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2,
+        )
+
+        # Input data structures
+        case_old = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
+        case_new = EMXCase(
+            T,
+            resources,
+            [nodes, links],
+            [[f_nodes, f_links]],
+        )
+        return case_new, case_old, model
+    end
+    # Receive the case descriptions
+    case_new, case_old, model = simple_graph()
+
+    # Create models based on both input and optimize it
+    m_new = run_model(case_new, model, HiGHS.Optimizer)
+    m_old_1 = run_model(case_old, model, HiGHS.Optimizer)
+    m_old_2 = create_model(case_old, model)
+    set_optimizer(m_old_2, HiGHS.Optimizer)
+    set_optimizer_attribute(m_old_2, MOI.Silent(), true)
+    optimize!(m_old_2)
+
+    # Test that the results are the same
+    @test objective_value(m_old_1) ≈ objective_value(m_new)
+    @test size(all_variables(m_old_1))[1] == size(all_variables(m_new))[1]
+    @test objective_value(m_old_2) ≈ objective_value(m_new)
+    @test size(all_variables(m_old_2))[1] == size(all_variables(m_new))[1]
+end

--- a/test/test_deprecation.jl
+++ b/test/test_deprecation.jl
@@ -38,7 +38,7 @@
             T,
             resources,
             [nodes, links],
-            [[f_nodes, f_links]],
+            [[get_nodes, get_links]],
         )
         return case_new, case_old, model
     end

--- a/test/test_deprecation.jl
+++ b/test/test_deprecation.jl
@@ -34,7 +34,7 @@
 
         # Input data structures
         case_old = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
-        case_new = EMXCase(
+        case_new = Case(
             T,
             resources,
             [nodes, links],

--- a/test/test_general.jl
+++ b/test/test_general.jl
@@ -73,7 +73,7 @@ function generate_data()
     )
 
     # Input data structure
-    case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     return case, model
 end
 
@@ -82,14 +82,14 @@ end
     m = run_model(case, model, HiGHS.Optimizer)
 
     # Retrieve data from the case structure
-    𝒫 = f_products(case)
+    𝒫 = get_products(case)
     NG = 𝒫[1]
     CO2 = 𝒫[4]
 
-    𝒯 = f_time_struct(case)
+    𝒯 = get_time_struct(case)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-    𝒩 = f_nodes(case)
+    𝒩 = get_nodes(case)
     𝒩ⁿᵒᵗ = EMB.nodes_not_av(𝒩)
     𝒩ᵉᵐ = nodes_emissions(𝒩)
     avail = 𝒩[1]
@@ -98,7 +98,7 @@ end
     CO2_stor = 𝒩[6]
     demand = 𝒩[7]
 
-    ℒ = f_links(case)
+    ℒ = get_links(case)
 
     # Check for the objective value
     # (*2 compared to 0.6.0 due to change in strategic period duration)

--- a/test/test_general.jl
+++ b/test/test_general.jl
@@ -73,7 +73,7 @@ function generate_data()
     )
 
     # Input data structure
-    case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
+    case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
     return case, model
 end
 

--- a/test/test_general.jl
+++ b/test/test_general.jl
@@ -72,8 +72,8 @@ function generate_data()
         CO2,
     )
 
-    # WIP data structure
-    case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+    # Input data structure
+    case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
     return case, model
 end
 
@@ -82,14 +82,14 @@ end
     m = run_model(case, model, HiGHS.Optimizer)
 
     # Retrieve data from the case structure
-    𝒫 = case[:products]
+    𝒫 = f_products(case)
     NG = 𝒫[1]
     CO2 = 𝒫[4]
 
-    𝒯 = case[:T]
+    𝒯 = f_time_struct(case)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-    𝒩 = case[:nodes]
+    𝒩 = f_nodes(case)
     𝒩ⁿᵒᵗ = EMB.nodes_not_av(𝒩)
     𝒩ᵉᵐ = nodes_emissions(𝒩)
     avail = 𝒩[1]
@@ -98,7 +98,7 @@ end
     CO2_stor = 𝒩[6]
     demand = 𝒩[7]
 
-    ℒ = case[:links]
+    ℒ = f_links(case)
 
     # Check for the objective value
     # (*2 compared to 0.6.0 due to change in strategic period duration)

--- a/test/test_investments.jl
+++ b/test/test_investments.jl
@@ -212,7 +212,7 @@ using EnergyModelsInvestments
         modeltype = InvestmentModel(em_limits, em_cost, CO2, 0.07)
 
         # Input data structure
-        case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
         return case, modeltype
     end
 
@@ -230,8 +230,8 @@ using EnergyModelsInvestments
     @test round(objective_value(m)) ≈ -302624
 
     # Test that investments are happening
-    𝒯ᴵⁿᵛ = strategic_periods(f_time_struct(case))
-    𝒩 = f_nodes(case)
+    𝒯ᴵⁿᵛ = strategic_periods(get_time_struct(case))
+    𝒩 = get_nodes(case)
     𝒩ᴵⁿᵛ = filter(has_investment, filter(!EMB.is_storage, 𝒩))
     𝒩ˢᵗᵒʳ = filter(EMB.is_storage, 𝒩)
     𝒩ˡᵉᵛᵉˡ = filter(n -> has_investment(n, :level), 𝒩ˢᵗᵒʳ)
@@ -327,14 +327,14 @@ end
         modeltype = InvestmentModel(em_limits, em_cost, CO2, 0.0)
 
         # Input data structure
-        case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
         return run_model(case, modeltype, HiGHS.Optimizer), case, modeltype
     end
 
     m, case, model = link_inv_graph()
-    ℒ = f_links(case)
-    𝒩 = f_nodes(case)
-    𝒯 = f_time_struct(case)
+    ℒ = get_links(case)
+    𝒩 = get_nodes(case)
+    𝒯 = get_time_struct(case)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # Test for the total number of variables
@@ -417,7 +417,7 @@ EMB.TEST_ENV = true
             nodes = [source, sink]
             links = [Direct("scr-sink", nodes[1], nodes[2], Linear())]
             T = TwoLevel(4, 10, SimpleTimes(4, 1))
-            case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
+            case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
 
             em_limits = Dict(CO2 => StrategicProfile([450, 400, 350, 300]))
             em_cost = Dict(CO2 => FixedProfile(0))
@@ -554,7 +554,7 @@ EMB.TEST_ENV = true
                 Direct("stor-snk", nodes[2], nodes[3], Linear())
             ]
             T = TwoLevel(4, 10, SimpleTimes(4, 1))
-            case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
+            case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
 
             em_limits = Dict(CO2 => StrategicProfile([450, 400, 350, 300]))
             em_cost = Dict(CO2 => FixedProfile(0))
@@ -681,7 +681,7 @@ EMB.TEST_ENV = true
             nodes = [source, sink]
             links = [InvDirect("scr-sink", nodes[1], nodes[2], Linear(), inv_data)]
             T = TwoLevel(4, 10, SimpleTimes(4, 1))
-            case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
+            case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
 
             em_limits = Dict(CO2 => StrategicProfile([450, 400, 350, 300]))
             em_cost = Dict(CO2 => FixedProfile(0))

--- a/test/test_investments.jl
+++ b/test/test_investments.jl
@@ -211,8 +211,8 @@ using EnergyModelsInvestments
         em_cost = Dict(NG => FixedProfile(0), CO2 => FixedProfile(0))
         modeltype = InvestmentModel(em_limits, em_cost, CO2, 0.07)
 
-        # WIP case structure
-        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+        # Input data structure
+        case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
         return case, modeltype
     end
 
@@ -230,8 +230,8 @@ using EnergyModelsInvestments
     @test round(objective_value(m)) ≈ -302624
 
     # Test that investments are happening
-    𝒯ᴵⁿᵛ = strategic_periods(case[:T])
-    𝒩 = case[:nodes]
+    𝒯ᴵⁿᵛ = strategic_periods(f_time_struct(case))
+    𝒩 = f_nodes(case)
     𝒩ᴵⁿᵛ = filter(has_investment, filter(!EMB.is_storage, 𝒩))
     𝒩ˢᵗᵒʳ = filter(EMB.is_storage, 𝒩)
     𝒩ˡᵉᵛᵉˡ = filter(n -> has_investment(n, :level), 𝒩ˢᵗᵒʳ)
@@ -326,15 +326,15 @@ end
         em_cost = Dict(CO2 => FixedProfile(0))
         modeltype = InvestmentModel(em_limits, em_cost, CO2, 0.0)
 
-        # WIP case structure
-        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+        # Input data structure
+        case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
         return run_model(case, modeltype, HiGHS.Optimizer), case, modeltype
     end
 
     m, case, model = link_inv_graph()
-    ℒ = case[:links]
-    𝒩 = case[:nodes]
-    𝒯 = case[:T]
+    ℒ = f_links(case)
+    𝒩 = f_nodes(case)
+    𝒯 = f_time_struct(case)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # Test for the total number of variables
@@ -417,7 +417,7 @@ EMB.TEST_ENV = true
             nodes = [source, sink]
             links = [Direct("scr-sink", nodes[1], nodes[2], Linear())]
             T = TwoLevel(4, 10, SimpleTimes(4, 1))
-            case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+            case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
 
             em_limits = Dict(CO2 => StrategicProfile([450, 400, 350, 300]))
             em_cost = Dict(CO2 => FixedProfile(0))
@@ -554,7 +554,7 @@ EMB.TEST_ENV = true
                 Direct("stor-snk", nodes[2], nodes[3], Linear())
             ]
             T = TwoLevel(4, 10, SimpleTimes(4, 1))
-            case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+            case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
 
             em_limits = Dict(CO2 => StrategicProfile([450, 400, 350, 300]))
             em_cost = Dict(CO2 => FixedProfile(0))
@@ -681,7 +681,7 @@ EMB.TEST_ENV = true
             nodes = [source, sink]
             links = [InvDirect("scr-sink", nodes[1], nodes[2], Linear(), inv_data)]
             T = TwoLevel(4, 10, SimpleTimes(4, 1))
-            case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+            case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
 
             em_limits = Dict(CO2 => StrategicProfile([450, 400, 350, 300]))
             em_cost = Dict(CO2 => FixedProfile(0))

--- a/test/test_investments.jl
+++ b/test/test_investments.jl
@@ -212,7 +212,7 @@ using EnergyModelsInvestments
         modeltype = InvestmentModel(em_limits, em_cost, CO2, 0.07)
 
         # Input data structure
-        case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
         return case, modeltype
     end
 
@@ -327,7 +327,7 @@ end
         modeltype = InvestmentModel(em_limits, em_cost, CO2, 0.0)
 
         # Input data structure
-        case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
         return run_model(case, modeltype, HiGHS.Optimizer), case, modeltype
     end
 
@@ -417,7 +417,7 @@ EMB.TEST_ENV = true
             nodes = [source, sink]
             links = [Direct("scr-sink", nodes[1], nodes[2], Linear())]
             T = TwoLevel(4, 10, SimpleTimes(4, 1))
-            case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
+            case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
 
             em_limits = Dict(CO2 => StrategicProfile([450, 400, 350, 300]))
             em_cost = Dict(CO2 => FixedProfile(0))
@@ -554,7 +554,7 @@ EMB.TEST_ENV = true
                 Direct("stor-snk", nodes[2], nodes[3], Linear())
             ]
             T = TwoLevel(4, 10, SimpleTimes(4, 1))
-            case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
+            case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
 
             em_limits = Dict(CO2 => StrategicProfile([450, 400, 350, 300]))
             em_cost = Dict(CO2 => FixedProfile(0))
@@ -681,7 +681,7 @@ EMB.TEST_ENV = true
             nodes = [source, sink]
             links = [InvDirect("scr-sink", nodes[1], nodes[2], Linear(), inv_data)]
             T = TwoLevel(4, 10, SimpleTimes(4, 1))
-            case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
+            case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
 
             em_limits = Dict(CO2 => StrategicProfile([450, 400, 350, 300]))
             em_cost = Dict(CO2 => FixedProfile(0))

--- a/test/test_investments.jl
+++ b/test/test_investments.jl
@@ -275,6 +275,7 @@ end
         )
         constraints_capacity_installed(m, l, 𝒯, modeltype)
     end
+    EMB.capacity(l::InvDirect) = FixedProfile(0)
     EMB.capacity(l::InvDirect, t) = 0
     EMB.has_capacity(l::InvDirect) = true
     EMB.link_data(l::InvDirect) = l.data
@@ -375,7 +376,6 @@ end
 EMB.TEST_ENV = true
 
 @testset "Test checks - InvestmentData" begin
-
     # Testing, that the checks for NoStartInvData and StartInvData are working
     # - EMB.check_node_data(n::EMB.Node, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel)
     @testset "SingleInvData" begin
@@ -639,6 +639,75 @@ EMB.TEST_ENV = true
         # Check that we receive an error if we provide a larger `min_add` than `max_add`
         min_add = FixedProfile(20)
         @test_throws AssertionError build_simple_graph(;min_add)
+    end
+
+    # Testing, that the checks for Links are working
+    # - EMB.check_link_data(n::Link, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel)
+    @testset "SingleInvData" begin
+
+        function build_simple_graph(;
+            cap = FixedProfile(0),
+            min_add = FixedProfile(0),
+            max_add = FixedProfile(10),
+            inv_data = nothing,
+        )
+            if isnothing(inv_data)
+                inv_data = [
+                    SingleInvData(
+                        FixedProfile(1000),     # capex [€/kW]
+                        FixedProfile(30),       # max installed capacity [kW]
+                        ContinuousInvestment(min_add, max_add),   # investment mode
+                    ),
+                ]
+            end
+
+            CO2 = ResourceEmit("CO2", 1.0)
+            Power = ResourceCarrier("Power", 0.0)
+            products = [Power, CO2]
+
+            source = RefSource(
+                "-src",
+                cap,
+                FixedProfile(10),
+                FixedProfile(5),
+                Dict(Power => 1),
+            )
+            sink = RefSink(
+                "-snk",
+                FixedProfile(20),
+                Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e4)),
+                Dict(Power => 1),
+            )
+            nodes = [source, sink]
+            links = [InvDirect("scr-sink", nodes[1], nodes[2], Linear(), inv_data)]
+            T = TwoLevel(4, 10, SimpleTimes(4, 1))
+            case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+
+            em_limits = Dict(CO2 => StrategicProfile([450, 400, 350, 300]))
+            em_cost = Dict(CO2 => FixedProfile(0))
+            modeltype = InvestmentModel(em_limits, em_cost, CO2, 0.05)
+
+            return create_model(case, modeltype)
+        end
+
+        # Check that we receive an error if we provide two `InvestmentData`
+        inv_data = [
+            SingleInvData(
+                FixedProfile(1000),     # capex [€/kW]
+                FixedProfile(30),       # max installed capacity [kW]
+                ContinuousInvestment(FixedProfile(0), FixedProfile(20)), # investment mode
+            ),
+            SingleInvData(
+                FixedProfile(1000),     # capex [€/kW]
+                FixedProfile(30),       # max installed capacity [kW]
+                ContinuousInvestment(FixedProfile(0), FixedProfile(20)),   # investment mode
+            ),
+        ]
+        @test_throws AssertionError build_simple_graph(;inv_data)
+
+        # Check that the correct subtroutine is called
+        max_add = RepresentativeProfile([FixedProfile(4)])
+        @test_throws AssertionError build_simple_graph(;max_add)
     end
 end
 

--- a/test/test_links.jl
+++ b/test/test_links.jl
@@ -48,7 +48,7 @@
             Dict(CO2 => FixedProfile(0), NG => FixedProfile(0)),
             CO2,
         )
-        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
         return case, model
     end
 
@@ -143,7 +143,7 @@ function link_graph(LinkType::Vector{DataType})
         Dict(CO2 => FixedProfile(0)),
         CO2,
     )
-    case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
+    case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
     return run_model(case, model, HiGHS.Optimizer), case, model
 end
 

--- a/test/test_links.jl
+++ b/test/test_links.jl
@@ -48,13 +48,13 @@
             Dict(CO2 => FixedProfile(0), NG => FixedProfile(0)),
             CO2,
         )
-        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
         return case, model
     end
 
     @testset "Identification functions" begin
         case, model = simple_graph()
-        ℒ = f_links(case)
+        ℒ = get_links(case)
 
         # Test that all links are identified as unidirectional
         @test all(is_unidirectional(l) for l ∈ ℒ)
@@ -68,8 +68,8 @@
 
     @testset "Access functions" begin
         case, model = simple_graph()
-        ℒ = f_links(case)
-        𝒩 = f_nodes(case)
+        ℒ = get_links(case)
+        𝒩 = get_nodes(case)
 
         # Test that the tranported resources are correctly identified
         @test inputs(ℒ[1]) == outputs(𝒩[1])
@@ -88,8 +88,8 @@
     @testset "Variable declaration" begin
         case, model = simple_graph()
         m = create_model(case, model)
-        ℒ = f_links(case)
-        𝒯 = f_time_struct(case)
+        ℒ = get_links(case)
+        𝒯 = get_time_struct(case)
 
         # Test that all link variables have a lower bound of 0
         @test all(
@@ -143,7 +143,7 @@ function link_graph(LinkType::Vector{DataType})
         Dict(CO2 => FixedProfile(0)),
         CO2,
     )
-    case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
+    case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
     return run_model(case, model, HiGHS.Optimizer), case, model
 end
 
@@ -171,9 +171,9 @@ end
 
     # Create and solve the system
     m, case, model = link_graph([EmissionDirect])
-    ℒ = f_links(case)
-    𝒩 = f_nodes(case)
-    𝒯 = f_time_struct(case)
+    ℒ = get_links(case)
+    𝒩 = get_nodes(case)
+    𝒯 = get_time_struct(case)
 
     # Test that `emissions_link` variable is not empty
     @test !isempty(m[:emissions_link])
@@ -210,9 +210,9 @@ end
 
     # Create and solve the system
     m, case, model = link_graph([OpexDirect])
-    ℒ = f_links(case)
-    𝒩 = f_nodes(case)
-    𝒯 = f_time_struct(case)
+    ℒ = get_links(case)
+    𝒩 = get_nodes(case)
+    𝒯 = get_time_struct(case)
 
     # Test that `link_opex_var` and `link_opex_fixed` are not empty
     @test !isempty(m[:link_opex_var])
@@ -252,9 +252,9 @@ end
 
     # Create and solve the system
     m, case, model = link_graph([CapDirect])
-    ℒ = f_links(case)
-    𝒩 = f_nodes(case)
-    𝒯 = f_time_struct(case)
+    ℒ = get_links(case)
+    𝒩 = get_nodes(case)
+    𝒯 = get_time_struct(case)
 
     # Helper for usage
     cap = OperationalProfile([2, 3, 3, 2, 1])
@@ -306,9 +306,9 @@ end
 
     # Create and solve the system
     m, case, model = link_graph([DirectSub1, DirectSub2, Direct1])
-    ℒ = f_links(case)
-    𝒩 = f_nodes(case)
-    𝒯 = f_time_struct(case)
+    ℒ = get_links(case)
+    𝒩 = get_nodes(case)
+    𝒯 = get_time_struct(case)
 
     # Test that `test_var_sub`, `test_var_sub_1`, and `test_var_1` are created
     @test haskey(object_dictionary(m), :test_var_sub)

--- a/test/test_links.jl
+++ b/test/test_links.jl
@@ -48,13 +48,13 @@
             Dict(CO2 => FixedProfile(0), NG => FixedProfile(0)),
             CO2,
         )
-        case = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
+        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
         return case, model
     end
 
     @testset "Identification functions" begin
         case, model = simple_graph()
-        ℒ = case[:links]
+        ℒ = f_links(case)
 
         # Test that all links are identified as unidirectional
         @test all(is_unidirectional(l) for l ∈ ℒ)
@@ -68,8 +68,8 @@
 
     @testset "Access functions" begin
         case, model = simple_graph()
-        ℒ = case[:links]
-        𝒩 = case[:nodes]
+        ℒ = f_links(case)
+        𝒩 = f_nodes(case)
 
         # Test that the tranported resources are correctly identified
         @test inputs(ℒ[1]) == outputs(𝒩[1])
@@ -88,8 +88,8 @@
     @testset "Variable declaration" begin
         case, model = simple_graph()
         m = create_model(case, model)
-        ℒ = case[:links]
-        𝒯 = case[:T]
+        ℒ = f_links(case)
+        𝒯 = f_time_struct(case)
 
         # Test that all link variables have a lower bound of 0
         @test all(
@@ -143,7 +143,7 @@ function link_graph(LinkType::Vector{DataType})
         Dict(CO2 => FixedProfile(0)),
         CO2,
     )
-    case = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
+    case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
     return run_model(case, model, HiGHS.Optimizer), case, model
 end
 
@@ -171,9 +171,9 @@ end
 
     # Create and solve the system
     m, case, model = link_graph([EmissionDirect])
-    ℒ = case[:links]
-    𝒩 = case[:nodes]
-    𝒯 = case[:T]
+    ℒ = f_links(case)
+    𝒩 = f_nodes(case)
+    𝒯 = f_time_struct(case)
 
     # Test that `emissions_link` variable is not empty
     @test !isempty(m[:emissions_link])
@@ -210,9 +210,9 @@ end
 
     # Create and solve the system
     m, case, model = link_graph([OpexDirect])
-    ℒ = case[:links]
-    𝒩 = case[:nodes]
-    𝒯 = case[:T]
+    ℒ = f_links(case)
+    𝒩 = f_nodes(case)
+    𝒯 = f_time_struct(case)
 
     # Test that `link_opex_var` and `link_opex_fixed` are not empty
     @test !isempty(m[:link_opex_var])
@@ -252,9 +252,9 @@ end
 
     # Create and solve the system
     m, case, model = link_graph([CapDirect])
-    ℒ = case[:links]
-    𝒩 = case[:nodes]
-    𝒯 = case[:T]
+    ℒ = f_links(case)
+    𝒩 = f_nodes(case)
+    𝒯 = f_time_struct(case)
 
     # Helper for usage
     cap = OperationalProfile([2, 3, 3, 2, 1])
@@ -306,9 +306,9 @@ end
 
     # Create and solve the system
     m, case, model = link_graph([DirectSub1, DirectSub2, Direct1])
-    ℒ = case[:links]
-    𝒩 = case[:nodes]
-    𝒯 = case[:T]
+    ℒ = f_links(case)
+    𝒩 = f_nodes(case)
+    𝒯 = f_time_struct(case)
 
     # Test that `test_var_sub`, `test_var_sub_1`, and `test_var_1` are created
     @test haskey(object_dictionary(m), :test_var_sub)

--- a/test/test_modeltype.jl
+++ b/test/test_modeltype.jl
@@ -29,14 +29,14 @@
         nodes = [source, sink]
         links = [Direct(12, source, sink)]
         model = OperationalModel(Dict(CO2 => em_cap), Dict(CO2 => em_price), CO2)
-        case = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
+        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
     function general_tests(m, case)
         # Extract parameters
-        𝒯 = case[:T]
-        sink = case[:nodes][2]
+        𝒯 = f_time_struct(case)
+        sink = f_nodes(case)[2]
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Test that the system produces
@@ -56,8 +56,8 @@
 
         # Solve the system and extract parameters
         m, case, model = simple_graph(em_data, em_cap, em_price)
-        𝒯 = case[:T]
-        sink = case[:nodes][2]
+        𝒯 = f_time_struct(case)
+        sink = f_nodes(case)[2]
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Conduct the general tests
@@ -86,8 +86,8 @@
         em_price = FixedProfile(price)
 
         m, case, model = simple_graph(em_data, em_cap, em_price)
-        𝒯 = case[:T]
-        sink = case[:nodes][2]
+        𝒯 = f_time_struct(case)
+        sink = f_nodes(case)[2]
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Conduct the general tests

--- a/test/test_modeltype.jl
+++ b/test/test_modeltype.jl
@@ -29,14 +29,14 @@
         nodes = [source, sink]
         links = [Direct(12, source, sink)]
         model = OperationalModel(Dict(CO2 => em_cap), Dict(CO2 => em_price), CO2)
-        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
     function general_tests(m, case)
         # Extract parameters
-        𝒯 = f_time_struct(case)
-        sink = f_nodes(case)[2]
+        𝒯 = get_time_struct(case)
+        sink = get_nodes(case)[2]
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Test that the system produces
@@ -56,8 +56,8 @@
 
         # Solve the system and extract parameters
         m, case, model = simple_graph(em_data, em_cap, em_price)
-        𝒯 = f_time_struct(case)
-        sink = f_nodes(case)[2]
+        𝒯 = get_time_struct(case)
+        sink = get_nodes(case)[2]
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Conduct the general tests
@@ -86,8 +86,8 @@
         em_price = FixedProfile(price)
 
         m, case, model = simple_graph(em_data, em_cap, em_price)
-        𝒯 = f_time_struct(case)
-        sink = f_nodes(case)[2]
+        𝒯 = get_time_struct(case)
+        sink = get_nodes(case)[2]
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Conduct the general tests

--- a/test/test_modeltype.jl
+++ b/test/test_modeltype.jl
@@ -29,7 +29,7 @@
         nodes = [source, sink]
         links = [Direct(12, source, sink)]
         model = OperationalModel(Dict(CO2 => em_cap), Dict(CO2 => em_price), CO2)
-        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 

--- a/test/test_nodes.jl
+++ b/test/test_nodes.jl
@@ -80,14 +80,14 @@
             CO2,
         )
 
-        # WIP data structure
-        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+        # Input data structure
+        case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
         return case, model
     end
 
     @testset "Identification functions" begin
         case, model = simple_graph()
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         stor = 𝒩[6]
 
         # Test that all nodal supertypes are identified correctly
@@ -125,7 +125,7 @@
 
     @testset "Access functions" begin
         case, model = simple_graph()
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
 
         # Test that the input and output resources are correctly identified
         @test outputs(𝒩[2]) == [NG]
@@ -140,11 +140,11 @@
         case, model = simple_graph()
         m = create_model(case, model)
 
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         stor = 𝒩[6]
         𝒩ⁱⁿ = filter(has_input, 𝒩)
         𝒩ᵒᵘᵗ = setdiff(filter(has_output, 𝒩), [stor]) # The storage has a fixed output variable
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
 
         # Test that all node flow variables have a lower bound of 0
         @test all(
@@ -177,7 +177,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
+        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
@@ -197,7 +197,7 @@ end
         )
 
         m, case, model = simple_graph(source, sink)
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Test that the capacity bound is properly set
@@ -258,7 +258,7 @@ end
         )
 
         m, case, model = simple_graph(source, sink)
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Test that the inflow is equal to the specified capacity usage
@@ -297,7 +297,7 @@ end
             Dict(Power => 1),
         )
         m, case, model = simple_graph(source, sink)
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Test that the mass balance is properly calculated
@@ -336,7 +336,7 @@ end
             Dict(Power => 1),
         )
         m, case, model = simple_graph(source, sink)
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         @test !any(val == source for val ∈ axes(m[:emissions_node])[1])
         @test !any(val == sink for val ∈ axes(m[:emissions_node])[1])
 
@@ -351,7 +351,7 @@ end
             [em_data],
         )
         m, case, model = simple_graph(source, snk_emit)
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         # Test that the emissions are properly calculated
         @test all(
             value.(m[:cap_use][snk_emit, t]) * process_emissions(em_data, CO2, t) ≈
@@ -369,7 +369,7 @@ end
             [em_data],
         )
         m, case, model = simple_graph(src_emit, sink)
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         # Test that the emissions are properly calculated, although no input is present in
         # a `Source ndoe`
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
@@ -455,7 +455,7 @@ end
             Dict(CO2 => FixedProfile(0), NG => FixedProfile(0)),
             CO2,
         )
-        case = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
+        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
@@ -465,9 +465,9 @@ end
 
         # Run the model and extract the data
         m, case, model = simple_graph()
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         net = 𝒩[2]
 
         # Check that there is production
@@ -498,11 +498,11 @@ end
         # Run the model and extract the data
         em_data = EmissionsEnergy()
         m, case, model = simple_graph(data_em = em_data)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         𝒩ᵉᵐ = nodes_emissions(𝒩)
         net = 𝒩[2]
 
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Check that there is production
@@ -529,14 +529,14 @@ end
         # Run the model and extract the data
         em_data = EmissionsProcess(Dict(CO2 => 0.1, NG => 0.5))
         m, case, model = simple_graph(data_em = em_data)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         𝒩ᵉᵐ = nodes_emissions(𝒩)
         net = 𝒩[2]
 
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-        𝒫   = case[:products]
+        𝒫   = f_products(case)
         𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
         # Check that there is production
@@ -568,14 +568,14 @@ end
         # Run the model and extract the data
         em_data = EmissionsProcess(Dict(CO2 => FixedProfile(0.1), NG => FixedProfile(0.5)))
         m, case, model = simple_graph(data_em = em_data)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         𝒩ᵉᵐ = nodes_emissions(𝒩)
         net = 𝒩[2]
 
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-        𝒫   = case[:products]
+        𝒫   = f_products(case)
         𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
         # Check that there is production
@@ -607,14 +607,14 @@ end
         # Run the model and extract the data
         em_data = CaptureEnergyEmissions(Dict(CO2 => 0.1, NG => 0.5), 0.9)
         m, case, model = simple_graph(data_em = em_data)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         𝒩ᵉᵐ = nodes_emissions(𝒩)
         net = 𝒩[2]
 
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-        𝒫   = case[:products]
+        𝒫   = f_products(case)
         𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
         # Check that there is production
@@ -655,14 +655,14 @@ end
         # Run the model and extract the data
         em_data = CaptureProcessEmissions(Dict(CO2 => 0.1, NG => 0.5), 0.9)
         m, case, model = simple_graph(data_em = em_data)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         𝒩ᵉᵐ = nodes_emissions(𝒩)
         net = 𝒩[2]
 
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-        𝒫   = case[:products]
+        𝒫   = f_products(case)
         𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
         # Check that there is production
@@ -704,14 +704,14 @@ end
         # Run the model and extract the data
         em_data = CaptureProcessEnergyEmissions(Dict(CO2 => 0.1, NG => 0.5), 0.9)
         m, case, model = simple_graph(data_em = em_data)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         𝒩ᵉᵐ = nodes_emissions(𝒩)
         net = 𝒩[2]
 
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-        𝒫   = case[:products]
+        𝒫   = f_products(case)
         𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
         # Check that there is production
@@ -807,7 +807,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
+        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
@@ -815,9 +815,9 @@ end
     function general_tests(m, case, model)
 
         # Extract the data
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         stor = 𝒩[3]
         sink = 𝒩[4]
 
@@ -870,9 +870,9 @@ end
 
         # Run the model and extract the data
         m, case, model = simple_graph()
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -921,9 +921,9 @@ end
 
         # Run the model and extract the data
         m, case, model = simple_graph(; demand = OperationalProfile([10, 15, 5, 15, 5]))
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -978,9 +978,9 @@ end
 
         m, case, model = simple_graph(; ops, op_per_strat = 8760, demand)
 
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -1116,7 +1116,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
+        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
@@ -1124,9 +1124,9 @@ end
     function general_tests(m, case, model)
 
         # Extract the data
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         stor = 𝒩[3]
         sink = 𝒩[4]
 
@@ -1180,9 +1180,9 @@ end
 
         # Run the model and extract the data
         m, case, model = simple_graph()
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -1231,9 +1231,9 @@ end
 
         # Run the model and extract the data
         m, case, model = simple_graph(; demand = OperationalProfile([10, 15, 5, 15, 5]))
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -1288,10 +1288,10 @@ end
 
         m, case, model = simple_graph(; ops, op_per_strat = 20, demand)
 
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
         𝒯ˢᶜ = opscenarios(𝒯)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -1355,10 +1355,10 @@ end
 
         m, case, model = simple_graph(; ops, op_per_strat = 8760, demand)
 
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
         𝒯ʳᵖ = repr_periods(𝒯)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -1434,11 +1434,11 @@ end
 
         m, case, model = simple_graph(; ops, op_per_strat = 8760, demand)
 
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
         𝒯ʳᵖ = repr_periods(𝒯)
         𝒯ˢᶜ = opscenarios(𝒯)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         stor = 𝒩[3]
         # Run the general tests
         general_tests(m, case, model)
@@ -1569,7 +1569,7 @@ end
             Dict(CO2 => FixedProfile(0), NG => FixedProfile(0)),
             CO2,
         )
-        case = Dict(:T => T, :nodes => nodes, :links => links, :products => resources)
+        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
@@ -1577,9 +1577,9 @@ end
     function general_tests(m, case, model)
 
         # Extract the data
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         stor = 𝒩[3]
 
         # Test that there is production
@@ -1625,9 +1625,9 @@ end
 
         # Run the model and extract the data
         m, case, model = simple_graph()
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -1676,9 +1676,9 @@ end
 
         # Run the model and extract the data
         m, case, model = simple_graph(; stor_cap = 100, em_limit = [100, 4])
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -1740,9 +1740,9 @@ end
         ops = RepresentativePeriods(2, 60, [0.5, 0.5], [op_1, op_2])
 
         m, case, model = simple_graph(; ops, op_per_strat = 60, stor_cap = 1e6)
-        𝒯 = case[:T]
+        𝒯 = f_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
+        𝒩 = f_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests

--- a/test/test_nodes.jl
+++ b/test/test_nodes.jl
@@ -81,7 +81,7 @@
         )
 
         # Input data structure
-        case = EMXCase(T, products, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
         return case, model
     end
 
@@ -177,7 +177,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
@@ -455,7 +455,7 @@ end
             Dict(CO2 => FixedProfile(0), NG => FixedProfile(0)),
             CO2,
         )
-        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
@@ -807,7 +807,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
@@ -1116,7 +1116,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
@@ -1569,7 +1569,7 @@ end
             Dict(CO2 => FixedProfile(0), NG => FixedProfile(0)),
             CO2,
         )
-        case = EMXCase(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 

--- a/test/test_nodes.jl
+++ b/test/test_nodes.jl
@@ -81,13 +81,13 @@
         )
 
         # Input data structure
-        case = Case(T, products, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
         return case, model
     end
 
     @testset "Identification functions" begin
         case, model = simple_graph()
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         stor = 𝒩[6]
 
         # Test that all nodal supertypes are identified correctly
@@ -125,7 +125,7 @@
 
     @testset "Access functions" begin
         case, model = simple_graph()
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
 
         # Test that the input and output resources are correctly identified
         @test outputs(𝒩[2]) == [NG]
@@ -140,11 +140,11 @@
         case, model = simple_graph()
         m = create_model(case, model)
 
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         stor = 𝒩[6]
         𝒩ⁱⁿ = filter(has_input, 𝒩)
         𝒩ᵒᵘᵗ = setdiff(filter(has_output, 𝒩), [stor]) # The storage has a fixed output variable
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
 
         # Test that all node flow variables have a lower bound of 0
         @test all(
@@ -177,7 +177,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
@@ -197,7 +197,7 @@ end
         )
 
         m, case, model = simple_graph(source, sink)
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Test that the capacity bound is properly set
@@ -258,7 +258,7 @@ end
         )
 
         m, case, model = simple_graph(source, sink)
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Test that the inflow is equal to the specified capacity usage
@@ -297,7 +297,7 @@ end
             Dict(Power => 1),
         )
         m, case, model = simple_graph(source, sink)
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Test that the mass balance is properly calculated
@@ -336,7 +336,7 @@ end
             Dict(Power => 1),
         )
         m, case, model = simple_graph(source, sink)
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         @test !any(val == source for val ∈ axes(m[:emissions_node])[1])
         @test !any(val == sink for val ∈ axes(m[:emissions_node])[1])
 
@@ -351,7 +351,7 @@ end
             [em_data],
         )
         m, case, model = simple_graph(source, snk_emit)
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         # Test that the emissions are properly calculated
         @test all(
             value.(m[:cap_use][snk_emit, t]) * process_emissions(em_data, CO2, t) ≈
@@ -369,7 +369,7 @@ end
             [em_data],
         )
         m, case, model = simple_graph(src_emit, sink)
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         # Test that the emissions are properly calculated, although no input is present in
         # a `Source ndoe`
         # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
@@ -455,7 +455,7 @@ end
             Dict(CO2 => FixedProfile(0), NG => FixedProfile(0)),
             CO2,
         )
-        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
@@ -465,9 +465,9 @@ end
 
         # Run the model and extract the data
         m, case, model = simple_graph()
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         net = 𝒩[2]
 
         # Check that there is production
@@ -498,11 +498,11 @@ end
         # Run the model and extract the data
         em_data = EmissionsEnergy()
         m, case, model = simple_graph(data_em = em_data)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         𝒩ᵉᵐ = nodes_emissions(𝒩)
         net = 𝒩[2]
 
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Check that there is production
@@ -529,14 +529,14 @@ end
         # Run the model and extract the data
         em_data = EmissionsProcess(Dict(CO2 => 0.1, NG => 0.5))
         m, case, model = simple_graph(data_em = em_data)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         𝒩ᵉᵐ = nodes_emissions(𝒩)
         net = 𝒩[2]
 
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-        𝒫   = f_products(case)
+        𝒫   = get_products(case)
         𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
         # Check that there is production
@@ -568,14 +568,14 @@ end
         # Run the model and extract the data
         em_data = EmissionsProcess(Dict(CO2 => FixedProfile(0.1), NG => FixedProfile(0.5)))
         m, case, model = simple_graph(data_em = em_data)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         𝒩ᵉᵐ = nodes_emissions(𝒩)
         net = 𝒩[2]
 
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-        𝒫   = f_products(case)
+        𝒫   = get_products(case)
         𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
         # Check that there is production
@@ -607,14 +607,14 @@ end
         # Run the model and extract the data
         em_data = CaptureEnergyEmissions(Dict(CO2 => 0.1, NG => 0.5), 0.9)
         m, case, model = simple_graph(data_em = em_data)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         𝒩ᵉᵐ = nodes_emissions(𝒩)
         net = 𝒩[2]
 
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-        𝒫   = f_products(case)
+        𝒫   = get_products(case)
         𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
         # Check that there is production
@@ -655,14 +655,14 @@ end
         # Run the model and extract the data
         em_data = CaptureProcessEmissions(Dict(CO2 => 0.1, NG => 0.5), 0.9)
         m, case, model = simple_graph(data_em = em_data)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         𝒩ᵉᵐ = nodes_emissions(𝒩)
         net = 𝒩[2]
 
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-        𝒫   = f_products(case)
+        𝒫   = get_products(case)
         𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
         # Check that there is production
@@ -704,14 +704,14 @@ end
         # Run the model and extract the data
         em_data = CaptureProcessEnergyEmissions(Dict(CO2 => 0.1, NG => 0.5), 0.9)
         m, case, model = simple_graph(data_em = em_data)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         𝒩ᵉᵐ = nodes_emissions(𝒩)
         net = 𝒩[2]
 
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-        𝒫   = f_products(case)
+        𝒫   = get_products(case)
         𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
         # Check that there is production
@@ -807,7 +807,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
@@ -815,9 +815,9 @@ end
     function general_tests(m, case, model)
 
         # Extract the data
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         stor = 𝒩[3]
         sink = 𝒩[4]
 
@@ -870,9 +870,9 @@ end
 
         # Run the model and extract the data
         m, case, model = simple_graph()
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -921,9 +921,9 @@ end
 
         # Run the model and extract the data
         m, case, model = simple_graph(; demand = OperationalProfile([10, 15, 5, 15, 5]))
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -978,9 +978,9 @@ end
 
         m, case, model = simple_graph(; ops, op_per_strat = 8760, demand)
 
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -1116,7 +1116,7 @@ end
             Dict(CO2 => FixedProfile(0)),
             CO2,
         )
-        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
@@ -1124,9 +1124,9 @@ end
     function general_tests(m, case, model)
 
         # Extract the data
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         stor = 𝒩[3]
         sink = 𝒩[4]
 
@@ -1180,9 +1180,9 @@ end
 
         # Run the model and extract the data
         m, case, model = simple_graph()
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -1231,9 +1231,9 @@ end
 
         # Run the model and extract the data
         m, case, model = simple_graph(; demand = OperationalProfile([10, 15, 5, 15, 5]))
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -1288,10 +1288,10 @@ end
 
         m, case, model = simple_graph(; ops, op_per_strat = 20, demand)
 
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
         𝒯ˢᶜ = opscenarios(𝒯)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -1355,10 +1355,10 @@ end
 
         m, case, model = simple_graph(; ops, op_per_strat = 8760, demand)
 
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
         𝒯ʳᵖ = repr_periods(𝒯)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -1434,11 +1434,11 @@ end
 
         m, case, model = simple_graph(; ops, op_per_strat = 8760, demand)
 
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
         𝒯ʳᵖ = repr_periods(𝒯)
         𝒯ˢᶜ = opscenarios(𝒯)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         stor = 𝒩[3]
         # Run the general tests
         general_tests(m, case, model)
@@ -1569,7 +1569,7 @@ end
             Dict(CO2 => FixedProfile(0), NG => FixedProfile(0)),
             CO2,
         )
-        case = Case(T, resources, [nodes, links], [[f_nodes, f_links]])
+        case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
         return run_model(case, model, HiGHS.Optimizer), case, model
     end
 
@@ -1577,9 +1577,9 @@ end
     function general_tests(m, case, model)
 
         # Extract the data
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         stor = 𝒩[3]
 
         # Test that there is production
@@ -1625,9 +1625,9 @@ end
 
         # Run the model and extract the data
         m, case, model = simple_graph()
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -1676,9 +1676,9 @@ end
 
         # Run the model and extract the data
         m, case, model = simple_graph(; stor_cap = 100, em_limit = [100, 4])
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests
@@ -1740,9 +1740,9 @@ end
         ops = RepresentativePeriods(2, 60, [0.5, 0.5], [op_1, op_2])
 
         m, case, model = simple_graph(; ops, op_per_strat = 60, stor_cap = 1e6)
-        𝒯 = f_time_struct(case)
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = f_nodes(case)
+        𝒩 = get_nodes(case)
         stor = 𝒩[3]
 
         # Run the general tests


### PR DESCRIPTION
So far, our input for model creation was based on a dictionary which is required to contain certain keys. This is unsatisfactory and lead to the situation that we needed to develop a new *[method in geography ](https://github.com/EnergyModelsX/EnergyModelsGeography.jl/blob/03c712779ecfa393c0b4cf04f9c9a5b7e16b7805/src/model.jl#L24)* for model generation to introduce additional constraints.

As it is in general advisable to avoid this problem, I decided to utilize the concepts introduced in #48 to change the internal structure in the package as well as the input to a model. The latter is solved through introduction of the type `EMXCase` which allows for various different type of elements added as vector.

The update was tested with both the current latest version and an adjusted local version of  `EnergyModelsGeography`. It seems to work without any problems. The changes are not breaking, but we can make them breaking if we plan to reduce the number of functions further as this would require adjustment of the exported functions.

## Major changes

- Declared all abstract types that create variables and so on as `AbstractElement`
- Switched to a type based input through `EMXCase`.
- Automatize the function call flow through the entries in `EMXCase`.
- Generalize the checks as well. They are currently not working for new types of elements.

## Minor changes

- Create function `objective_invest` in EMB and not the extension to allow its utilization outside of EMB.

## Potential additional adjustments

- Rename some of the functions to be able to reduce the number of internal functions.