### PR TITLE
Improvement of profile checks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Unversioned
+## Version 0.9.0 (2025-01-29)
 
 ### Major rework of input data structure
 
@@ -14,6 +14,7 @@
 * Changed functions to allow for nodes without OPEX that are not `Availability` nodes and nodes without capacity that are not `Availability` nodes.
 * Restructured the arguments in `create_link` to be consistent with `create_node`.
 * Allow for `OperationalProfile` in emission prices.
+* Updated the time profile checks to include also check operational scenarios.
 
 ## Version 0.8.3 (2024-11-29)
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsBase"
 uuid = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.8.3"
+version = "0.9.0"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -212,9 +212,8 @@ function check_elements(
             check_node_data(n, data, 𝒯, modeltype, check_timeprofiles)
         end
 
-        if check_timeprofiles
-            check_time_structure(n, 𝒯)
-        end
+        check_timeprofiles && check_time_structure(n, 𝒯)
+
         # Put all log messages that emerged during the check, in a dictionary with the node as key.
         log_by_element[n] = logs
     end
@@ -257,9 +256,7 @@ function check_elements(
         for data ∈ link_data(l)
             check_link_data(l, data, 𝒯, modeltype, check_timeprofiles)
         end
-        if check_timeprofiles
-            check_time_structure(l, 𝒯)
-        end
+        check_timeprofiles && check_time_structure(l, 𝒯)
         # Put all log messages that emerged during the check, in a dictionary with the node as key.
         log_by_element[l] = logs
     end
@@ -319,8 +316,7 @@ function check_model(case, modeltype::EnergyModel, check_timeprofiles::Bool)
 
     for p ∈ keys(emission_price(modeltype))
         em_price = emission_price(modeltype, p)
-        !check_timeprofiles && continue
-        println(p)
+        check_timeprofiles || continue
         check_profile("emission_price[" * string(p) * "]", em_price, 𝒯)
     end
 end
@@ -882,8 +878,8 @@ function check_node_data(
 
     for p ∈ process_emissions(data)
         value = process_emissions(data, p)
-        !check_timeprofiles && continue
-        !isa(value, TimeProfile) && continue
+        check_timeprofiles || continue
+        isa(value, TimeProfile) || continue
         check_profile(string(p) * " process emissions", value, 𝒯)
     end
 end
@@ -902,8 +898,8 @@ function check_node_data(
 
     for p ∈ process_emissions(data)
         value = process_emissions(data, p)
-        !check_timeprofiles && continue
-        !isa(value, TimeProfile) && continue
+        check_timeprofiles || continue
+        isa(value, TimeProfile) || continue
         check_profile(string(p) * " process emissions", value, 𝒯)
     end
     @assert_or_log(

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -269,7 +269,7 @@ end
     end
 
     # Create a function for running the simple graph
-    function run_simple_graph(T::TimeStructure, tp::TimeProfile)
+    function create_simple_graph(T::TimeStructure, tp::TimeProfile)
         case, model = simple_graph(T, tp)
         return create_model(case, model), case, model
     end
@@ -280,32 +280,108 @@ end
     # - EMB.check_profile(fieldname, value::StrategicProfile, 𝒯::TwoLevel)
     ts = TwoLevel(2, 1, day)
     ops = OperationalProfile(ones(24))
-    tp = StrategicProfile([ops, ops, ops])
-    @test_throws AssertionError run_simple_graph(ts, tp)
+    profiles = [
+        StrategicProfile([ops, ops, ops]),
+        StrategicProfile([ops]),
+    ]
+    for tp ∈ profiles
+        @test_throws AssertionError create_simple_graph(ts, tp)
+    end
 
-    # Test that there is an error with wrong operational profiles
+    # Test that there is an error with wrong `OperationalProfile`s
     # - EMB.check_profile(fieldname, value::OperationalProfile, ts::SimpleTimes, sp)
-    ts = TwoLevel(2, 1, day)
-    tp = OperationalProfile(ones(20))
-    @test_throws AssertionError run_simple_graph(ts, tp)
-    tp = OperationalProfile(ones(30))
-    @test_throws AssertionError run_simple_graph(ts, tp)
+    profiles = [
+        OperationalProfile(ones(20)),
+        OperationalProfile(ones(30)),
+    ]
+    for tp ∈ profiles
+        @test_throws AssertionError create_simple_graph(ts, tp)
+    end
 
-    # Test that there is warning when using RepresentativeProfile without RepresentativePeriods
+    # Test that there is an error with wrong `OperationalProfile`s in operational scenarios
+    # - EMB.check_profile(fieldname, value::OperationalProfile, ts::OperationalScenarios, sp)
+    oscs = OperationalScenarios(3, day)
+    ts =  TwoLevel(2, 1, oscs)
+    for tp ∈ profiles
+        @test_throws AssertionError create_simple_graph(ts, tp)
+    end
+
+    # Test that there is an error with wrong `OperationalProfile`s in representative periods
+    # - EMB.check_profile(fieldname, value::OperationalProfile, ts::RepresentativePeriods, sp)
+    ts =  TwoLevel(2, 1, RepresentativePeriods(2, [.5, .5], day))
+    for tp ∈ profiles
+        @test_throws AssertionError create_simple_graph(ts, tp)
+    end
+
+    # Test that there is an error with wrong `OperationalProfile`s in operational scenarios
+    # in representative periods
+    # - EMB.check_profile(fieldname, value::OperationalProfile, ts::OperationalScenarios, sp)
+    # - EMB.check_profile(fieldname, value::OperationalProfile, ts::RepresentativePeriods, sp)
+    ts =  TwoLevel(2, 1, RepresentativePeriods(2, [.5, .5], oscs))
+    for tp ∈ profiles
+        @test_throws AssertionError create_simple_graph(ts, tp)
+    end
+
+    # Test that there is warning when using `ScenarioProfile` without `OperationalScenarios`
     # - EMB.check_profile(fieldname, value::RepresentativeProfile, ts::SimpleTimes, sp)
-    ts = TwoLevel(1, 1, day)
+    ts = TwoLevel(2, 1, day)
+    profiles = [
+        ScenarioProfile([FixedProfile(5), FixedProfile(10)]),
+        ScenarioProfile([
+            FixedProfile(5), FixedProfile(5), FixedProfile(5), FixedProfile(10)
+        ]),
+    ]
+    msg =
+        "Using `ScenarioProfile` with `SimpleTimes` is dangerous, as it may " *
+        "lead to unexpected behaviour. " *
+        "In this case, only the first profile is used in the model and tested."
+    @test_logs (:warn, msg) create_simple_graph(ts, profiles[1]);
+
+    # Test that there is an error with wrong `ScenarioProfile`s
+    # - EMB.check_profile(fieldname, value::ScenarioProfile, ts::SimpleTimes, sp)
+    ts =  TwoLevel(2, 1, oscs)
+    for tp ∈ profiles
+        @test_throws AssertionError create_simple_graph(ts, tp)
+    end
+
+    # Test that there is an error with wrong `OperationalProfile`s in representative periods
+    # - EMB.check_profile(fieldname, value::OperationalProfile, ts::RepresentativePeriods, sp)
+    ts =  TwoLevel(2, 1, RepresentativePeriods(2, [.5, .5], oscs))
+    for tp ∈ profiles
+        @test_throws AssertionError create_simple_graph(ts, tp)
+    end
+
+    # Test that there is warning when using `RepresentativeProfile` without
+    # `RepresentativePeriods`
+    # - EMB.check_profile(fieldname, value::RepresentativeProfile, ts::SimpleTimes, sp)
+    ts = TwoLevel(2, 1, day)
     tp = RepresentativeProfile([FixedProfile(5), FixedProfile(10)])
     msg =
         "Using `RepresentativeProfile` with `SimpleTimes` is dangerous, as it may " *
         "lead to unexpected behaviour. " *
         "In this case, only the first profile is used in the model and tested."
-    @test_logs (:warn, msg) run_simple_graph(ts, tp)
+    @test_logs (:warn, msg) create_simple_graph(ts, tp);
+    # - EMB.check_profile(fieldname, value::RepresentativeProfile, ts::OperationalScenarios, sp)
+    ts =  TwoLevel(2, 1, OperationalScenarios(2, day))
+    tp = RepresentativeProfile([FixedProfile(5), FixedProfile(10)])
+    msg =
+        "Using `RepresentativeProfile` with `OperationalScenarios` is dangerous, as it may " *
+        "lead to unexpected behaviour. " *
+        "In this case, only the first profile is used in the model and tested."
+    @test_logs (:warn, msg) create_simple_graph(ts, tp);
 
-    # Test that there is an error when `RepresentativeProfile` have a different length than
-    # the corresponding `RepresentativePeriods`
+    # Test that there is an error with wrong `RepresentativeProfile`s
     # - EMB.check_profile(fieldname, value::RepresentativeProfile, ts::SimpleTimes, sp)
-    ts = TwoLevel(2, 1, RepresentativePeriods(3, 8760, ones(3) / 3, [day, day, day]))
-    @test_throws AssertionError run_simple_graph(ts, tp)
+    ts = TwoLevel(2, 1, RepresentativePeriods(2, ones(3) / 3, [day, day, day]))
+    profiles = [
+        RepresentativeProfile([FixedProfile(5), FixedProfile(10)]),
+        RepresentativeProfile([
+            FixedProfile(5), FixedProfile(5), FixedProfile(5), FixedProfile(10)
+        ]),
+    ]
+    for tp ∈ profiles
+        @test_throws AssertionError create_simple_graph(ts, tp)
+    end
 
     # Check that turning of the timeprofile checks leads to a warning
     case, model = simple_graph(ts, tp)


### PR DESCRIPTION
In PR #58, I outlined that we are missing profile checks for `ScenarioProfile`s. This is solved now in this PR with additional tests for profiles.

In addition, I moved from `!<cond> && <statement>` to `<cond> || <statement>` as outlined in the *[Julia documentation](https://docs.julialang.org/en/v1/manual/control-flow/#Short-Circuit-Evaluation)* in the checks.