### PR TITLE
Fix variable name-collision guard to match updated JuMP error message - Version 0.9

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Release notes
 
+## Version 0.9.7 (2026-08-11)
+
+### Bug fixes
+
+* Fixed the variable name-collision guard in `variables_elements` and `variables_element_ext_data` to match the updated JuMP error message:
+  * JuMP changed the wording from "is already attached to this model." to "is already registered in this model.".
+  * Both variants are now accepted for cross-version compatibility.
+
 ## Version 0.9.6 (2026-04-15)
 
 ### Bug fixes

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsBase"
 uuid = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.9.6"
+version = "0.9.7"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/src/model.jl
+++ b/src/model.jl
@@ -445,11 +445,14 @@ function variables_elements(m, 𝒳::Vector{<:AbstractElement}, 𝒳ᵛᵉᶜ, �
         try
             variables_element(m, 𝒳ˢᵘᵇ, 𝒯, modeltype)
         catch e
-            # Parts of the exception message we are looking for.
+            # Parts of the exception message we are looking for. JuMP changed the wording
+            # from "is already attached to this model." to "is already registered in this
+            # model.", so both variants are accepted for cross-version compatibility.
             pre1 = "An object of name"
-            pre2 = "is already attached to this model."
+            pre2a = "is already attached to this model."
+            pre2b = "is already registered in this model."
             if isa(e, ErrorException)
-                if occursin(pre1, e.msg) && occursin(pre2, e.msg)
+                if occursin(pre1, e.msg) && (occursin(pre2a, e.msg) || occursin(pre2b, e.msg))
                     # 𝒳ˢᵘᵇ was already registered by a call to a supertype, so just continue.
                     continue
                 end
@@ -497,11 +500,14 @@ function variables_element_ext_data(
         try
             variables_ext_data(m, data_type, 𝒳ᵈᵃᵗ, 𝒯, 𝒫, modeltype)
         catch e
-            # Parts of the exception message we are looking for
+            # Parts of the exception message we are looking for. JuMP changed the wording
+            # from "is already attached to this model." to "is already registered in this
+            # model.", so both variants are accepted for cross-version compatibility.
             pre1 = "An object of name"
-            pre2 = "is already attached to this model."
+            pre2a = "is already attached to this model."
+            pre2b = "is already registered in this model."
             if isa(e, ErrorException)
-                if occursin(pre1, e.msg) && occursin(pre2, e.msg)
+                if occursin(pre1, e.msg) && (occursin(pre2a, e.msg) || occursin(pre2b, e.msg))
                     # data_type was already registered by a call to a supertype, so just continue.
                     continue
                 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -18,11 +18,14 @@
         # changes, we must change how variables are created.
         @test isa(e, ErrorException)
 
-        # Check that the error message is not changed.
+        # Check that the error message matches what `variables_elements` looks for. JuMP
+        # changed the wording from "is already attached to this model." to "is already
+        # registered in this model.", so both variants are accepted.
         pre1 = "An object of name"
-        pre2 = "is already attached to this model."
+        pre2a = "is already attached to this model."
+        pre2b = "is already registered in this model."
         @test occursin(pre1, e.msg)
-        @test occursin(pre2, e.msg)
+        @test occursin(pre2a, e.msg) || occursin(pre2b, e.msg)
     end
 end
 


### PR DESCRIPTION
This PR mirrors #97 for the supported version 0.9.