### PR TITLE
Fixed problems with indexing checks for time profiles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 # Release notes
 
-## Version 0.10.6 (2026-07-30)
+## Version 0.10.7 (2026-08-11)
+
+### Bug fixes
+
+* Fixed a problem introduced in version 0.10.5.
+* The problem was associated to wrong breaks from the check of the type of the time profile.
+
+## Version 0.10.6 (2026-08-04)
 
 ### Bug fixes
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsBase"
 uuid = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.10.6"
+version = "0.10.7"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -661,7 +661,11 @@ on potential subprofiles. This can be achieved through the function [`check_sub_
     User should never use this function directly. It should only be included within the core
     structure in `EnergyModelsBase`.
 """
-function check_sub_profile(::Type{TP}, sub_prof::TimeProfile, sub_msg::String) where {TP<:Union{StrategicProfile, StrategicStochasticProfile}}
+function check_sub_profile(
+    ::Type{TP},
+    sub_prof::TimeProfile,
+    sub_msg::String,
+) where  {TP<:Union{StrategicProfile, StrategicStochasticProfile}}
     bool_op = check_not_profile(OperationalProfile, sub_prof, sub_msg)
     bool_part = check_not_profile(PartitionProfile, sub_prof, sub_msg)
     bool_scp = check_not_profile(ScenarioProfile, sub_prof, sub_msg)
@@ -669,24 +673,40 @@ function check_sub_profile(::Type{TP}, sub_prof::TimeProfile, sub_msg::String) w
 
     return bool_op * bool_part * bool_scp * bool_rp
 end
-function check_sub_profile(::Type{TP}, sub_prof::TimeProfile, sub_msg::String) where {TP<:RepresentativeProfile}
+function check_sub_profile(
+    ::Type{TP},
+    sub_prof::TimeProfile,
+    sub_msg::String,
+) where  {TP<:RepresentativeProfile}
     bool_op = check_not_profile(OperationalProfile, sub_prof, sub_msg)
     bool_part = check_not_profile(PartitionProfile, sub_prof, sub_msg)
     bool_scp = check_not_profile(ScenarioProfile, sub_prof, sub_msg)
 
     return bool_op * bool_part * bool_scp
 end
-function check_sub_profile(::Type{TP}, sub_prof::TimeProfile, sub_msg::String) where {TP<:ScenarioProfile}
+function check_sub_profile(
+    ::Type{TP},
+    sub_prof::TimeProfile,
+    sub_msg::String,
+) where  {TP<:ScenarioProfile}
     bool_op = check_not_profile(OperationalProfile, sub_prof, sub_msg)
     bool_part = check_not_profile(PartitionProfile, sub_prof, sub_msg)
 
     return bool_op * bool_part
 end
-function check_sub_profile(::Type{TP}, sub_prof::TimeProfile, sub_msg::String) where {TP<:PartitionProfile}
+function check_sub_profile(
+    ::Type{TP},
+    sub_prof::TimeProfile,
+    sub_msg::String,
+) where  {TP<:PartitionProfile}
     bool_op = check_not_profile(OperationalProfile, sub_prof, sub_msg)
     return bool_op
 end
-function check_sub_profile(::Type{TP}, sub_prof::Number, sub_msg::String) where {TP<:PartitionProfile}
+function check_sub_profile(
+    ::Type{TP},
+    sub_prof::Number,
+    sub_msg::String,
+) where {TP<:PartitionProfile}
     return true
 end
 
@@ -719,6 +739,7 @@ function check_sub_profs(
     sub_msg = "in `$(TP.name.name)`s " * msg
     for sub_prof ∈ prof.vals
         bool_val *= check_sub_profile(TP_C, sub_prof, sub_msg)
+        !bool_val && break
         bool_val *= check_sub_profs(TP_C, sub_prof, sub_msg)
         !bool_val && break
     end
@@ -746,6 +767,7 @@ function check_sub_profs(
     sub_msg = "in `StrategicStochasticProfile`s " * msg
     for sp_array ∈ prof.vals, sub_prof ∈ sp_array
         bool_val = check_sub_profile(TP_C, sub_prof, sub_msg)
+        !bool_val && break
         bool_val *= check_sub_profs(TP_C, sub_prof, msg)
         !bool_val && break
     end


### PR DESCRIPTION
[PR 16 of `EnergyModelsHydrogen`](https://github.com/EnergyModelsX/EnergyModelsHydrogen.jl/pull/16) crashed after I reran the PR due to problems introduced in #95 as it required more breaks that implemented. This is fixed in this PR.