### PR TITLE
Fixed a bug in link resources

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Unversioned
 
+### Bugfixes
+
+* Fixed a bug when a `Link` did not have the same `input` and `output` `Resource`.
+
 ### Changes to checks
 
 * Add check that `stor_res` is included in both `input` and `output`.

--- a/src/model.jl
+++ b/src/model.jl
@@ -594,14 +594,14 @@ function constraints_couple(m, 𝒩::Vector{<:Node}, ℒ::Vector{<:Link}, 𝒫, 
         if has_output(n)
             @constraint(m, [t ∈ 𝒯, p ∈ outputs(n)],
                 m[:flow_out][n, t, p] ==
-                sum(m[:link_in][l, t, p] for l ∈ ℒᶠʳᵒᵐ if p ∈ outputs(l))
+                sum(m[:link_in][l, t, p] for l ∈ ℒᶠʳᵒᵐ if p ∈ inputs(l))
             )
         end
         # Constraint for input flowrate and output links.
         if has_input(n)
             @constraint(m, [t ∈ 𝒯, p ∈ inputs(n)],
                 m[:flow_in][n, t, p] ==
-                sum(m[:link_out][l, t, p] for l ∈ ℒᵗᵒ if p ∈ inputs(l))
+                sum(m[:link_out][l, t, p] for l ∈ ℒᵗᵒ if p ∈ outputs(l))
             )
         end
     end

--- a/test/test_links.jl
+++ b/test/test_links.jl
@@ -115,20 +115,20 @@ Power = ResourceCarrier("Power", 0.0)
 CO2 = ResourceEmit("CO2", 1.0)
 
 # Function for setting up the system
-function link_graph(LinkType::Vector{DataType})
+function link_graph(LinkType::Vector{DataType}; res_in=Power, res_out=Power)
     # Used source, network, and sink
     source = RefSource(
         "source",
         FixedProfile(4),
         FixedProfile(10),
         FixedProfile(0),
-        Dict(Power => 1),
+        Dict(res_in => 1),
     )
     sink = RefSink(
         "sink",
         FixedProfile(3),
         Dict(:surplus => FixedProfile(4), :deficit => FixedProfile(100)),
-        Dict(Power => 1),
+        Dict(res_out => 1),
     )
 
     resources = [Power, CO2]
@@ -145,6 +145,37 @@ function link_graph(LinkType::Vector{DataType})
     )
     case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
     return run_model(case, model, HiGHS.Optimizer), case, model
+end
+
+@testset "Link - different resources" begin
+    # Creation of a new link type with associated emissions in each operational period
+    struct ResourceLink <: Link
+        id::Any
+        from::EMB.Node
+        to::EMB.Node
+        formulation::EMB.Formulation
+    end
+    function EMB.create_link(m, l::ResourceLink, 𝒯, 𝒫, modeltype::EnergyModel)
+        # Generic link in which each output corresponds to the input
+        @constraint(m, [t ∈ 𝒯],
+            sum(m[:link_out][l, t, p_out] for p_out ∈ outputs(l)) ==
+                sum(m[:link_in][l, t, p_in] for p_in ∈ inputs(l))
+        )
+    end
+    EMB.inputs(l::ResourceLink) = [Power]
+    EMB.outputs(l::ResourceLink) = [CO2]
+
+    # Create and solve the system
+    m, case, model = link_graph([ResourceLink]; res_out=CO2)
+    ℒ = get_links(case)
+    𝒩 = get_nodes(case)
+    𝒯 = get_time_struct(case)
+
+    # Test that the coupling is working correctly and resources are transported
+    @test all(value.(m[:flow_out][𝒩[1], t, Power]) ≈ value.(m[:link_in][ℒ[1], t, Power]) for t ∈ 𝒯)
+    @test all(value.(m[:flow_in][𝒩[2], t, CO2]) ≈ value.(m[:link_out][ℒ[1], t, CO2]) for t ∈ 𝒯)
+    @test all(value.(m[:flow_out][𝒩[1], t, Power]) ≈ value.(m[:flow_in][𝒩[2], t, CO2]) for t ∈ 𝒯)
+    @test all(value.(m[:flow_out][𝒩[1], t, Power]) ≈ 3 for t ∈ 𝒯)
 end
 
 @testset "Link - emissions" begin


### PR DESCRIPTION
We had a wrong connection in the couplings of the links, resulting in wrong connections when the input and output `Resource` of a link differed.

So far, we do not have `Link`s in which the input and output `Resource` are different. Hence, the bug did not affect any officially supported link.

I plan to add the same commit to v0.8 for backwards compatibility.