### PR TITLE
Fixed a bug in link resources

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Unversioned
+
+### Bugfixes
+
+* Fixed a bug when a `Link` did not have the same `input` and `output` `Resource`.
+
 ## Version 0.8.3 (2024-11-29)
 
 ### Reference checks possible to be called

--- a/src/model.jl
+++ b/src/model.jl
@@ -468,14 +468,14 @@ function constraints_node(m, 𝒩, 𝒯, 𝒫, ℒ, modeltype::EnergyModel)
         if has_output(n)
             @constraint(m, [t ∈ 𝒯, p ∈ outputs(n)],
                 m[:flow_out][n, t, p] ==
-                sum(m[:link_in][l, t, p] for l ∈ ℒᶠʳᵒᵐ if p ∈ outputs(l))
+                sum(m[:link_in][l, t, p] for l ∈ ℒᶠʳᵒᵐ if p ∈ inputs(l))
             )
         end
         # Constraint for input flowrate and output links.
         if has_input(n)
             @constraint(m, [t ∈ 𝒯, p ∈ inputs(n)],
                 m[:flow_in][n, t, p] ==
-                sum(m[:link_out][l, t, p] for l ∈ ℒᵗᵒ if p ∈ inputs(l))
+                sum(m[:link_out][l, t, p] for l ∈ ℒᵗᵒ if p ∈ outputs(l))
             )
         end
         # Call of function for individual node constraints.


### PR DESCRIPTION
This MR mirrors #66 for the 0.8 branch. It has only the following differences:

* the arguments of `create_link` in the test set is changed and
* the extraction has to be performed *via* the case dictionary and not the `Case` type.