### PR TITLE
Allow for operational emission prices

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * Allow for checks for links.
 * Changed functions to allow for nodes without OPEX that are not `Availability` nodes and nodes without capacity that are not `Availability` nodes.
 * Restructured the arguments in `create_link` to be consistent with `create_node`.
+* Allow for `OperationalProfile` in emission prices.
 
 ## Version 0.8.3 (2024-11-29)
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -567,7 +567,7 @@ end
 Create JuMP expressions indexed over the operational periods `𝒯` for different elements 𝒳.
 The expressions correspond to the total emissions of a given element type.
 
-By default, objective expressions are included for:
+By default, emissions expressions are included for:
 - `𝒳 = 𝒩::Vector{<:Node}`. In the case of a vector of nodes, the function returns the
   sum of the emissions of all nodes whose method of the function [`has_emissions`](@ref)
   returns true. These nodes should be automatically identified without user intervention.
@@ -684,8 +684,8 @@ function objective_operational(
 
     return @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
         sum(
-            m[:emissions_strategic][t_inv, p] * emission_price(modeltype, p, t_inv) for
-            p ∈ 𝒫ᵉᵐ
+            m[:emissions_total][t, p] * emission_price(modeltype, p, t) *
+            scale_op_sp(t_inv, t) for t ∈ t_inv, p ∈ 𝒫ᵉᵐ
         )
     )
 end

--- a/src/structures/model.jl
+++ b/src/structures/model.jl
@@ -36,17 +36,17 @@ emission_limit(modeltype, p::ResourceEmit, t_inv::TS.AbstractStrategicPeriod) =
 """
     emission_price(modeltype::EnergyModel)
     emission_price(modeltype, p::ResourceEmit)
-    emission_price(modeltype, p::ResourceEmit, t_inv::TS.AbstractStrategicPeriod)
+    emission_price(modeltype, p::ResourceEmit, t_inv::TS.TimePeriod)
 
 Returns the emission price of EnergyModel `model` as dictionary with `TimeProfile`s for
 each [`ResourceEmit`](@ref), as `TimeProfile` for [`ResourceEmit`](@ref) `p` or, in
-strategic period `t_inv` for [`ResourceEmit`](@ref) `p`.
+operational period `t` for [`ResourceEmit`](@ref) `p`.
 """
 emission_price(modeltype::EnergyModel) = modeltype.emission_price
 emission_price(modeltype, p::ResourceEmit) =
     haskey(modeltype.emission_price, p) ? modeltype.emission_price[p] : 0
-emission_price(modeltype, p::ResourceEmit, t_inv::TS.AbstractStrategicPeriod) =
-    haskey(modeltype.emission_price, p) ? modeltype.emission_price[p][t_inv] : 0
+emission_price(modeltype, p::ResourceEmit, t::TS.TimePeriod) =
+    haskey(modeltype.emission_price, p) ? modeltype.emission_price[p][t] : 0
 
 """
     co2_instance(modeltype::EnergyModel)

--- a/test/test_general.jl
+++ b/test/test_general.jl
@@ -102,7 +102,7 @@ end
 
     # Check for the objective value
     # (*2 compared to 0.6.0 due to change in strategic period duration)
-    # (+10400 = 2*10*(160+140+120+100) compared to 0.8.3 due to inclusion of co2 emissions)
+    # (-10400 = 2*10*(160+140+120+100) compared to 0.8.3 due to inclusion of co2 emissions)
     @test objective_value(m) ≈ -99383.3860
 
     # Check for the total number of variables


### PR DESCRIPTION
So far, emission price profiles were limited to `StrategicProfile`s as we included the costs through the variable `:emissions_strategic`. While that is understandable in a multi horizon framework, it can be problematic in single horizon analyses.

This PR instead utilizes the variable `:emissions_total` which allows now as well `OperationalProfile` in the system. The tests were correspondingly adjusted. 

> [!NOTE]  
> Looking through the checks for the time profiles, I realized that we miss checks for `OperationalScenario`s. This will be included in a last PR before we register version 0.10.0.