### PR TITLE
Add support for JuMP.AbstractModel 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+### Minor updates
+
 * Add support for JuMP.AbstractModel to allow custom model types, e.g. for decomposition.
 
 ## Version 0.10.0 (2026-04-09)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## Unversioned
+
+* Add support for JuMP.AbstractModel to allow custom model types, e.g. for decomposition.
+
 ## Version 0.10.0 (2026-04-09)
 
 ### Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Unversioned
+## Version 0.10.1 (2026-04-14)
 
 ### Minor updates
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsBase"
 uuid = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/src/model.jl
+++ b/src/model.jl
@@ -2,7 +2,7 @@
     create_model(
         case::Case,
         modeltype::EnergyModel,
-        m::JuMP.Model;
+        m::JuMP.AbstractModel = JuMP.Model();
         check_timeprofiles::Bool = true,
         check_any_data::Bool = true,
     )
@@ -32,7 +32,7 @@ Create the model and call all required functions.
 function create_model(
     case::Case,
     modeltype::EnergyModel,
-    m::JuMP.Model;
+    m::JuMP.AbstractModel = JuMP.Model();
     check_timeprofiles::Bool = true,
     check_any_data::Bool = true,
 )
@@ -85,33 +85,16 @@ function create_model(
 
     return m
 end
-function create_model(
-    case::Case,
-    modeltype::EnergyModel;
-    check_timeprofiles::Bool = true,
-    check_any_data::Bool = true,
-)
-    m = JuMP.Model()
-    create_model(case, modeltype, m; check_timeprofiles, check_any_data)
-end
+
 function create_model(
     case::Dict,
     modeltype::EnergyModel,
-    m::JuMP.Model;
+    m::JuMP.AbstractModel = JuMP.Model();
     check_timeprofiles::Bool = true,
     check_any_data::Bool = true,
 )
     case_new = Case(case[:T], case[:products], [case[:nodes], case[:links]])
     create_model(case_new, modeltype, m; check_timeprofiles, check_any_data)
-end
-function create_model(
-    case::Dict,
-    modeltype::EnergyModel;
-    check_timeprofiles::Bool = true,
-    check_any_data::Bool = true,
-)
-    m = JuMP.Model()
-    create_model(case, modeltype, m; check_timeprofiles, check_any_data)
 end
 
 """


### PR DESCRIPTION
Add support for JuMP.AbstractModel to allow passing alternative model types e.g. for decomposition.

Simplify optional model passing code. This should be equivalent, but shorter and easier to read.