### PR TITLE
Added check for `stor_res` to avoid problems

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Release notes
 
+## Unversioned
+
+### Changes to checks
+
+* Add check that `stor_res` is included in both `input` and `output`.
+* Minor rewriting of function flow in tests of checks.
+
 ## Version 0.9.1 (2025-06-24)
 
 ### Rework of data

--- a/docs/src/nodes/networknode.md
+++ b/docs/src/nodes/networknode.md
@@ -72,7 +72,7 @@ The variables of [`NetworkNode`](@ref)s include:
 
 A qualitative overview of the individual constraints can be found on *[Constraint functions](@ref man-con)*.
 This section focuses instead on the mathematical description of the individual constraints.
-It omits the direction inclusion of the vector of network nodes (or all nodes, if nothing specific is implemented).
+It omits the direct inclusion of the vector of network nodes (or all nodes, if nothing specific is implemented).
 Instead, it is implicitly assumed that the constraints are valid ``\forall n ∈ N^{\text{NetworkNode}}`` (for all [`NetworkNode`](@ref) types) if not stated differently.
 In addition, all constraints are valid ``\forall t \in T`` (that is in all operational periods) or ``\forall t_{inv} \in T^{Inv}`` (that is in all investment periods).
 

--- a/docs/src/nodes/sink.md
+++ b/docs/src/nodes/sink.md
@@ -62,7 +62,7 @@ The variables of [`Sink`](@ref) nodes include:
 
 A qualitative overview of the individual constraints can be found on *[Constraint functions](@ref man-con)*.
 This section focuses instead on the mathematical description of the individual constraints.
-It omits the direction inclusion of the vector of sink nodes (or all nodes, if nothing specific is implemented).
+It omits the direct inclusion of the vector of sink nodes (or all nodes, if nothing specific is implemented).
 Instead, it is implicitly assumed that the constraints are valid ``\forall n ∈ N^{\text{Sink}}`` for all [`Sink`](@ref) types if not stated differently.
 In addition, all constraints are valid ``\forall t \in T`` (that is in all operational periods) or ``\forall t_{inv} \in T^{Inv}`` (that is in all investment periods).
 

--- a/docs/src/nodes/source.md
+++ b/docs/src/nodes/source.md
@@ -76,7 +76,7 @@ The variables of [`Source`](@ref) nodes include:
 
 A qualitative overview of the individual constraints can be found on *[Constraint functions](@ref man-con)*.
 This section focuses instead on the mathematical description of the individual constraints.
-It omits the direction inclusion of the vector of source nodes (or all nodes, if nothing specific is implemented).
+It omits the direct inclusion of the vector of source nodes (or all nodes, if nothing specific is implemented).
 Instead, it is implicitly assumed that the constraints are valid ``\forall n ∈ N^{\text{Source}}`` for all [`Source`](@ref) types if not stated differently.
 In addition, all constraints are valid ``\forall t \in T`` (that is in all operational periods) or ``\forall t_{inv} \in T^{Inv}`` (that is in all investment periods).
 

--- a/docs/src/nodes/storage.md
+++ b/docs/src/nodes/storage.md
@@ -62,7 +62,7 @@ The fields of a [`RefStorage`](@ref) are given as:
 - **`id`**:\
   The field `id` is only used for providing a name to the node.
 - **`charge::AbstractStorageParameters`**:\
-    More information can be found on *[storage parameters](@ref lib-pub-nodes-stor_par)*.
+  More information can be found on *[storage parameters](@ref lib-pub-nodes-stor_par)*.
 - **`level::UnionCapacity`**:\
   The level storage parameters must include a capacity.
   More information can be found on *[storage parameters](@ref lib-pub-nodes-stor_par)*.
@@ -71,11 +71,11 @@ The fields of a [`RefStorage`](@ref) are given as:
       Similarly, you can only use `FixedProfile` or `StrategicProfile` for the fixed OPEX, but not `RepresentativeProfile` or `OperationalProfile`.
       The variable operating expenses can be provided as `OperationalProfile` as well.
       In addition, all capacity and fixed OPEX values have to be non-negative.
-- **`stor_res::ResourceEmit`**:\
+- **`stor_res::Resource`**:\
   The `stor_res` is the stored [`Resource`](@ref Resource).
 - **`input::Dict{<:Resource,<:Real}`** and **`output::Dict{<:Resource,<:Real}`**:\
   Both fields describe the `input` and `output` [`Resource`](@ref Resource)s with their corresponding conversion factors as dictionaries.
-  It is not necessary to specify the stored [`Resource`](@ref Resource) (outlined above), but it is in general advisable.\
+  The stored [`Resource`](@extref EnergyModelsBase.Resource) (outlined above) must be included in both dictionaries to create the linking variables although its conversion factor is not utilized.
   All values have to be non-negative.
   !!! warning "Ratios for Storage"
       In the current implementation, we do not consider `output` conversion factors for the outflow from the [`RefStorage`](@ref) node.
@@ -130,7 +130,7 @@ The variables of [`Storage`](@ref)s include:
 
 A qualitative overview of the individual constraints can be found on *[Constraint functions](@ref man-con)*.
 This section focuses instead on the mathematical description of the individual constraints.
-It omits the direction inclusion of the vector of network nodes (or all nodes, if nothing specific is implemented).
+It omits the direct inclusion of the vector of network nodes (or all nodes, if nothing specific is implemented).
 Instead, it is implicitly assumed that the constraints are valid ``\forall n ∈ N^{\text{Storage}}`` for all [`Storage`](@ref) types if not stated differently.
 In addition, all constraints are valid ``\forall t \in T`` (that is in all operational periods) or ``\forall t_{inv} \in T^{Inv}`` (that is in all investment periods).
 

--- a/docs/src/nodes/storage.md
+++ b/docs/src/nodes/storage.md
@@ -75,7 +75,7 @@ The fields of a [`RefStorage`](@ref) are given as:
   The `stor_res` is the stored [`Resource`](@ref Resource).
 - **`input::Dict{<:Resource,<:Real}`** and **`output::Dict{<:Resource,<:Real}`**:\
   Both fields describe the `input` and `output` [`Resource`](@ref Resource)s with their corresponding conversion factors as dictionaries.
-  The stored [`Resource`](@extref EnergyModelsBase.Resource) (outlined above) must be included in both dictionaries to create the linking variables although its conversion factor is not utilized.
+  The stored [`Resource`](@ref Resource) (outlined above) must be included in both dictionaries to create the linking variables although its conversion factor is not utilized.
   All values have to be non-negative.
   !!! warning "Ratios for Storage"
       In the current implementation, we do not consider `output` conversion factors for the outflow from the [`RefStorage`](@ref) node.

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -86,7 +86,7 @@ function generate_example_network()
             Dict(Power => 1, CO2 => 1), # Output from the node with output ratio
             # Line above: CO2 is required as output for variable definition, but the
             # value does not matter
-            [capture_data],             # Additonal data for emissions and CO₂ capture
+            [capture_data],             # Additional data for emissions and CO₂ capture
         ),
         RefNetworkNode(
             "coal power plant",         # Node id
@@ -95,7 +95,7 @@ function generate_example_network()
             FixedProfile(0),            # Fixed OPEX in EUR/MW/8h
             Dict(Coal => 2.5),          # Input to the node with input ratio
             Dict(Power => 1),           # Output from the node with output ratio
-            [emission_data],            # Additonal data for emissions
+            [emission_data],            # Additional data for emissions
         ),
         RefStorage{AccumulatingEmissions}(
             "CO2 storage",              # Node id

--- a/examples/network_invest.jl
+++ b/examples/network_invest.jl
@@ -90,7 +90,7 @@ function generate_example_network_investment()
             # Line above: CO2 is required as output for variable definition, but the
             # value does not matter
             [
-                capture_data,           # Additonal data for emissions and CO₂ capture
+                capture_data,           # Additional data for emissions and CO₂ capture
                 SingleInvData(
                     FixedProfile(600 * 1e3),  # Capex in EUR/MW
                     FixedProfile(40),       # Max installed capacity [MW]

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -793,7 +793,9 @@ a [`Storage`](@ref) node.
   accessible through a `StrategicPeriod` as outlined in the function
   [`check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)`](@ref) for the chosen composite type.
 - The values of the dictionary `input` are required to be non-negative.
+- The specified storage [`Resource`](@ref) must be included in the dictionary `input`.
 - The values of the dictionary `output` are required to be non-negative.
+- The specified storage [`Resource`](@ref) must be included in the dictionary `output`.
 """
 function check_node_default(n::Storage, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
@@ -830,9 +832,17 @@ function check_node_default(n::Storage, 𝒯, modeltype::EnergyModel, check_time
         all(inputs(n, p) ≥ 0 for p ∈ inputs(n)),
         "The values for the Dictionary `input` must be non-negative."
     )
+    has_input(n) && @assert_or_log(
+        storage_resource(n) ∈ inputs(n),
+        "The stored resource must be included in the Dictionary `input`."
+    )
     has_output(n) && @assert_or_log(
         all(outputs(n, p) ≥ 0 for p ∈ outputs(n)),
         "The values for the Dictionary `output` must be non-negative."
+    )
+    has_output(n) && @assert_or_log(
+        storage_resource(n) ∈ outputs(n),
+        "The stored resource must be included in the Dictionary `output`."
     )
 end
 

--- a/src/structures/node.jl
+++ b/src/structures/node.jl
@@ -298,7 +298,7 @@ The reference `Availability` node solves the energy balance for all connected fl
 
 # Fields
 - **`id`** is the name/identifier of the node.
-- **`inputs::Vector{<:Resource}`** are the input [`Resource`](@ref)s.
+- **`input::Vector{<:Resource}`** are the input [`Resource`](@ref)s.
 - **`output::Vector{<:Resource}`** are the output [`Resource`](@ref)s.
 
 A constructor is provided so that only a single array can be provided with the fields:
@@ -332,7 +332,8 @@ The current implemented cyclic behaviours are [`CyclicRepresentative`](@ref),
   Depending on the chosen type, the charge parameters can include variable OPEX, fixed OPEX,
   and/or a capacity.
 - **`level::AbstractStorageParameters`** are the level parameters of the [`Storage`](@ref) node.
-  Depending on the chosen type, the charge parameters can include variable OPEX and/or fixed OPEX.
+  Depending on the chosen type, the level parameters can include variable OPEX and/or fixed OPEX.
+  They must include a capacity.
 - **`stor_res::Resource`** is the stored [`Resource`](@ref).
 - **`input::Dict{<:Resource,<:Real}`** are the input [`Resource`](@ref)s with conversion
   value `Real`.


### PR DESCRIPTION
It is in the current version not checked whether the storage resource is included in the respective `input` and ` output` dictionaries. If it is not included, one would receive errors from JuMP regarding indexing. To avoid this, a check was included.

In addition, I reduced the loc in the check tests without changing the individual tests as well as fixed minor typos in the documentation.