### PR TITLE
Incorporation of variables for `Data` types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,14 @@
 # Release notes
 
-## Unversioned
+## Version 0.9.1 (2025-06-24)
+
+### Rework of data
+
+* Renamed extension data related functions and types:
+  * `Data` is now called `ExtraData`.
+  * `create_data` is now called `create_ext_data`.
+* The old version is still accessible, but will be removed in release 0.10.
+* Allow for variable creation for `ExtraData` types and implemented the approach for `InvestmentData` for both `Node`s and `Link`s.
 
 ### Minor updates
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsBase"
 uuid = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -43,7 +43,7 @@ makedocs(
             "Philosophy"=>"manual/philosophy.md",
             "Optimization variables"=>"manual/optimization-variables.md",
             "Constraint functions"=>"manual/constraint-functions.md",
-            "Data functions"=>"manual/data-functions.md",
+            "ExtensionData functions"=>"manual/data-functions.md",
             "Example"=>"manual/simple-example.md",
             "Investment options"=>"manual/investments.md",
             "Release notes"=>"manual/NEWS.md",
@@ -65,7 +65,7 @@ makedocs(
         "Library" => Any[
             "Public"=>Any[
                 "Resources"=>"library/public/resources.md",
-                "Modeltype and Data"=>"library/public/model_data.md",
+                "Modeltype and ExtensionData"=>"library/public/model_data.md",
                 "Nodes"=>"library/public/nodes.md",
                 "Links"=>"library/public/links.md",
                 "Case"=>"library/public/case_element.md",

--- a/docs/src/how-to/create-new-node.md
+++ b/docs/src/how-to/create-new-node.md
@@ -47,7 +47,7 @@ This is however only advised if you do not need to access the value of the varia
 2. Emissions can be included in any way.
    It is however beneficial to reutilize the [`EmissionsData`](@ref) type to improve usability with other packages.
    This requries again the inclusion of the field `data` in `NewNodeType`.
-   It is possible to also create new subtypes for `EmissionsData` as well as dispatch on the function [`constraints_data(m, n::Node, 𝒯, 𝒫, modeltype, data::Data)`](@ref man-data_fun).
+   It is possible to also create new subtypes for `EmissionsData` as well as dispatch on the function [`constraints_data(m, n::Node, 𝒯, 𝒫, modeltype, data::ExtensionData)`](@ref man-data_fun).
 3. It is in a first stage not important to include functions for handling all possible `TimeStructure`s, that is, *e.g.*, `RepresentativePeriods`.
    Instead, and error can be provided if an unsupported `TimeStructure` is chosen.
 4. The existing reference nodes and their respective *[constraint functions](@ref man-con)* can serve as idea generators.

--- a/docs/src/how-to/create-new-node.md
+++ b/docs/src/how-to/create-new-node.md
@@ -47,7 +47,7 @@ This is however only advised if you do not need to access the value of the varia
 2. Emissions can be included in any way.
    It is however beneficial to reutilize the [`EmissionsData`](@ref) type to improve usability with other packages.
    This requries again the inclusion of the field `data` in `NewNodeType`.
-   It is possible to also create new subtypes for `EmissionsData` as well as dispatch on the function [`constraints_data(m, n::Node, 𝒯, 𝒫, modeltype, data::ExtensionData)`](@ref man-data_fun).
+   It is possible to also create new subtypes for `EmissionsData` as well as dispatch on the function [`constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype, data::ExtensionData)`](@ref man-data_fun).
 3. It is in a first stage not important to include functions for handling all possible `TimeStructure`s, that is, *e.g.*, `RepresentativePeriods`.
    Instead, and error can be provided if an unsupported `TimeStructure` is chosen.
 4. The existing reference nodes and their respective *[constraint functions](@ref man-con)* can serve as idea generators.

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -16,6 +16,7 @@ CurrentModule = EnergyModelsBase
 create_element
 create_link
 variables_element
+variables_data
 objective(m, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
 objective_operational
 emissions_operational
@@ -42,6 +43,7 @@ variables_opex
 variables_capex(m, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
 variables_emission
 variables_elements
+variables_element_data
 ```
 
 ## [Check functions](@id lib-int-fun-check)

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -16,7 +16,7 @@ CurrentModule = EnergyModelsBase
 create_element
 create_link
 variables_element
-variables_data
+variables_data(m, _::Type{<:Data}, 𝒳::Vector{<:AbstractElement}, 𝒯, 𝒫, modeltype::EnergyModel)
 objective(m, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
 objective_operational
 emissions_operational
@@ -40,7 +40,7 @@ constraints_level_bounds
 variables_capacity
 variables_flow
 variables_opex
-variables_capex(m, 𝒩::Vector{<:Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
+variables_capex
 variables_emission
 variables_elements
 variables_element_data

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -16,7 +16,7 @@ CurrentModule = EnergyModelsBase
 create_element
 create_link
 variables_element
-variables_data(m, _::Type{<:Data}, 𝒳::Vector{<:AbstractElement}, 𝒯, 𝒫, modeltype::EnergyModel)
+variables_data(m, _::Type{<:ExtensionData}, 𝒳::Vector{<:AbstractElement}, 𝒯, 𝒫, modeltype::EnergyModel)
 objective(m, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
 objective_operational
 emissions_operational
@@ -57,7 +57,7 @@ check_node
 check_link
 check_node_default
 check_node_data(n::Node, data::EmissionsData, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
-check_link_data(n::Link, data::Data, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+check_link_data(n::Link, data::ExtensionData, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 check_fixed_opex
 check_time_structure
 check_profile

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -16,7 +16,7 @@ CurrentModule = EnergyModelsBase
 create_element
 create_link
 variables_element
-variables_data(m, _::Type{<:ExtensionData}, 𝒳::Vector{<:AbstractElement}, 𝒯, 𝒫, modeltype::EnergyModel)
+variables_ext_data(m, _::Type{<:ExtensionData}, 𝒳::Vector{<:AbstractElement}, 𝒯, 𝒫, modeltype::EnergyModel)
 objective(m, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
 objective_operational
 emissions_operational
@@ -43,7 +43,7 @@ variables_opex
 variables_capex
 variables_emission
 variables_elements
-variables_element_data
+variables_element_ext_data
 ```
 
 ## [Check functions](@id lib-int-fun-check)

--- a/docs/src/library/internals/reference_EMIExt.md
+++ b/docs/src/library/internals/reference_EMIExt.md
@@ -32,7 +32,7 @@ check_inv_data
 ### [Methods](@id lib-int-EMIext-met)
 
 ```@docs
-EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::AbstractInvestmentModel)
+EMB.variables_data(m, _::Type{SingleInvData}, 𝒩ᴵⁿᵛ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
 EMB.objective_invest(m, 𝒩::Vector{<:EMB.Node}, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, modeltype::AbstractInvestmentModel)
 EMB.constraints_capacity_installed(m, n::EMB.Node, 𝒯::TimeStructure, modeltype::AbstractInvestmentModel)
 EMB.check_node_data(n::EMB.Node, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel, check_timeprofiles::Bool)

--- a/docs/src/library/internals/reference_EMIExt.md
+++ b/docs/src/library/internals/reference_EMIExt.md
@@ -32,7 +32,7 @@ check_inv_data
 ### [Methods](@id lib-int-EMIext-met)
 
 ```@docs
-EMB.variables_data(m, _::Type{SingleInvData}, 𝒩ᴵⁿᵛ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
+EMB.variables_ext_data(m, _::Type{SingleInvData}, 𝒩ᴵⁿᵛ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
 EMB.objective_invest(m, 𝒩::Vector{<:EMB.Node}, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, modeltype::AbstractInvestmentModel)
 EMB.constraints_capacity_installed(m, n::EMB.Node, 𝒯::TimeStructure, modeltype::AbstractInvestmentModel)
 EMB.check_node_data(n::EMB.Node, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel, check_timeprofiles::Bool)

--- a/docs/src/library/public/case_element.md
+++ b/docs/src/library/public/case_element.md
@@ -23,6 +23,12 @@ The connections are incorporated through `Link`s which transport resources betwe
 AbstractElement
 ```
 
+`EnergyModelsBase` allows for the potential of extension data which can be extracted through
+
+```@docs
+element_data
+```
+
 ## [Case type](@id lib-pub-case-case)
 
 The case type is used as input to `EnergyModelsBase` models.

--- a/docs/src/library/public/emi_extension.md
+++ b/docs/src/library/public/emi_extension.md
@@ -34,7 +34,7 @@ discount_rate
 
 ### [`InvestmentData` types](@id lib-pub-emi_ext-inv_data-types)
 
-`InvestmentData` subtypes are used to provide technologies introduced in `EnergyModelsX` (nodes and transmission modes) a subtype of `Data` that can be used for dispatching.
+`InvestmentData` subtypes are used to provide technologies introduced in `EnergyModelsX` (nodes and transmission modes) a subtype of `ExtensionData` that can be used for dispatching.
 Two different types are directly introduced, `SingleInvData` and `StorageInvData`.
 
 `SingleInvData` is providing a composite type with a single field.

--- a/docs/src/library/public/functions.md
+++ b/docs/src/library/public/functions.md
@@ -58,6 +58,7 @@ constraints_level
 constraints_level_aux
 constraints_opex_var
 constraints_opex_fixed
+constraints_ext_data
 constraints_data
 ```
 
@@ -68,6 +69,10 @@ These auxiliary functions provide the user with simple approaches for calculatin
 previous_level
 previous_level_sp
 ```
+
+!!! note "Changes in names"
+    The function `constraints_data` is replaced by the function `constraints_ext_data`.
+    This implies that if you created new methods for the function, it is best to rename your functions as we plan to remove the function `constraints_data` in the next major release.
 
 ## [Utility functions](@id lib-pub-fun-util)
 

--- a/docs/src/library/public/functions.md
+++ b/docs/src/library/public/functions.md
@@ -42,7 +42,7 @@ CurrentModule = EMB
 ```
 
 The following functions can be used in newly developed nodes to include constraints.
-See the pages *[Constraint functions](@ref man-con)* and *[Data functions](@ref man-data_fun)* for a detailed explanation on their usage.
+See the pages *[Constraint functions](@ref man-con)* and *[ExtensionData functions](@ref man-data_fun)* for a detailed explanation on their usage.
 
 !!! warning
     The function `constraints_capacity_installed` should not be changed.

--- a/docs/src/library/public/model_data.md
+++ b/docs/src/library/public/model_data.md
@@ -30,16 +30,16 @@ co2_instance
 ## [Additional data](@id lib-pub-mod_data-data)
 
 Emission data are used to provide the individual nodes with potential emissions.
-The approach is also explained on the page *[Data functions](@ref man-data_fun)*.
+The approach is also explained on the page *[ExtensionData functions](@ref man-data_fun)*.
 
-### [`Data` and `Emission` types](@id lib-pub-mod_data-data-types)
+### [`ExtensionData` and `Emission` types](@id lib-pub-mod_data-data-types)
 
-`Data` types are introduced for introducing additional parameters, variables, and constraints to the `Node`s.
-The approach of using the `data` field of `Node`s is explained on the page *[Data functions](@ref man-data_fun)*.
+`ExtensionData` types are introduced for introducing additional parameters, variables, and constraints to the `Node`s.
+The approach of using the `data` field of `Node`s is explained on the page *[ExtensionData functions](@ref man-data_fun)*.
 `EmptyData` is no longer relevant for the modelling, but it is retained for avoiding any problems with existing models.
 
 ```@docs
-Data
+ExtensionData
 EmptyData
 ```
 

--- a/docs/src/manual/data-functions.md
+++ b/docs/src/manual/data-functions.md
@@ -1,7 +1,7 @@
-# [Data functions](@id man-data_fun)
+# [ExtensionData functions](@id man-data_fun)
 
-The package provides the wildcard [`Data`](@ref) type as outlined in the *[Extensions to the model](@ref man-phil-ext)* section of the philosophy page.
-`Data` can be utilized to extend the functionality of the model through dispatching on its type.
+The package provides the wildcard [`ExtensionData`](@ref) type as outlined in the *[Extensions to the model](@ref man-phil-ext)* section of the philosophy page.
+`ExtensionData` can be utilized to extend the functionality of the model through dispatching on its type.
 The following function is included in all reference `create_node` functions, except for `Storage` types
 
 ```julia
@@ -11,10 +11,10 @@ for data ∈ node_data(n)
 end
 ```
 
-There is always a fallback option if a `Data` is specified, but no functions are provided:
+There is always a fallback option if a `ExtensionData` is specified, but no functions are provided:
 
 ```julia
-constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::Data) = nothing
+constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::ExtensionData) = nothing
 ```
 
 Its application is best explained by the implemented functionality for emissions.

--- a/docs/src/manual/data-functions.md
+++ b/docs/src/manual/data-functions.md
@@ -44,9 +44,9 @@ The individual fields of the different types are described in the *[Public inter
 The extension is then implemented through the functions
 
 ```julia
-function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype, data::EmissionsEnergy)
-function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype, data::EmissionsProcess)
-function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
+function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsEnergy)
+function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
+function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
 function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureProcessEmissions)
 function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureProcessEnergyEmissions)
 ```

--- a/docs/src/manual/data-functions.md
+++ b/docs/src/manual/data-functions.md
@@ -7,17 +7,25 @@ The following function is included in all reference `create_node` functions, exc
 ```julia
 # Iterate through all data and set up the constraints corresponding to the data
 for data ∈ node_data(n)
-    constraints_data(m, n, 𝒯, 𝒫, modeltype, data)
+    constraints_ext_data(m, n, 𝒯, 𝒫, modeltype, data)
 end
 ```
 
 There is always a fallback option if a `ExtensionData` is specified, but no functions are provided:
 
 ```julia
-constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::ExtensionData) = nothing
+constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::ExtensionData) = nothing
 ```
 
 Its application is best explained by the implemented functionality for emissions.
+
+!!! warning "Renamed types and functions"
+    We renamed `Data` to `ExtensionData` while retaining the original `Data` type to avoid breaking changes.
+    If you provide new extension data in one of your packages, we recommend that you adjust the subtyping.
+
+    We renamed the function `constraints_data` with `constraints_ext_data` while keeping the original function and its call within the individual [`create_node`](@ref EnergyModelsBase.create_node) functions.
+
+    The legacy functions will be removed in version 0.10.
 
 ## [Emissions data](@id man-data_fun-emissions)
 
@@ -36,11 +44,11 @@ The individual fields of the different types are described in the *[Public inter
 The extension is then implemented through the functions
 
 ```julia
-function constraints_data(m, n::Node, 𝒯, 𝒫, modeltype, data::EmissionsEnergy)
-function constraints_data(m, n::Node, 𝒯, 𝒫, modeltype, data::EmissionsProcess)
-function constraints_data(m, n::Node, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
-function constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureProcessEmissions)
-function constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureProcessEnergyEmissions)
+function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype, data::EmissionsEnergy)
+function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype, data::EmissionsProcess)
+function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
+function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureProcessEmissions)
+function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureProcessEnergyEmissions)
 ```
 
 in the file `data_functions.jl`.

--- a/docs/src/manual/philosophy.md
+++ b/docs/src/manual/philosophy.md
@@ -73,12 +73,12 @@ This is done in the package [`EnergyModelsInvestments`](https://energymodelsx.gi
 It can be problematic when one also wants to use investments.
 In addition, care has to be taken with respect to method amibiguity when dispatching on the type `EnergyModel`.
 
-The `Array{Data}` field provides us with flexibility with respect to providing additional data to the existing nodes.
+The `Array{ExtensionData}` field provides us with flexibility with respect to providing additional data to the existing nodes.
 It is implemented in `EnergyModelsBase` for including emissions (both process and energy usage related).
 In that case, it allows for flexibility through either saying whether process (or energy related emissions) are present, or not.
 In addition, it allows for capturing the CO₂ from either the individual CO₂ sources (process and energy usage related), alternatively from both sources, or not at all.
-The individual data types are explained in the Section *[Additional data](@ref lib-pub-mod_data-data)* in the public library as well as on *[Data functions](@ref man-data_fun)*.
-In addition, it is already used in the package [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) through the introduction of the `abstract type` `InvestmentData` as subtype of `Data`.
+The individual data types are explained in the Section *[Additional data](@ref lib-pub-mod_data-data)* in the public library as well as on *[ExtensionData functions](@ref man-data_fun)*.
+In addition, it is already used in the package [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) through the introduction of the `abstract type` `InvestmentData` as subtype of `ExtensionData`.
 The introduction of `InvestmentData` allows providing additional parameters to individual technologies.
-However, the implementation in `EnergyModelsInvestments` does not utilize the extension through the *[Data functions](@ref man-data_fun)*.
+However, the implementation in `EnergyModelsInvestments` does not utilize the extension through the *[ExtensionData functions](@ref man-data_fun)*.
 Instead, as outlined above, it dispatches on the type `EnergyModel`.

--- a/docs/src/nodes/availability.md
+++ b/docs/src/nodes/availability.md
@@ -66,7 +66,7 @@ The variables of [`Availability`](@ref) nodes include:
 
 ### [Constraints](@id nodes-availability-math-con)
 
-Availability nodes do not add by default any constraints, except for the constraints introduced in the function `create_node`(@ref).
+Availability nodes do not add by default any constraints, except for the constraints introduced in the function [`create_node`](@ref).
 This constraint is given by:
 
 ```math

--- a/docs/src/nodes/networknode.md
+++ b/docs/src/nodes/networknode.md
@@ -28,7 +28,7 @@ The fields of a [`RefNetworkNode`](@ref) are given as:
   CO₂ cannot be directly specified, *i.e.*, you cannot specify a ratio.
   If you use [`CaptureData`](@ref), it is however necessary to specify CO₂ as output, although the ratio is not important.\
   All values have to be non-negative.
-- **`data::Vector{Data}`**:\
+- **`data::Vector{ExtensionData}`**:\
   An entry for providing additional data to the model.
   In the current version, it is used for both providing `EmissionsData` and additional investment data when [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) is used.
   !!! note "Constructor for RefNetworkNode"

--- a/docs/src/nodes/networknode.md
+++ b/docs/src/nodes/networknode.md
@@ -132,5 +132,5 @@ Hence, if you do not have to call additional functions, but only plan to include
       The function [``scale\_op\_sp(t_{inv}, t)``](@ref scale_op_sp) calculates the scaling factor between operational and investment periods.
       It also takes into account potential operational scenarios and their probability as well as representative periods.
 
-- `constraints_data`:\
+- `constraints_ext_data`:\
   This function is only called for specified data of the nodes, see above.

--- a/docs/src/nodes/sink.md
+++ b/docs/src/nodes/sink.md
@@ -121,5 +121,5 @@ Hence, if you do not have to call additional functions, but only plan to include
       The function [``scale\_op\_sp(t_{inv}, t)``](@ref scale_op_sp) calculates the scaling factor between operational and investment periods.
       It also takes into account potential operational scenarios and their probability as well as representative periods.
 
-- `constraints_data`:\
+- `constraints_ext_data`:\
   This function is only called for specified additional data, see above.

--- a/docs/src/nodes/sink.md
+++ b/docs/src/nodes/sink.md
@@ -23,7 +23,7 @@ The fields of a [`RefSink`](@ref) node are given as:
 - **`input::Dict{<:Resource,<:Real}`**:\
   The field `input` includes [`Resource`](@ref Resource)s with their corresponding conversion factors as dictionaries.\
   All values have to be non-negative.
-- **`data::Vector{Data}`**:\
+- **`data::Vector{ExtensionData}`**:\
   An entry for providing additional data to the model.
   In the current version, it is used for both providing `EmissionsData` and additional investment data when [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) is used.
   !!! note "Constructor for `RefSink`"

--- a/docs/src/nodes/source.md
+++ b/docs/src/nodes/source.md
@@ -29,7 +29,7 @@ The fields of a [`RefSource`](@ref) node are given as:
   If you would like to use a `Source` node with CO₂ as output with a given ratio, it is necessary to utilize the package [`EnergyModelsCO2`](https://energymodelsx.github.io/EnergyModelsCO2.jl/).
   If you use [`CaptureData`](@ref), it is however necessary to specify CO₂ as output, although the ratio is not important.\
   All values have to be non-negative.
-- **`data::Vector{Data}`**:\
+- **`data::Vector{ExtensionData}`**:\
   An entry for providing additional data to the model.
   In the current version, it is used for both providing `EmissionsData` and additional investment data when [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) is used.
   When using `EmissionsData`, only process emissions can be considered, that is the types [`EmissionsProcess`](@ref) and that is the types [`EmissionsProcess`](@ref) and [`CaptureProcessEmissions`](@ref).

--- a/docs/src/nodes/source.md
+++ b/docs/src/nodes/source.md
@@ -129,5 +129,5 @@ Hence, if you do not have to call additional functions, but only plan to include
       The function [``scale\_op\_sp(t_{inv}, t)``](@ref scale_op_sp) calculates the scaling factor between operational and investment periods.
       It also takes into account potential operational scenarios and their probability as well as representative periods.
 
-- `constraints_data`:\
+- `constraints_ext_data`:\
   This function is only called for specified additional data, see above.

--- a/docs/src/nodes/storage.md
+++ b/docs/src/nodes/storage.md
@@ -231,7 +231,7 @@ Hence, if you do not have to call additional functions, but only plan to include
       The function [``scale\_op\_sp(t_{inv}, t)``](@ref scale_op_sp) calculates the scaling factor between operational and investment periods.
       It also takes into account potential operational scenarios and their probability as well as representative periods.
 
-- `constraints_data`:\
+- `constraints_ext_data`:\
   This function is only called for specified data of the storage node, see above.
 
 !!! info "Implementation of capacity and OPEX"

--- a/docs/src/nodes/storage.md
+++ b/docs/src/nodes/storage.md
@@ -81,7 +81,7 @@ The fields of a [`RefStorage`](@ref) are given as:
       In the current implementation, we do not consider `output` conversion factors for the outflow from the [`RefStorage`](@ref) node.
       Similarly, we do not consider the `input` conversion factor of the stored resource.
       Instead, it is assumed that there is no loss of the stored resource in the storage.
-- **`data::Vector{Data}`**:\
+- **`data::Vector{ExtensionData}`**:\
   An entry for providing additional data to the model.
   In the current version, it is used for both providing `EmissionsData` and additional investment data when [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) is used.
   !!! note "Constructor for `RefStorage`"

--- a/ext/EMIExt/variables_capex.jl
+++ b/ext/EMIExt/variables_capex.jl
@@ -1,6 +1,7 @@
 """
-    EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::AbstractInvestmentModel)
-    EMB.variables_capex(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::AbstractInvestmentModel)
+    EMB.variables_data(m, _::Type{SingleInvData}, 𝒩ᴵⁿᵛ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
+    EMB.variables_data(m, _::Type{StorageInvData}, 𝒩ᴵⁿᵛ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
+    EMB.variables_data(m, _::Type{SingleInvData}, 𝒩ᴵⁿᵛ::Vector{<:Link}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
 
 Declaration of different capital expenditures (CAPEX) variables for the element types
 introduced in `EnergyModelsBase`. CAPEX variables are only introduced for elements that have
@@ -37,23 +38,22 @@ user with two individual methods for both `𝒩::Vector{<:EMB.Node}` and 𝒩::V
     - `**prefix**_remove_b` is an auxiliary variable used in some investment modes for the
       reduction of capacities.
 """
-function EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::AbstractInvestmentModel)
-    𝒩ᴵⁿᵛ = filter(has_investment, filter(!EMB.is_storage, 𝒩))
-    𝒩ˢᵗᵒʳ = filter(EMB.is_storage, 𝒩)
-    𝒩ˡᵉᵛᵉˡ = filter(n -> has_investment(n, :level), 𝒩ˢᵗᵒʳ)
-    𝒩ᶜʰᵃʳᵍᵉ = filter(n -> has_investment(n, :charge), 𝒩ˢᵗᵒʳ)
-    𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ = filter(n -> has_investment(n, :discharge), 𝒩ˢᵗᵒʳ)
+function EMB.variables_data(m, _::Type{SingleInvData}, 𝒩ᴵⁿᵛ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-    # Add investment variables for reference nodes for each strategic period:
+    # Add investment variables for nodes for each strategic period
     @variable(m, cap_capex[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0)
     @variable(m, cap_current[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0)
     @variable(m, cap_add[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0)
     @variable(m, cap_rem[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0)
     @variable(m, cap_invest_b[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
     @variable(m, cap_remove_b[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
+end
+function EMB.variables_data(m, _::Type{StorageInvData}, 𝒩ˢᵗᵒʳ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::EnergyModel)
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-    # Add storage specific investment variables for each strategic period:
+    # Add investment variables for storage nodes for each strategic period
+    𝒩ˡᵉᵛᵉˡ = filter(n -> has_investment(n, :level), 𝒩ˢᵗᵒʳ)
     @variable(m, stor_level_capex[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] ≥ 0)
     @variable(m, stor_level_current[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] ≥ 0)
     @variable(m, stor_level_add[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] ≥ 0)
@@ -61,6 +61,7 @@ function EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳ᵛᵉᶜ, 𝒯, m
     @variable(m, stor_level_invest_b[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
     @variable(m, stor_level_remove_b[𝒩ˡᵉᵛᵉˡ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
 
+    𝒩ᶜʰᵃʳᵍᵉ = filter(n -> has_investment(n, :charge), 𝒩ˢᵗᵒʳ)
     @variable(m, stor_charge_capex[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0)
     @variable(m, stor_charge_current[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0)
     @variable(m, stor_charge_add[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0)
@@ -68,6 +69,7 @@ function EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳ᵛᵉᶜ, 𝒯, m
     @variable(m, stor_charge_invest_b[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
     @variable(m, stor_charge_remove_b[𝒩ᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
 
+    𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ = filter(n -> has_investment(n, :discharge), 𝒩ˢᵗᵒʳ)
     @variable(m, stor_discharge_capex[𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0)
     @variable(m, stor_discharge_current[𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0)
     @variable(m, stor_discharge_add[𝒩ᵈⁱˢᶜʰᵃʳᵍᵉ, 𝒯ᴵⁿᵛ] ≥ 0)
@@ -83,11 +85,10 @@ function EMB.variables_capex(m, 𝒩::Vector{<:EMB.Node}, 𝒳ᵛᵉᶜ, 𝒯, m
         container = IndexedVarArray
     )
 end
-function EMB.variables_capex(m, ℒ::Vector{<:Link}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::AbstractInvestmentModel)
-    ℒᴵⁿᵛ = filter(has_investment, ℒ)
+function EMB.variables_data(m, _::Type{SingleInvData}, ℒᴵⁿᵛ::Vector{<:Link}, 𝒯, 𝒫, modeltype::EnergyModel)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-    # Add investment variables for reference nodes for each strategic period:
+    # Add investment variables for links for each strategic period
     @variable(m, link_cap_capex[ℒᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0)
     @variable(m, link_cap_current[ℒᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0)
     @variable(m, link_cap_add[ℒᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0)

--- a/ext/EMIExt/variables_capex.jl
+++ b/ext/EMIExt/variables_capex.jl
@@ -38,7 +38,14 @@ user with two individual methods for both `𝒩::Vector{<:EMB.Node}` and 𝒩::V
     - `**prefix**_remove_b` is an auxiliary variable used in some investment modes for the
       reduction of capacities.
 """
-function EMB.variables_ext_data(m, _::Type{SingleInvData}, 𝒩ᴵⁿᵛ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
+function EMB.variables_ext_data(
+    m,
+    _::Type{SingleInvData},
+    𝒩ᴵⁿᵛ::Vector{<:EMB.Node},
+    𝒯,
+    𝒫,
+    modeltype::AbstractInvestmentModel,
+)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # Add investment variables for nodes for each strategic period
@@ -49,7 +56,14 @@ function EMB.variables_ext_data(m, _::Type{SingleInvData}, 𝒩ᴵⁿᵛ::Vector
     @variable(m, cap_invest_b[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
     @variable(m, cap_remove_b[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
 end
-function EMB.variables_ext_data(m, _::Type{StorageInvData}, 𝒩ˢᵗᵒʳ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::EnergyModel)
+function EMB.variables_ext_data(
+    m,
+    _::Type{StorageInvData},
+    𝒩ˢᵗᵒʳ::Vector{<:EMB.Node},
+    𝒯,
+    𝒫,
+    modeltype::EnergyModel,
+)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # Add investment variables for storage nodes for each strategic period
@@ -85,7 +99,14 @@ function EMB.variables_ext_data(m, _::Type{StorageInvData}, 𝒩ˢᵗᵒʳ::Vect
         container = IndexedVarArray
     )
 end
-function EMB.variables_ext_data(m, _::Type{SingleInvData}, ℒᴵⁿᵛ::Vector{<:Link}, 𝒯, 𝒫, modeltype::EnergyModel)
+function EMB.variables_ext_data(
+    m,
+    _::Type{SingleInvData},
+    ℒᴵⁿᵛ::Vector{<:Link},
+    𝒯,
+    𝒫,
+    modeltype::EnergyModel
+)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # Add investment variables for links for each strategic period

--- a/ext/EMIExt/variables_capex.jl
+++ b/ext/EMIExt/variables_capex.jl
@@ -1,7 +1,7 @@
 """
-    EMB.variables_data(m, _::Type{SingleInvData}, 𝒩ᴵⁿᵛ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
-    EMB.variables_data(m, _::Type{StorageInvData}, 𝒩ᴵⁿᵛ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
-    EMB.variables_data(m, _::Type{SingleInvData}, 𝒩ᴵⁿᵛ::Vector{<:Link}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
+    EMB.variables_ext_data(m, _::Type{SingleInvData}, 𝒩ᴵⁿᵛ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
+    EMB.variables_ext_data(m, _::Type{StorageInvData}, 𝒩ᴵⁿᵛ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
+    EMB.variables_ext_data(m, _::Type{SingleInvData}, 𝒩ᴵⁿᵛ::Vector{<:Link}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
 
 Declaration of different capital expenditures (CAPEX) variables for the element types
 introduced in `EnergyModelsBase`. CAPEX variables are only introduced for elements that have
@@ -38,7 +38,7 @@ user with two individual methods for both `𝒩::Vector{<:EMB.Node}` and 𝒩::V
     - `**prefix**_remove_b` is an auxiliary variable used in some investment modes for the
       reduction of capacities.
 """
-function EMB.variables_data(m, _::Type{SingleInvData}, 𝒩ᴵⁿᵛ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
+function EMB.variables_ext_data(m, _::Type{SingleInvData}, 𝒩ᴵⁿᵛ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # Add investment variables for nodes for each strategic period
@@ -49,7 +49,7 @@ function EMB.variables_data(m, _::Type{SingleInvData}, 𝒩ᴵⁿᵛ::Vector{<:E
     @variable(m, cap_invest_b[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
     @variable(m, cap_remove_b[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] ≥ 0; container = IndexedVarArray)
 end
-function EMB.variables_data(m, _::Type{StorageInvData}, 𝒩ˢᵗᵒʳ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::EnergyModel)
+function EMB.variables_ext_data(m, _::Type{StorageInvData}, 𝒩ˢᵗᵒʳ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::EnergyModel)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # Add investment variables for storage nodes for each strategic period
@@ -85,7 +85,7 @@ function EMB.variables_data(m, _::Type{StorageInvData}, 𝒩ˢᵗᵒʳ::Vector{<
         container = IndexedVarArray
     )
 end
-function EMB.variables_data(m, _::Type{SingleInvData}, ℒᴵⁿᵛ::Vector{<:Link}, 𝒯, 𝒫, modeltype::EnergyModel)
+function EMB.variables_ext_data(m, _::Type{SingleInvData}, ℒᴵⁿᵛ::Vector{<:Link}, 𝒯, 𝒫, modeltype::EnergyModel)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # Add investment variables for links for each strategic period

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -82,7 +82,7 @@ export constraints_capacity, constraints_capacity_installed
 export constraints_flow_in, constraints_flow_out
 export constraints_level, constraints_level_aux
 export constraints_opex_fixed, constraints_opex_var
-export constraints_data
+export constraints_data, constraints_ext_data
 
 # Export functions used for level balancing modifications
 export previous_level, previous_level_sp

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -6,7 +6,7 @@ In addition, all required functions for creaeting and running the model are expo
 
 You can find the exported types and functions below or on the pages
 *[Constraint functions](@ref man-con)* and
-*[Data functions](@ref man-data_fun)*.
+*[ExtensionData functions](@ref man-data_fun)*.
 """
 module EnergyModelsBase
 
@@ -58,7 +58,7 @@ export Cyclic, CyclicRepresentative, CyclicStrategic
 export StorCapOpex, StorCap, StorCapOpexVar, StorCapOpexFixed, StorOpexVar
 
 # Export the data types
-export Data, EmptyData, EmissionsData, CaptureData
+export Data, ExtensionData, EmptyData, EmissionsData, CaptureData
 export CaptureProcessEnergyEmissions, CaptureProcessEmissions, CaptureEnergyEmissions
 export EmissionsProcess, EmissionsEnergy
 

--- a/src/EnergyModelsBase.jl
+++ b/src/EnergyModelsBase.jl
@@ -41,7 +41,7 @@ export get_time_struct, get_products, get_elements_vec, get_nodes, get_links, ge
 # Export the general classes
 export EnergyModel, OperationalModel
 export Resource, ResourceCarrier, ResourceEmit
-export AbstractElement
+export AbstractElement, element_data
 
 # Export the different node types
 export Source, NetworkNode, Sink, Storage, Availability

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -170,7 +170,7 @@ and Vector{<:Link}.
 !!! note "Node methods"
     All nodes are checked through the functions
     - [`check_node`](@ref) to identify problematic input,
-    - [`check_node_data`](@ref EnergyModelsBase.check_node_data(n::Node, data::Data, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool))
+    - [`check_node_data`](@ref EnergyModelsBase.check_node_data(n::Node, data::ExtensionData, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool))
       issues in the provided additional data, and
     - [`check_time_structure`](@ref) to identify time profiles at the highest level that
       are not equivalent to the provided timestructure.
@@ -178,7 +178,7 @@ and Vector{<:Link}.
 !!! note "Links methods"
     All links are checked through the functions
     - [`check_link`](@ref) to identify problematic input,
-    - [`check_link_data`](@ref EnergyModelsBase.check_link_data(l::Link, data::Data, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool))
+    - [`check_link_data`](@ref EnergyModelsBase.check_link_data(l::Link, data::ExtensionData, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool))
       to identify issues in the provided additional data, and
     - [`check_time_structure`](@ref) to identify time profiles at the highest level that
       are not equivalent to the provided timestructure.
@@ -910,10 +910,10 @@ function check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles::Bool)
 end
 
 """
-    check_node_data(n::Node, data::Data, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_node_data(n::Node, data::ExtensionData, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
     check_node_data(n::Node, data::EmissionsData, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
-Check that the included `Data` types of a `Node` correspond to required structure.
+Check that the included `ExtensionData` types of a `Node` correspond to required structure.
 
 ## Checks `EmissionsData`
 - Each node can only have a single `EmissionsData`.
@@ -921,7 +921,7 @@ Check that the included `Data` types of a `Node` correspond to required structur
 - The value of the field `co2_capture` is required to be in the range ``[0, 1]``, if
   [`CaptureData`](@ref) is used.
 """
-check_node_data(n::Node, data::Data, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool) =
+check_node_data(n::Node, data::ExtensionData, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool) =
     nothing
 function check_node_data(
     n::Node,
@@ -988,9 +988,9 @@ functionality does not check anthing, aside from the checks performed in [`check
 check_link(n::Link, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool) = nothing
 
 """
-    check_link_data(l::Link, data::Data, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_link_data(l::Link, data::ExtensionData, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
-Check that the included `Data` types of a `Link` correspond to required structure.
+Check that the included `ExtensionData` types of a `Link` correspond to required structure.
 """
-check_link_data(l::Link, data::Data, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool) =
+check_link_data(l::Link, data::ExtensionData, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool) =
     nothing

--- a/src/data_functions.jl
+++ b/src/data_functions.jl
@@ -162,10 +162,10 @@ function constraints_data(
 end
 
 """
-    constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::Data)
+    constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::ExtensionData)
 
 Fallback option when data is specified, but it is not desired to add the constraints through
 this function. This is, *e.g.*, the case for `EnergyModelsInvestments` as the capacity
 constraint has to be replaced.
 """
-constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::Data) = nothing
+constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::ExtensionData) = nothing

--- a/src/data_functions.jl
+++ b/src/data_functions.jl
@@ -1,9 +1,9 @@
 """
-    constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsEnergy)
-    constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
-    constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
-    constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureProcessEmissions)
-    constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureProcessEnergyEmissions)
+    constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsEnergy)
+    constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
+    constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
+    constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureProcessEmissions)
+    constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureProcessEnergyEmissions)
 
 Constraints functions for calculating both the emissions and amount of CO₂ captured in the
 process. If the data ia a [`CaptureData`](@ref), it provides the constraint for the variable
@@ -19,7 +19,7 @@ There exist several configurations:
 - **[`CaptureProcessEnergyEmissions`](@ref)** corresponds to capture of both process and energy
    usage related emissions.
 """
-function constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsEnergy)
+function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsEnergy)
 
     # Declaration of the required subsets.
     𝒫ⁱⁿ = inputs(n)
@@ -36,7 +36,7 @@ function constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::
         fix(m[:emissions_node][n, t, p_em], 0, ; force = true)
     end
 end
-function constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
+function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
 
     # Declaration of the required subsets.
     𝒫ⁱⁿ = inputs(n)
@@ -56,7 +56,7 @@ function constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::
         m[:cap_use][n, t] * process_emissions(data, p_em, t)
     )
 end
-function constraints_data(
+function constraints_ext_data(
     m,
     n::Node,
     𝒯,
@@ -91,7 +91,7 @@ function constraints_data(
     # Constraint for the outlet of the CO2
     @constraint(m, [t ∈ 𝒯], m[:flow_out][n, t, CO2] == CO2_tot[t] * co2_capture(data))
 end
-function constraints_data(
+function constraints_ext_data(
     m,
     n::Node,
     𝒯,
@@ -126,7 +126,7 @@ function constraints_data(
     # Constraint for the outlet of the CO2
     @constraint(m, [t ∈ 𝒯], m[:flow_out][n, t, CO2] == CO2_tot[t] * co2_capture(data))
 end
-function constraints_data(
+function constraints_ext_data(
     m,
     n::Node,
     𝒯,
@@ -162,10 +162,20 @@ function constraints_data(
 end
 
 """
-    constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::ExtensionData)
+    constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::ExtensionData)
 
 Fallback option when data is specified, but it is not desired to add the constraints through
 this function. This is, *e.g.*, the case for `EnergyModelsInvestments` as the capacity
 constraint has to be replaced.
 """
-constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::ExtensionData) = nothing
+constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::ExtensionData) = nothing
+
+"""
+    constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::ExtensionData)
+
+Legacy function for calling the new function [`constraints_ext_data`](@ref).
+The function will be removed in release 0.10.
+"""
+function constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::ExtensionData)
+    constraints_ext_data(m, n, 𝒯, 𝒫, modeltype, data)
+end

--- a/src/legacy_constructor.jl
+++ b/src/legacy_constructor.jl
@@ -86,7 +86,7 @@ function RefStorage(
         stor_res,
         input,
         output,
-        Data[],
+        ExtensionData[],
     )
     return tmp
 end
@@ -181,7 +181,7 @@ function RefStorage(
         stor_res,
         input,
         output,
-        Data[],
+        ExtensionData[],
     )
     return tmp
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -51,7 +51,7 @@ function create_model(
         )
     end
 
-    # WIP Data structure
+    # Extract the information from the `Case`
     𝒯 = get_time_struct(case)
     𝒫 = get_products(case)
     𝒳ᵛᵉᶜ = get_elements_vec(case)
@@ -442,7 +442,7 @@ function variables_element_data(
     𝒫,
     modeltype::EnergyModel
 )
-    # Extract all Data types within all elements
+    # Extract all ExtensionData types within all elements
     𝒟 = reduce(vcat, [element_data(x) for x ∈ 𝒳])
 
     # Skip if no data is added to the individual elements
@@ -450,9 +450,9 @@ function variables_element_data(
 
     # Vector of the unique data types in 𝒟.
     data_composite_types = unique(typeof.(𝒟))
-    # Get all `Data`-types in the type-hierarchy that the nodes 𝒟 represents.
+    # Get all `ExtensionData`-types in the type-hierarchy that the nodes 𝒟 represents.
     data_types = collect_types(data_composite_types)
-    # Sort the `Data`-types such that a supertype will always come before its subtypes.
+    # Sort the `ExtensionData`-types such that a supertype will always come before its subtypes.
     data_types = sort_types(data_types)
 
     for data_type ∈ data_types
@@ -497,7 +497,7 @@ variables_element(m, ℒˢᵘᵇ::Vector{<:Link}, 𝒯, modeltype::EnergyModel) 
     variables_link(m, ℒˢᵘᵇ, 𝒯, modeltype)
 
 """
-    variables_data(m, _::Type{<:Data}, 𝒳::Vector{<:AbstractElement}, 𝒯, 𝒫, modeltype::EnergyModel)
+    variables_data(m, _::Type{<:ExtensionData}, 𝒳::Vector{<:AbstractElement}, 𝒯, 𝒫, modeltype::EnergyModel)
 
 Default fallback method for the variables creation for a data type of a `Vector{<:AbstractElement}`
 `𝒳` if no other method is defined. The default method does not specify any variables.
@@ -507,7 +507,7 @@ Default fallback method for the variables creation for a data type of a `Vector{
     consequence, methods, and hence, variables for [`Node`](@ref)s and [`Link`](@ref)s must
     be specified specifically.
 """
-function variables_data(m, _::Type{<:Data}, 𝒳::Vector{<:AbstractElement}, 𝒯, 𝒫, modeltype::EnergyModel)
+function variables_data(m, _::Type{<:ExtensionData}, 𝒳::Vector{<:AbstractElement}, 𝒯, 𝒫, modeltype::EnergyModel)
 end
 
 """

--- a/src/model.jl
+++ b/src/model.jl
@@ -65,7 +65,7 @@ function create_model(
         variables_capex(m, 𝒳, 𝒳ᵛᵉᶜ, 𝒯, modeltype)
         variables_emission(m, 𝒳, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype)
         variables_elements(m, 𝒳, 𝒳ᵛᵉᶜ, 𝒯, modeltype)
-        variables_element_data(m, 𝒳, 𝒳ᵛᵉᶜ, 𝒯, 𝒫, modeltype)
+        variables_element_ext_data(m, 𝒳, 𝒳ᵛᵉᶜ, 𝒯, 𝒫, modeltype)
 
         constraints_elements(m, 𝒳, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype)
     end
@@ -426,15 +426,15 @@ function variables_elements(m, 𝒳::Vector{<:AbstractElement}, 𝒳ᵛᵉᶜ, �
 end
 
 """
-    variables_element_data(m, 𝒳::Vector{<:AbstractElement}, 𝒳ᵛᵉᶜ, 𝒯, 𝒫,modeltype::EnergyModel)
+    variables_element_ext_data(m, 𝒳::Vector{<:AbstractElement}, 𝒳ᵛᵉᶜ, 𝒯, 𝒫,modeltype::EnergyModel)
 
 Loop through all data subtypes and create variables specific to each subtype. It starts
 at the top level and subsequently move through the branches until it reaches a leave.
 
-The function subsequently calls the subroutine [`variables_data`](@ref) for creating the
+The function subsequently calls the subroutine [`variables_ext_data`](@ref) for creating the
 variables for the nodes that have the corresponding data types.
 """
-function variables_element_data(
+function variables_element_ext_data(
     m,
     𝒳::Vector{<:AbstractElement},
     𝒳ᵛᵉᶜ,
@@ -459,7 +459,7 @@ function variables_element_data(
         # All elements with the given data sub type.
         𝒳ᵈᵃᵗ = filter(x -> any(isa.(element_data(x), data_type)), 𝒳)
         try
-            variables_data(m, data_type, 𝒳ᵈᵃᵗ, 𝒯, 𝒫, modeltype)
+            variables_ext_data(m, data_type, 𝒳ᵈᵃᵗ, 𝒯, 𝒫, modeltype)
         catch e
             # Parts of the exception message we are looking for
             pre1 = "An object of name"
@@ -497,7 +497,7 @@ variables_element(m, ℒˢᵘᵇ::Vector{<:Link}, 𝒯, modeltype::EnergyModel) 
     variables_link(m, ℒˢᵘᵇ, 𝒯, modeltype)
 
 """
-    variables_data(m, _::Type{<:ExtensionData}, 𝒳::Vector{<:AbstractElement}, 𝒯, 𝒫, modeltype::EnergyModel)
+    variables_ext_data(m, _::Type{<:ExtensionData}, 𝒳::Vector{<:AbstractElement}, 𝒯, 𝒫, modeltype::EnergyModel)
 
 Default fallback method for the variables creation for a data type of a `Vector{<:AbstractElement}`
 `𝒳` if no other method is defined. The default method does not specify any variables.
@@ -507,7 +507,14 @@ Default fallback method for the variables creation for a data type of a `Vector{
     consequence, methods, and hence, variables for [`Node`](@ref)s and [`Link`](@ref)s must
     be specified specifically.
 """
-function variables_data(m, _::Type{<:ExtensionData}, 𝒳::Vector{<:AbstractElement}, 𝒯, 𝒫, modeltype::EnergyModel)
+function variables_ext_data(
+    m,
+    _::Type{<:ExtensionData},
+    𝒳::Vector{<:AbstractElement},
+    𝒯,
+    𝒫,
+    modeltype::EnergyModel
+)
 end
 
 """

--- a/src/structures/data.jl
+++ b/src/structures/data.jl
@@ -1,11 +1,17 @@
-""" Abstract type used to define concrete struct containing the package specific elements
-to add to the composite type defined in this package."""
-abstract type Data end
-""" Empty composite type for `Data`"""
-struct EmptyData <: Data end
+"""
+    abstract type ExtensionData
+
+Abstract type used to define concrete struct containing the package specific elements
+to add to the composite type defined in this package.
+"""
+abstract type ExtensionData end
+Data = ExtensionData
+
+""" Empty composite type for `ExtensionData`"""
+struct EmptyData <: ExtensionData end
 
 """
-    EmissionsData{T<:Union{TimeProfile,Float64}} <: Data
+    EmissionsData{T<:Union{TimeProfile,Float64}} <: ExtensionData
 
 Abstract type for `EmissionsData` can be used to dispatch on different types of
 capture configurations.
@@ -27,7 +33,7 @@ In general, the different types require the following input:
 - **[`EmissionsEnergy`](@ref)**: No capture and no process emissions. Does not require
   `co2_capture` or `emissions` as input, but will ignore them, if provided.
 """
-abstract type EmissionsData{T<:Union{TimeProfile,Float64}} <: Data end
+abstract type EmissionsData{T<:Union{TimeProfile,Float64}} <: ExtensionData end
 """
     CaptureData{T} <: EmissionsData{T}
 
@@ -166,11 +172,11 @@ process_emissions(data::EmissionsEnergy{T}, p::ResourceEmit, t) where {T} =
     the function `process_emissions`.")
 
 """
-    InvestmentData <: Data
+    InvestmentData <: ExtensionData
 
 Abstract type for the extra data for investing in technologies.
 """
-abstract type InvestmentData <: Data end
+abstract type InvestmentData <: ExtensionData end
 
 """
     StorageInvData <: InvestmentData

--- a/src/structures/element.jl
+++ b/src/structures/element.jl
@@ -19,11 +19,11 @@ abstract type AbstractElement end
 """
     element_data(x::AbstractElement)
 
-Returns the [`Data`](@ref) array of [`AbstractElement`](@ref) `x`. The function requires the
+Returns the [`ExtensionData`](@ref) array of [`AbstractElement`](@ref) `x`. The function requires the
 specification of a new method for each `AbstractElement`.
 
 It is implemented in `EnergyModelsBase` for
 - [`Node`](@ref) calling the subfunction [`node_data`](@ref) and
 - [`Link`](@ref) calling the subfunction [`link_data`](@ref).
 """
-element_data(x::AbstractElement) = Data[]
+element_data(x::AbstractElement) = ExtensionData[]

--- a/src/structures/element.jl
+++ b/src/structures/element.jl
@@ -14,3 +14,16 @@ an energy system.
     and constraints.
 """
 abstract type AbstractElement end
+
+
+"""
+    element_data(x::AbstractElement)
+
+Returns the [`Data`](@ref) array of [`AbstractElement`](@ref) `x`. The function requires the
+specification of a new method for each `AbstractElement`.
+
+It is implemented in `EnergyModelsBase` for
+- [`Node`](@ref) calling the subfunction [`node_data`](@ref) and
+- [`Link`](@ref) calling the subfunction [`link_data`](@ref).
+"""
+element_data(x::AbstractElement) = Data[]

--- a/src/structures/link.jl
+++ b/src/structures/link.jl
@@ -124,9 +124,9 @@ formulation(l::Link) = l.formulation
 """
     link_data(l::Link)
 
-Returns the [`Data`](@ref) array of link `l`.
+Returns the [`ExtensionData`](@ref) array of link `l`.
 
-The default options returns an empty `Data` vector.
+The default options returns an empty `ExtensionData` vector.
 """
-link_data(l::Link) = Data[]
+link_data(l::Link) = ExtensionData[]
 element_data(l::Link) = link_data(l)

--- a/src/structures/link.jl
+++ b/src/structures/link.jl
@@ -129,3 +129,4 @@ Returns the [`Data`](@ref) array of link `l`.
 The default options returns an empty `Data` vector.
 """
 link_data(l::Link) = Data[]
+element_data(l::Link) = link_data(l)

--- a/src/structures/node.jl
+++ b/src/structures/node.jl
@@ -97,7 +97,8 @@ end
     struct StorCap <: AbstractStorageParameters
 
 A storage parameter type for including only a capacity. This implies that neither the usage
-of the [`Storage`](@ref), nor the installed capacity have a direct impact on the objective function.
+of the [`Storage`](@ref), nor the installed capacity have a direct impact on the objective
+function.
 
 # Fields
 - **`capacity::TimeProfile`** is the installed capacity.
@@ -225,8 +226,8 @@ or `StrategicProfile`.
   through the variable `:cap_inst`.
 - **`output::Dict{<:Resource,<:Real}`** are the generated [`Resource`](@ref)s with
   conversion value `Real`.
-- **`data::Vector{<:Data}`** is the additional data (*e.g.*, for investments). The field `data`
-  is conditional through usage of a constructor.
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments).
+  The field `data` is conditional through usage of a constructor.
 """
 struct RefSource <: Source
     id::Any
@@ -234,7 +235,7 @@ struct RefSource <: Source
     opex_var::TimeProfile
     opex_fixed::TimeProfile
     output::Dict{<:Resource,<:Real}
-    data::Vector{<:Data}
+    data::Vector{<:ExtensionData}
 end
 function RefSource(
     id,
@@ -243,7 +244,7 @@ function RefSource(
     opex_fixed::TimeProfile,
     output::Dict{<:Resource,<:Real},
 )
-    return RefSource(id, cap, opex_var, opex_fixed, output, Data[])
+    return RefSource(id, cap, opex_var, opex_fixed, output, ExtensionData[])
 end
 
 """
@@ -266,8 +267,8 @@ The capacity is hereby normalized to a conversion value of 1 in the fields `inpu
   value `Real`.
 - **`output::Dict{<:Resource,<:Real}`** are the generated [`Resource`](@ref)s with
   conversion value `Real`.
-- **`data::Vector{Data}`** is the additional data (*e.g.*, for investments). The field `data`
-  is conditional through usage of a constructor.
+- **`data::Vector{ExtensionData}`** is the additional data (*e.g.*, for investments).
+  The field `data` is conditional through usage of a constructor.
 """
 struct RefNetworkNode <: NetworkNode
     id::Any
@@ -276,7 +277,7 @@ struct RefNetworkNode <: NetworkNode
     opex_fixed::TimeProfile
     input::Dict{<:Resource,<:Real}
     output::Dict{<:Resource,<:Real}
-    data::Vector{<:Data}
+    data::Vector{<:ExtensionData}
 end
 function RefNetworkNode(
     id,
@@ -286,7 +287,7 @@ function RefNetworkNode(
     input::Dict{<:Resource,<:Real},
     output::Dict{<:Resource,<:Real},
 )
-    return RefNetworkNode(id, cap, opex_var, opex_fixed, input, output, Data[])
+    return RefNetworkNode(id, cap, opex_var, opex_fixed, input, output, ExtensionData[])
 end
 
 """
@@ -338,8 +339,8 @@ The current implemented cyclic behaviours are [`CyclicRepresentative`](@ref),
 - **`output::Dict{<:Resource,<:Real}`** are the generated [`Resource`](@ref)s with conversion
   value `Real`. Only relevant for linking and the stored [`Resource`](@ref) as the output
   value is not utilized in the calculations.
-- **`data::Vector{<:Data}`** is the additional data (*e.g.*, for investments). The field `data`
-  is conditional through usage of a constructor.
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments).
+  The field `data` is conditional through usage of a constructor.
 """
 struct RefStorage{T} <: Storage{T}
     id::Any
@@ -348,7 +349,7 @@ struct RefStorage{T} <: Storage{T}
     stor_res::Resource
     input::Dict{<:Resource,<:Real}
     output::Dict{<:Resource,<:Real}
-    data::Vector{<:Data}
+    data::Vector{<:ExtensionData}
 end
 
 function RefStorage{T}(
@@ -359,7 +360,7 @@ function RefStorage{T}(
     input::Dict{<:Resource,<:Real},
     output::Dict{<:Resource,<:Real},
 ) where {T<:StorageBehavior}
-    return RefStorage{T}(id, charge, level, stor_res, input, output, Data[])
+    return RefStorage{T}(id, charge, level, stor_res, input, output, ExtensionData[])
 end
 
 """
@@ -376,15 +377,15 @@ and deficit.
   dictionary requires the  fields `:surplus` and `:deficit`.
 - **`input::Dict{<:Resource,<:Real}`** are the input [`Resource`](@ref)s with conversion
   value `Real`.
-- **`data::Vector{<:Data}`** is the additional data (*e.g.*, for investments). The field `data`
-  is conditional through usage of a constructor.
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments).
+  The field `data` is conditional through usage of a constructor.
 """
 struct RefSink <: Sink
     id::Any
     cap::TimeProfile
     penalty::Dict{Symbol,<:TimeProfile}
     input::Dict{<:Resource,<:Real}
-    data::Vector{<:Data}
+    data::Vector{<:ExtensionData}
 end
 function RefSink(
     id,
@@ -392,7 +393,7 @@ function RefSink(
     penalty::Dict{<:Any,<:TimeProfile},
     input::Dict{<:Resource,<:Real},
 )
-    return RefSink(id, cap, penalty, input, Data[])
+    return RefSink(id, cap, penalty, input, ExtensionData[])
 end
 
 """
@@ -681,10 +682,10 @@ outputs(n::Sink, p::Resource) = nothing
 """
     node_data(n::Node)
 
-Returns the [`Data`](@ref) array of node `n`.
+Returns the [`ExtensionData`](@ref) array of node `n`.
 """
 node_data(n::Node) = n.data
-node_data(n::Availability) = Data[]
+node_data(n::Availability) = ExtensionData[]
 element_data(n::Node) = node_data(n)
 
 """

--- a/src/structures/node.jl
+++ b/src/structures/node.jl
@@ -684,7 +684,8 @@ outputs(n::Sink, p::Resource) = nothing
 Returns the [`Data`](@ref) array of node `n`.
 """
 node_data(n::Node) = n.data
-node_data(n::Availability) = []
+node_data(n::Availability) = Data[]
+element_data(n::Node) = node_data(n)
 
 """
     storage_resource(n::Storage)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ ENV["EMB_TEST"] = true # Set flag for example scripts to check if they are run a
         include("test_general.jl")
     end
 
-    @testset "Base | Data" begin
+    @testset "Base | ExtensionData" begin
         include("test_data.jl")
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,10 @@ ENV["EMB_TEST"] = true # Set flag for example scripts to check if they are run a
         include("test_general.jl")
     end
 
+    @testset "Base | Data" begin
+        include("test_data.jl")
+    end
+
     @testset "Base | Node" begin
         include("test_nodes.jl")
     end

--- a/test/test_data.jl
+++ b/test/test_data.jl
@@ -1,0 +1,160 @@
+@testset "Variable creation" begin
+    # New data type including 2 subtypes
+    abstract type ExampleData <: Data end
+    struct ExampleDataA <: ExampleData
+    end
+    struct ExampleDataB <: ExampleData
+    end
+
+    # Creation of a data link type with associated OPEX
+    struct DataDirect <: Link
+        id::Any
+        from::EMB.Node
+        to::EMB.Node
+        formulation::EMB.Formulation
+        data::Vector{<:Data}
+    end
+
+    EMB.element_data(l::DataDirect) = l.data
+
+    # Subfunctions for the nodes
+    function EMB.variables_data(m, _::Type{<:ExampleData}, 𝒳ᵈᵃᵗ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::EnergyModel)
+        @variable(m, node_example[𝒳ᵈᵃᵗ, 𝒯] ≥ 0)
+    end
+    function EMB.variables_data(m, _::Type{ExampleDataB}, 𝒳ᵈᵃᵗ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::EnergyModel)
+        @variable(m, node_example_b[𝒳ᵈᵃᵗ, 𝒯] ≥ 0)
+    end
+
+    # Subfunctions for the link
+    function EMB.variables_data(m, _::Type{<:ExampleDataA}, 𝒳ᵈᵃᵗ::Vector{<:Link}, 𝒯, 𝒫, modeltype::EnergyModel)
+        @variable(m, link_example_a[𝒳ᵈᵃᵗ, 𝒯] ≥ 0)
+    end
+    function EMB.variables_data(m, _::Type{<:ExampleDataB}, 𝒳ᵈᵃᵗ::Vector{<:Link}, 𝒯, 𝒫, modeltype::EnergyModel)
+        @variable(m, link_example_b[𝒳ᵈᵃᵗ, 𝒯] ≥ 0)
+    end
+    function EMB.create_link(m, l::DataDirect, 𝒯, 𝒫, modeltype::EnergyModel)
+        # Generic link in which each output corresponds to the input
+        @constraint(m, [t ∈ 𝒯, p ∈ EMB.link_res(l)],
+            m[:link_out][l, t, p] == m[:link_in][l, t, p]
+        )
+    end
+
+    # Resources used in the analysis
+    NG = ResourceEmit("NG", 0.2)
+    Coal = ResourceCarrier("Coal", 0.35)
+    Power = ResourceCarrier("Power", 0.0)
+    CO2 = ResourceEmit("CO2", 1.0)
+
+    # Function for setting up the system
+    function simple_graph()
+        # Define the different resources
+        NG = ResourceEmit("NG", 0.2)
+        Coal = ResourceCarrier("Coal", 0.35)
+        Power = ResourceCarrier("Power", 0.0)
+        CO2 = ResourceEmit("CO2", 1.0)
+        products = [NG, Coal, Power, CO2]
+
+        # Creation of the emission data for the individual nodes.
+        capture_data = CaptureEnergyEmissions(0.9)
+        emission_data = EmissionsEnergy()
+
+        # Create the individual test nodes, corresponding to a system with an electricity demand/sink,
+        # coal and nautral gas sources, coal and natural gas (with CCS) power plants and CO2 storage.
+        nodes = [
+            GenAvailability(1, products),
+            RefSource(2, FixedProfile(1e12), FixedProfile(30), FixedProfile(0), Dict(NG => 1), Data[ExampleDataA()]),
+            RefSource(3, FixedProfile(1e12), FixedProfile(9), FixedProfile(0), Dict(Coal => 1), Data[ExampleDataB()]),
+            RefNetworkNode(
+                4,
+                FixedProfile(25),
+                FixedProfile(5.5),
+                FixedProfile(5),
+                Dict(NG => 2),
+                Dict(Power => 1, CO2 => 1),
+                [capture_data, ExampleDataA()],
+            ),
+            RefNetworkNode(
+                5,
+                FixedProfile(25),
+                FixedProfile(6),
+                FixedProfile(10),
+                Dict(Coal => 2.5),
+                Dict(Power => 1),
+                [emission_data, ExampleDataB()],
+            ),
+            RefStorage{AccumulatingEmissions}(
+                6,
+                StorCapOpex(FixedProfile(60), FixedProfile(9.1), FixedProfile(0)),
+                StorCap(FixedProfile(600)),
+                CO2,
+                Dict(CO2 => 1, Power => 0.02),
+                Dict(CO2 => 1),
+                Data[ExampleDataB()],
+            ),
+            RefSink(
+                7,
+                OperationalProfile([20, 30, 40, 30]),
+                Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
+                Dict(Power => 1),
+            ),
+        ]
+
+        # Connect all nodes with the availability node for the overall energy/mass balance
+        links = [
+            DataDirect(14, nodes[1], nodes[4], Linear(), Data[ExampleDataA()])
+            Direct(15, nodes[1], nodes[5], Linear())
+            Direct(16, nodes[1], nodes[6], Linear())
+            Direct(17, nodes[1], nodes[7], Linear())
+            Direct(21, nodes[2], nodes[1], Linear())
+            DataDirect(31, nodes[3], nodes[1], Linear(), Data[ExampleDataB()])
+            Direct(41, nodes[4], nodes[1], Linear())
+            Direct(51, nodes[5], nodes[1], Linear())
+            Direct(61, nodes[6], nodes[1], Linear())
+        ]
+
+        # Creation of the time structure and global data
+        T = TwoLevel(4, 2, SimpleTimes(4, 2), op_per_strat = 8)
+        model = OperationalModel(
+            Dict(CO2 => StrategicProfile([160, 140, 120, 100]), NG => FixedProfile(1e6)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2,
+        )
+
+        # Input data structure
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
+        return case, model
+    end
+
+    # Create the case and the model
+    case, model = simple_graph()
+    m = create_model(case, model)
+
+    # Extract data from the case
+    𝒩 = get_nodes(case)
+    ℒ = get_links(case)
+    𝒯 = get_time_struct(case)
+
+    @testset "Node data" begin
+        # Test that the variables_data function for the abstract type is included for all subtypes
+        @test haskey(m, :node_example)
+        @test sum(nt[1] == 𝒩[2] for nt ∈ keys(m[:node_example])) == length(𝒯)
+        @test sum(nt[1] == 𝒩[3] for nt ∈ keys(m[:node_example])) == length(𝒯)
+        @test sum(nt[1] == 𝒩[4] for nt ∈ keys(m[:node_example])) == length(𝒯)
+        @test sum(nt[1] == 𝒩[6] for nt ∈ keys(m[:node_example])) == length(𝒯)
+
+        # Test that the variables_data for the concrete type is included
+        @test haskey(m, :node_example_b)
+        @test sum(nt[1] == 𝒩[3] for nt ∈ keys(m[:node_example_b])) == length(𝒯)
+        @test sum(nt[1] == 𝒩[5] for nt ∈ keys(m[:node_example_b])) == length(𝒯)
+        @test sum(nt[1] == 𝒩[6] for nt ∈ keys(m[:node_example_b])) == length(𝒯)
+    end
+
+
+    @testset "Link data" begin
+        @test haskey(m, :link_example_a)
+        @test sum(nt[1] == ℒ[1] for nt ∈ keys(m[:link_example_a])) == length(𝒯)
+
+        @test haskey(m, :link_example_b)
+        @test sum(nt[1] == ℒ[6] for nt ∈ keys(m[:link_example_b])) == length(𝒯)
+    end
+end

--- a/test/test_data.jl
+++ b/test/test_data.jl
@@ -18,18 +18,18 @@
     EMB.element_data(l::DataDirect) = l.data
 
     # Subfunctions for the nodes
-    function EMB.variables_data(m, _::Type{<:ExampleData}, 𝒳ᵈᵃᵗ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::EnergyModel)
+    function EMB.variables_ext_data(m, _::Type{<:ExampleData}, 𝒳ᵈᵃᵗ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::EnergyModel)
         @variable(m, node_example[𝒳ᵈᵃᵗ, 𝒯] ≥ 0)
     end
-    function EMB.variables_data(m, _::Type{ExampleDataB}, 𝒳ᵈᵃᵗ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::EnergyModel)
+    function EMB.variables_ext_data(m, _::Type{ExampleDataB}, 𝒳ᵈᵃᵗ::Vector{<:EMB.Node}, 𝒯, 𝒫, modeltype::EnergyModel)
         @variable(m, node_example_b[𝒳ᵈᵃᵗ, 𝒯] ≥ 0)
     end
 
     # Subfunctions for the link
-    function EMB.variables_data(m, _::Type{<:ExampleDataA}, 𝒳ᵈᵃᵗ::Vector{<:Link}, 𝒯, 𝒫, modeltype::EnergyModel)
+    function EMB.variables_ext_data(m, _::Type{<:ExampleDataA}, 𝒳ᵈᵃᵗ::Vector{<:Link}, 𝒯, 𝒫, modeltype::EnergyModel)
         @variable(m, link_example_a[𝒳ᵈᵃᵗ, 𝒯] ≥ 0)
     end
-    function EMB.variables_data(m, _::Type{<:ExampleDataB}, 𝒳ᵈᵃᵗ::Vector{<:Link}, 𝒯, 𝒫, modeltype::EnergyModel)
+    function EMB.variables_ext_data(m, _::Type{<:ExampleDataB}, 𝒳ᵈᵃᵗ::Vector{<:Link}, 𝒯, 𝒫, modeltype::EnergyModel)
         @variable(m, link_example_b[𝒳ᵈᵃᵗ, 𝒯] ≥ 0)
     end
     function EMB.create_link(m, l::DataDirect, 𝒯, 𝒫, modeltype::EnergyModel)
@@ -135,14 +135,14 @@
     𝒯 = get_time_struct(case)
 
     @testset "Node data" begin
-        # Test that the variables_data function for the abstract type is included for all subtypes
+        # Test that the variables_ext_data function for the abstract type is included for all subtypes
         @test haskey(m, :node_example)
         @test sum(nt[1] == 𝒩[2] for nt ∈ keys(m[:node_example])) == length(𝒯)
         @test sum(nt[1] == 𝒩[3] for nt ∈ keys(m[:node_example])) == length(𝒯)
         @test sum(nt[1] == 𝒩[4] for nt ∈ keys(m[:node_example])) == length(𝒯)
         @test sum(nt[1] == 𝒩[6] for nt ∈ keys(m[:node_example])) == length(𝒯)
 
-        # Test that the variables_data for the concrete type is included
+        # Test that the variables_ext_data for the concrete type is included
         @test haskey(m, :node_example_b)
         @test sum(nt[1] == 𝒩[3] for nt ∈ keys(m[:node_example_b])) == length(𝒯)
         @test sum(nt[1] == 𝒩[5] for nt ∈ keys(m[:node_example_b])) == length(𝒯)

--- a/test/test_data.jl
+++ b/test/test_data.jl
@@ -1,6 +1,6 @@
 @testset "Variable creation" begin
     # New data type including 2 subtypes
-    abstract type ExampleData <: Data end
+    abstract type ExampleData <: ExtensionData end
     struct ExampleDataA <: ExampleData
     end
     struct ExampleDataB <: ExampleData
@@ -12,7 +12,7 @@
         from::EMB.Node
         to::EMB.Node
         formulation::EMB.Formulation
-        data::Vector{<:Data}
+        data::Vector{<:ExtensionData}
     end
 
     EMB.element_data(l::DataDirect) = l.data
@@ -62,8 +62,8 @@
         # coal and nautral gas sources, coal and natural gas (with CCS) power plants and CO2 storage.
         nodes = [
             GenAvailability(1, products),
-            RefSource(2, FixedProfile(1e12), FixedProfile(30), FixedProfile(0), Dict(NG => 1), Data[ExampleDataA()]),
-            RefSource(3, FixedProfile(1e12), FixedProfile(9), FixedProfile(0), Dict(Coal => 1), Data[ExampleDataB()]),
+            RefSource(2, FixedProfile(1e12), FixedProfile(30), FixedProfile(0), Dict(NG => 1), ExtensionData[ExampleDataA()]),
+            RefSource(3, FixedProfile(1e12), FixedProfile(9), FixedProfile(0), Dict(Coal => 1), ExtensionData[ExampleDataB()]),
             RefNetworkNode(
                 4,
                 FixedProfile(25),
@@ -89,7 +89,7 @@
                 CO2,
                 Dict(CO2 => 1, Power => 0.02),
                 Dict(CO2 => 1),
-                Data[ExampleDataB()],
+                ExtensionData[ExampleDataB()],
             ),
             RefSink(
                 7,
@@ -101,12 +101,12 @@
 
         # Connect all nodes with the availability node for the overall energy/mass balance
         links = [
-            DataDirect(14, nodes[1], nodes[4], Linear(), Data[ExampleDataA()])
+            DataDirect(14, nodes[1], nodes[4], Linear(), ExtensionData[ExampleDataA()])
             Direct(15, nodes[1], nodes[5], Linear())
             Direct(16, nodes[1], nodes[6], Linear())
             Direct(17, nodes[1], nodes[7], Linear())
             Direct(21, nodes[2], nodes[1], Linear())
-            DataDirect(31, nodes[3], nodes[1], Linear(), Data[ExampleDataB()])
+            DataDirect(31, nodes[3], nodes[1], Linear(), ExtensionData[ExampleDataB()])
             Direct(41, nodes[4], nodes[1], Linear())
             Direct(51, nodes[5], nodes[1], Linear())
             Direct(61, nodes[6], nodes[1], Linear())

--- a/test/test_investments.jl
+++ b/test/test_investments.jl
@@ -260,7 +260,7 @@ end
         from::EMB.Node
         to::EMB.Node
         formulation::EMB.Formulation
-        data::Vector{<:Data}
+        data::Vector{<:ExtensionData}
     end
     function EMB.create_link(m, 𝒯, 𝒫, l::InvDirect, modeltype::EnergyModel, formulation::EMB.Formulation)
 
@@ -305,7 +305,7 @@ end
             Dict(Power => 1),
         )
 
-        data_link = Data[
+        data_link = ExtensionData[
             SingleInvData(
                 FixedProfile(10),
                 FixedProfile(10),

--- a/test/test_links.jl
+++ b/test/test_links.jl
@@ -22,7 +22,7 @@
             FixedProfile(0),
             Dict(NG => 2),
             Dict(Power => 1),
-            Data[EmissionsEnergy()],
+            ExtensionData[EmissionsEnergy()],
         )
 
         sink = RefSink(

--- a/test/test_nodes.jl
+++ b/test/test_nodes.jl
@@ -341,7 +341,7 @@ end
         @test !any(val == sink for val ∈ axes(m[:emissions_node])[1])
 
         # Test that the emissions from a sink node with emissions are properly accounted for
-        # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
+        # - constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
         em_data = EmissionsProcess(Dict(CO2 => 10.0))
         snk_emit = RefSink(
             "sink_emit",
@@ -358,7 +358,7 @@ end
             value.(m[:emissions_node][snk_emit, t, CO2]) for t ∈ 𝒯
         )
         # Test that the emissions from a source node with emissions are properly accounted for
-        # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
+        # - constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
         em_data = EmissionsProcess(Dict(CO2 => 10.0))
         src_emit = RefSource(
             "source_emit",
@@ -372,7 +372,7 @@ end
         𝒯 = get_time_struct(case)
         # Test that the emissions are properly calculated, although no input is present in
         # a `Source ndoe`
-        # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
+        # - constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
         @test all(
             value.(m[:cap_use][src_emit, t]) * process_emissions(em_data, CO2, t) ≈
             value.(m[:emissions_node][src_emit, t, CO2]) for t ∈ 𝒯
@@ -513,7 +513,7 @@ end
         @test size(m[:emissions_node])[1] == 2
 
         # Check that the total and strategic emissions are correctly calculated
-        # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsEnergy)
+        # - constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsEnergy)
         @test all(
             value.(m[:emissions_node][net, t, CO2]) ≈
             sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) for t ∈ 𝒯,
@@ -547,7 +547,7 @@ end
         @test size(m[:emissions_node])[1] == 2
 
         # Check that the total and strategic emissions are correctly calculated
-        # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
+        # - constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
         @test all(
             value.(m[:emissions_node][net, t, CO2]) ≈
             sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) +
@@ -586,7 +586,7 @@ end
         @test size(m[:emissions_node])[1] == 2
 
         # Check that the total and strategic emissions are correctly calculated
-        # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
+        # - constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)
         @test all(
             value.(m[:emissions_node][net, t, CO2]) ≈
             sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) +
@@ -625,7 +625,7 @@ end
         @test size(m[:emissions_node])[1] == 2
 
         # Check that the total and strategic emissions are correctly calculated
-        # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
+        # - constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
         @test all(
             value.(m[:emissions_node][net, t, CO2]) ≈
             sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) *
@@ -640,7 +640,7 @@ end
         )
 
         # Test that the CO2 capture is calculated correctly
-        # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
+        # - constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
         @test all(
             value.(m[:flow_out][net, t, CO2]) ≈
             sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) *
@@ -673,7 +673,7 @@ end
         @test size(m[:emissions_node])[1] == 2
 
         # Check that the total and strategic emissions are correctly calculated
-        # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
+        # - constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
         @test all(
             value.(m[:emissions_node][net, t, CO2]) ≈
             sum(value.(m[:flow_in][net, t, p]) * co2_int(p) for p ∈ inputs(net)) +
@@ -688,7 +688,7 @@ end
         )
 
         # Test that the CO2 capture is calculated correctly
-        # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
+        # - constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
         @test all(
             value.(m[:flow_out][net, t, CO2]) ≈
             value.(m[:cap_use][net, t]) *
@@ -722,7 +722,7 @@ end
         @test size(m[:emissions_node])[1] == 2
 
         # Check that the total and strategic emissions are correctly calculated
-        # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
+        # - constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
         @test all(
             value.(m[:emissions_node][net, t, CO2]) ≈
             (
@@ -737,7 +737,7 @@ end
         )
 
         # Test that the CO2 capture is calculated correctly
-        # - constraints_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
+        # - constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureEnergyEmissions)
         @test all(
             value.(m[:flow_out][net, t, CO2]) ≈
             (

--- a/test/test_nodes.jl
+++ b/test/test_nodes.jl
@@ -398,8 +398,8 @@ end
             data_source = [EmissionsProcess(Dict(CO2 => 0.5))]
         else
             output = Dict(Power => 1)
-            data_net = Vector{Data}([])
-            data_source = Vector{Data}([])
+            data_net = Vector{ExtensionData}([])
+            data_source = Vector{ExtensionData}([])
         end
 
         # Used source, network, and sink


### PR DESCRIPTION
This is a first take at introducing variables as outlined in #11. It is a slight modification compared to the original proposal from my end to allow for declaring variables as well on the `abstract type` level. In addition, the filtering is used to avoid that a user must create two new functions. Instead, the design is similar to creating new variables for an element.

All data variables are created for a subtype of  `AbstractElement`. This implies that functions must be created for each individual subtype. This is in line with the existing philosophy.

I included the approach as well for `InvData` to illustrate the application.

The PR also includes a renaming of  `Data` to `ExtensionData` as proposed in #11. If undesired, we can revert the commit. Note that it is hence better to look directly at the individual commits.

### Deprecated versions left within the code base

The following functionality is retained, but will be removed in a breaking release:

1. I left the old `Data`.
2. I left the call for `variables_capex` in `create_model` as well as the functions for `Link` and `Node`.