### PR TITLE
Fix variable name-collision guard to match updated JuMP error message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Release notes
 
+## Version 0.10.6 (2026-07-30)
+
+### Bug fixes
+
+* Fixed the variable name-collision guard in `variables_elements` and `variables_element_ext_data` to match the updated JuMP error message:
+  * JuMP changed the wording from "is already attached to this model." to "is already registered in this model.".
+  * Both variants are now accepted for cross-version compatibility.
+
 ## Version 0.10.5 (2026-06-28)
 
 * Increased robustness for checking whether a `TimeProfile` is of the correct type for indexing.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsBase"
 uuid = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.10.5"
+version = "0.10.6"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/src/model.jl
+++ b/src/model.jl
@@ -428,11 +428,14 @@ function variables_elements(m, 𝒳::Vector{<:AbstractElement}, 𝒳ᵛᵉᶜ, �
         try
             variables_element(m, 𝒳ˢᵘᵇ, 𝒯, modeltype)
         catch e
-            # Parts of the exception message we are looking for.
+            # Parts of the exception message we are looking for. JuMP changed the wording
+            # from "is already attached to this model." to "is already registered in this
+            # model.", so both variants are accepted for cross-version compatibility.
             pre1 = "An object of name"
-            pre2 = "is already attached to this model."
+            pre2a = "is already attached to this model."
+            pre2b = "is already registered in this model."
             if isa(e, ErrorException)
-                if occursin(pre1, e.msg) && occursin(pre2, e.msg)
+                if occursin(pre1, e.msg) && (occursin(pre2a, e.msg) || occursin(pre2b, e.msg))
                     # 𝒳ˢᵘᵇ was already registered by a call to a supertype, so just continue.
                     continue
                 end
@@ -480,11 +483,14 @@ function variables_element_ext_data(
         try
             variables_ext_data(m, data_type, 𝒳ᵈᵃᵗ, 𝒯, 𝒫, modeltype)
         catch e
-            # Parts of the exception message we are looking for
+            # Parts of the exception message we are looking for. JuMP changed the wording
+            # from "is already attached to this model." to "is already registered in this
+            # model.", so both variants are accepted for cross-version compatibility.
             pre1 = "An object of name"
-            pre2 = "is already attached to this model."
+            pre2a = "is already attached to this model."
+            pre2b = "is already registered in this model."
             if isa(e, ErrorException)
-                if occursin(pre1, e.msg) && occursin(pre2, e.msg)
+                if occursin(pre1, e.msg) && (occursin(pre2a, e.msg) || occursin(pre2b, e.msg))
                     # data_type was already registered by a call to a supertype, so just continue.
                     continue
                 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -18,11 +18,14 @@
         # changes, we must change how variables are created.
         @test isa(e, ErrorException)
 
-        # Check that the error message is not changed.
+        # Check that the error message matches what `variables_elements` looks for. JuMP
+        # changed the wording from "is already attached to this model." to "is already
+        # registered in this model.", so both variants are accepted.
         pre1 = "An object of name"
-        pre2 = "is already attached to this model."
+        pre2a = "is already attached to this model."
+        pre2b = "is already registered in this model."
         @test occursin(pre1, e.msg)
-        @test occursin(pre2, e.msg)
+        @test occursin(pre2a, e.msg) || occursin(pre2b, e.msg)
     end
 end
 


### PR DESCRIPTION
## Summary

Fixes #96 (https://github.com/EnergyModelsX/EnergyModelsBase.jl/issues/96).

The test suite fails during "General tests" and "Variable creation" with:

> An object of name `:sink_surplus` is already registered in this model.

## Root cause

When building variables for a type hierarchy, `variables_elements` (and `variables_element_ext_data`) in `src/model.jl` intentionally call `variables_element` for a supertype and then again for its subtypes. To avoid double-registration of the same JuMP variable name, the call is wrapped in a `try/catch` that silently continues when the raised `ErrorException` corresponds to an already-registered name.

The guard matched the error text against the hardcoded substrings:
- `"An object of name"`
- `"is already attached to this model."`

Newer JuMP (v1.31.1) changed the wording of the duplicate-registration error from `"is already attached to this model."` to `"is already registered in this model."`. Because the second substring no longer matches, the exception was re-thrown instead of swallowed, aborting the model build.

## Changes

- `src/model.jl` — the guards in `variables_elements` and `variables_element_ext_data` now accept both message variants for cross-version compatibility.
- `test/test_utils.jl` — the "Variable creation" testset now asserts either message variant.
- Bumped version `0.10.5` → `0.10.6` and added a `NEWS.md` entry.

## Environment

- Julia 1.12.3
- JuMP 1.31.1

## Related

- Issue: https://github.com/EnergyModelsX/EnergyModelsBase.jl/issues/96