### PR TITLE
Fixed a potential problem for Storage with investment models  - Version 0.8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Version 0.8.5 (2025-10-23)
+
+## Bugfixes
+
+* Fix a bug in which field names for the capacities of a `Storage` node resulted in unconstrained capacities.
+
 ## Version 0.8.4 (2025-07-03)
 
 ### Bugfixes

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsBase"
 uuid = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.8.4"
+version = "0.8.5"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/ext/EMIExt/constraints.jl
+++ b/ext/EMIExt/constraints.jl
@@ -44,13 +44,13 @@ function EMB.constraints_capacity_installed(
     disc_rate = discount_rate(modeltype)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-    cap_fields = [:charge, :level, :discharge]
+    cap_map = Dict(:charge => charge, :level => level, :discharge => discharge)
 
-    for cap ∈ cap_fields
-        if !hasfield(typeof(n), cap)
+    for (cap, cap_fun) ∈ cap_map
+        if isnothing(cap_fun(n))
             continue
         end
-        stor_par = getfield(n, cap)
+        stor_par = cap_fun(n)
         prefix = Symbol(:stor_, cap)
         var_inst = EMI.get_var_inst(m, prefix, n)
         if has_investment(n, cap)


### PR DESCRIPTION
This PR mirrors #73 for the supported version 0.8. It will be merged once the fix for 0.9 is registered.