### PR TITLE
Fix undefined variable in check_scenario_profile and trailing commas in fix() calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Unversioned
+
+### Bug fixes
+
+* Fixed a bug in the function `check_scenario_profile` resulting in an error, if utilized.
+
 ## Version 0.10.0 (2026-04-09)
 
 ### Breaking changes

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -798,7 +798,7 @@ function check_scenario_profile(time_profile::TimeProfile, message::String)
             bool_osc = check_osc_sub_profile(l1_profile, sub_msg, bool_osc)
         end
     end
-    return bool_scp
+    return bool_osc
 end
 function check_osc_sub_profile(sub_profile::TimeProfile, sub_msg::String, bool_scp::Bool)
     @assert_or_log(

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -750,28 +750,28 @@ scenario indexing.
 """
 function check_scenario_profile(time_profile::TimeProfile, message::String)
     # Check on the highest level
-    bool_osc = check_osc_sub_profile(time_profile, message, true)
+    bool_scp = check_osc_sub_profile(time_profile, message, true)
 
     # Iterate through the strategic profiles, if existing
     if isa(time_profile, StrategicProfile)
         for l1_profile ∈ time_profile.vals
             sub_msg = "in strategic profiles " * message
-            bool_osc = check_osc_sub_profile(l1_profile, sub_msg, bool_osc)
+            bool_scp = check_osc_sub_profile(l1_profile, sub_msg, bool_scp)
             if isa(l1_profile, RepresentativeProfile)
                 for l2_profile ∈ l1_profile.vals
                     sub_msg = "in representative profiles in strategic profiles " * message
-                    bool_osc = check_osc_sub_profile(l2_profile, sub_msg, bool_osc)
+                    bool_scp = check_osc_sub_profile(l2_profile, sub_msg, bool_scp)
                     if isa(l2_profile, ScenarioProfile)
                         for l3_profile ∈ l2_profile.vals
                             sub_msg = "in scenario profiles in representative profiles in strategic profiles " * message
-                            bool_osc = check_osc_sub_profile(l3_profile, sub_msg, bool_osc)
+                            bool_scp = check_osc_sub_profile(l3_profile, sub_msg, bool_scp)
                         end
                     end
                 end
             elseif isa(l1_profile, ScenarioProfile)
                 for l2_profile ∈ l1_profile.vals
                     sub_msg = "in scenario profiles in strategic profiles " * message
-                    bool_osc = check_osc_sub_profile(l2_profile, sub_msg, bool_osc)
+                    bool_scp = check_osc_sub_profile(l2_profile, sub_msg, bool_scp)
                 end
             end
         end
@@ -781,11 +781,11 @@ function check_scenario_profile(time_profile::TimeProfile, message::String)
     if isa(time_profile, RepresentativeProfile)
         for l1_profile ∈ time_profile.vals
             sub_msg = "in representative profiles " * message
-            bool_osc = check_osc_sub_profile(l1_profile, sub_msg, bool_osc)
+            bool_scp = check_osc_sub_profile(l1_profile, sub_msg, bool_scp)
             if isa(l1_profile, ScenarioProfile)
                 for l2_profile ∈ l1_profile.vals
                     sub_msg = "in scenario profiles in representative profiles " * message
-                    bool_osc = check_osc_sub_profile(l2_profile, sub_msg, bool_osc)
+                    bool_scp = check_osc_sub_profile(l2_profile, sub_msg, bool_scp)
                 end
             end
         end
@@ -795,10 +795,10 @@ function check_scenario_profile(time_profile::TimeProfile, message::String)
     if isa(time_profile, ScenarioProfile)
         for l1_profile ∈ time_profile.vals
             sub_msg = "in scenario profiles " * message
-            bool_osc = check_osc_sub_profile(l1_profile, sub_msg, bool_osc)
+            bool_scp = check_osc_sub_profile(l1_profile, sub_msg, bool_scp)
         end
     end
-    return bool_osc
+    return bool_scp
 end
 function check_osc_sub_profile(sub_profile::TimeProfile, sub_msg::String, bool_scp::Bool)
     @assert_or_log(

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -638,7 +638,7 @@ function constraints_opex_fixed(m, n::Sink, 𝒯ᴵⁿᵛ, modeltype::EnergyMode
 
     # Fix the fixed OPEX
     for t_inv ∈ 𝒯ᴵⁿᵛ
-        fix(m[:opex_fixed][n, t_inv], 0, ; force = true)
+        fix(m[:opex_fixed][n, t_inv], 0; force = true)
     end
 end
 

--- a/src/data_functions.jl
+++ b/src/data_functions.jl
@@ -33,7 +33,7 @@ function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, da
 
     # Fix the other emissions to 0 to avoid problems with unconstrained variables
     for t ∈ 𝒯, p_em ∈ 𝒫ᵉᵐ
-        fix(m[:emissions_node][n, t, p_em], 0, ; force = true)
+        fix(m[:emissions_node][n, t, p_em], 0; force = true)
     end
 end
 function constraints_ext_data(m, n::Node, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsProcess)

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -506,7 +506,7 @@ end
         RepresentativeProfile([ScenarioProfile([FixedProfile(5)])]),
     ]
     for tp ∈ valid_profiles
-        @test EMB.check_scenario_profile(tp, "") == true
+        @test EMB.check_scenario_profile(tp, "")
     end
 
     # Reactivate logging

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -498,6 +498,17 @@ end
         @test_throws AssertionError EMB.check_scenario_profile(tp, "")
     end
 
+    # Check that valid profiles pass check_scenario_profile without error
+    valid_profiles = [
+        FixedProfile(5),
+        StrategicProfile([FixedProfile(5)]),
+        StrategicProfile([RepresentativeProfile([FixedProfile(5)])]),
+        RepresentativeProfile([ScenarioProfile([FixedProfile(5)])]),
+    ]
+    for tp ∈ valid_profiles
+        @test EMB.check_scenario_profile(tp, "") == true
+    end
+
     # Reactivate logging
     EMB.ASSERTS_AS_LOG = true
 end


### PR DESCRIPTION
## Fix undefined variable in `check_scenario_profile` and trailing commas in `fix()` calls

This PR addresses a few small issues I noticed while reading through the codebase.

### `check_scenario_profile` undefined variable on return

The function `check_scenario_profile` in `src/checks.jl` uses `bool_osc` throughout the body but returns `bool_scp` on the last line, which is not defined in that scope. This causes an `UndefVarError` when the function is called with a valid profile that passes all checks.

The existing tests didn't catch this because they only pass invalid profiles, so `@assert_or_log` throws before reaching the return statement.

**Fix:** `return bool_scp` → `return bool_osc`

Added tests with valid profiles to cover this path.

### Trailing commas in `fix()` calls

Two `fix()` calls had a trailing comma before the semicolon (`fix(..., 0, ; force = true)`), inconsistent with every other `fix()` call in the codebase.

**Fix:** `fix(..., 0, ; force = true)` → `fix(..., 0; force = true)`

### Files changed

- `src/checks.jl` — fixed return variable name
- `src/constraint_functions.jl` — removed trailing comma
- `src/data_functions.jl` — removed trailing comma
- `test/test_checks.jl` — added valid-input tests for `check_scenario_profile`