### PR TITLE
Restructured argument order for `create_link`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 
 * Allow for checks for links.
 * Changed functions to allow for nodes without OPEX that are not `Availability` nodes and nodes without capacity that are not `Availability` nodes.
+* Restructured the arguments in `create_link` to be consistent with `create_node`.
 
 ## Version 0.8.3 (2024-11-29)
 

--- a/docs/src/how-to/update-models.md
+++ b/docs/src/how-to/update-models.md
@@ -7,6 +7,8 @@ We will as well implement information regarding the adjustment of extension pack
 
 ## [Adjustments from 0.8.x](@id how_to-update-08)
 
+### [Case input data](@id how_to-update-08-case)
+
 Starting from version 0.9.0, we introduced a new input format to the function `create_model`.
 The original case dictionary is replaced with a new type, [`Case`](@ref).
 We introduced deprecated methods that can be utilized with the original dictionary, but it is advisable to switch to the new type as:
@@ -24,6 +26,22 @@ case = Dict(
 case = Case(T, products, [nodes, links], [[get_nodes, get_links]]) # or
 case = Case(T, products, [nodes, links])
 ```
+
+### [`create_link` arguments](@id how_to-update-08-link)
+
+We restructured the function call arguments for links through the function [`create_link`](@ref EnergyModelsBase.create_link):
+
+```julia
+# Old structure:
+create_link(m, 𝒯, 𝒫, l::Link, modeltype::EnergyModel, formulation::Formulation)
+
+# New structure:
+create_link(m, l::Link, 𝒯, 𝒫, modeltype::EnergyModel)
+```
+
+This implies that we removed the argument `formulation::Formulation` and reordered the individual arguments to be consistent with [`create_node`](@ref).
+The field `formulation` still exists for `Direct`.
+It can be used to provide differnet submethods, *e.g.*, when creating capacity constraints.
 
 ## [Adjustments from 0.6.x to 0.8.x](@id how_to-update-06)
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -501,7 +501,7 @@ differentiation in extension packages.
 create_element(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel) =
     create_node(m, n, 𝒯, 𝒫, modeltype)
 create_element(m, l::Link, 𝒯, 𝒫, modeltype::EnergyModel) =
-    create_link(m, 𝒯, 𝒫, l, modeltype, formulation(l))
+    create_link(m, l, 𝒯, 𝒫, modeltype)
 
 """
     constraints_couple(m, 𝒩::Vector{<:Node}, ℒ::Vector{<:Link}, 𝒫, 𝒯, modeltype::EnergyModel)
@@ -856,15 +856,31 @@ function create_node(m, n::Availability, 𝒯, 𝒫, modeltype::EnergyModel)
 end
 
 """
-    create_link(m, 𝒯, 𝒫, l::Link, formulation::Formulation)
+    create_link(m, l::Link, 𝒯, 𝒫, modeltype::EnergyModel)
+    create_link(m, l::Direct, 𝒯, 𝒫, modeltype::EnergyModel)
+    create_link(m, 𝒯, 𝒫, l::Link, modeltype::EnergyModel, formulation::Formulation)
 
-Set the constraints for a simple `Link` (input = output). Can serve as fallback option for
-all unspecified subtypes of `Link`.
+Set the constraints for a `Link`.
 
-All links with capacity, as indicated through the function [`has_capacity`](@ref) call
-furthermore the function [`constraints_capacity_installed`](@ref) for limiting the capacity
-to the installed capacity.
+!!! note "Deprecated arguments order"
+    The argument order `(m, 𝒯, 𝒫, l::Link, modeltype::EnergyModel, formulation::Formulation)`
+    is deprecated. It will be removed in the near future. It remains to provide the user
+    with the potential for a simple adjustment of the links
 """
+function create_link(m, l::Link, 𝒯, 𝒫, modeltype::EnergyModel)
+    @warn(
+        "`create_link(m, 𝒯, 𝒫, l::Link, modeltype::EnergyModel, formulation::Formulation)` " *
+        "is deprecated, use `create_link(m, l::Link, 𝒯, 𝒫, modeltype::EnergyModel)` instead.",
+        maxlog = 1
+    )
+    return create_link(m, 𝒯, 𝒫, l, modeltype, formulation(l))
+end
+function create_link(m, l::Direct, 𝒯, 𝒫, modeltype::EnergyModel)
+    # Generic link in which each output corresponds to the input
+    @constraint(m, [t ∈ 𝒯, p ∈ link_res(l)],
+        m[:link_out][l, t, p] == m[:link_in][l, t, p]
+    )
+end
 function create_link(m, 𝒯, 𝒫, l::Link, modeltype::EnergyModel, formulation::Formulation)
 
     # Generic link in which each output corresponds to the input

--- a/test/test_links.jl
+++ b/test/test_links.jl
@@ -155,7 +155,7 @@ end
         to::EMB.Node
         formulation::EMB.Formulation
     end
-    function EMB.create_link(m, 𝒯, 𝒫, l::EmissionDirect, modeltype::EnergyModel, formulation::EMB.Formulation)
+    function EMB.create_link(m, l::EmissionDirect, 𝒯, 𝒫, modeltype::EnergyModel)
         # Generic link in which each output corresponds to the input
         @constraint(m, [t ∈ 𝒯, p ∈ EMB.link_res(l)],
             m[:link_out][l, t, p] == m[:link_in][l, t, p]
@@ -194,7 +194,7 @@ end
         to::EMB.Node
         formulation::EMB.Formulation
     end
-    function EMB.create_link(m, 𝒯, 𝒫, l::OpexDirect, modeltype::EnergyModel, formulation::EMB.Formulation)
+    function EMB.create_link(m, l::OpexDirect, 𝒯, 𝒫, modeltype::EnergyModel)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Generic link in which each output corresponds to the input
@@ -234,7 +234,7 @@ end
         to::EMB.Node
         formulation::EMB.Formulation
     end
-    function EMB.create_link(m, 𝒯, 𝒫, l::CapDirect, modeltype::EnergyModel, formulation::EMB.Formulation)
+    function EMB.create_link(m, l::CapDirect, 𝒯, 𝒫, modeltype::EnergyModel)
 
         # Generic link in which each output corresponds to the input
         @constraint(m, [t ∈ 𝒯, p ∈ EMB.link_res(l)],


### PR DESCRIPTION
This PR addresses issue #55. The old version is included with a deprecation note.
It hence closes #55.